### PR TITLE
fix(business/checkbox): fill block of indeterminate

### DIFF
--- a/projects/sbb-esta/angular-public/src/lib/checkbox/_checkbox.scss
+++ b/projects/sbb-esta/angular-public/src/lib/checkbox/_checkbox.scss
@@ -65,6 +65,7 @@ $checkBoxContainerBorder: 2;
           left: 4px;
           top: 8.5px;
           border: 1px solid $sbbColorGranite;
+          background-color: $sbbColorGranite;
           display: block;
         }
 


### PR DESCRIPTION
This shows the indeterminate state of the business checkbox as block with background color. If someone tries to resize the checkbox, this is necessary to prevent a wrong look. This is precautionary.