### PR TITLE
fix(public): fix the sticky detection for public table

### DIFF
--- a/projects/sbb-esta/angular-public/table/src/table/table-scroll-area.directive.ts
+++ b/projects/sbb-esta/angular-public/table/src/table/table-scroll-area.directive.ts
@@ -13,6 +13,7 @@ import { takeUntil } from 'rxjs/operators';
 
 const stickySupported =
   typeof CSS !== 'undefined' &&
+  typeof CSS.supports === 'function' &&
   CSS.supports(
     ['', '-o-', '-webkit-', '-moz-', '-ms-'].map(p => `(position: ${p}sticky)`).join(' or ')
   );


### PR DESCRIPTION
IE11 does not have the variable CSS or the CSS.supports function. In some cases the CSS global variable might have been added, but the CSS.supports function is still missing. In order to avoid a reference error, we check for the type of CSS.supports, if CSS is available.

closes #247