### PR TITLE
refactor: drop support for form control on radio button

### DIFF
--- a/projects/sbb-esta/angular-public/radio-button-panel/src/radio-button-panel/radio-button-panel.component.spec.ts
+++ b/projects/sbb-esta/angular-public/radio-button-panel/src/radio-button-panel/radio-button-panel.component.spec.ts
@@ -3,6 +3,7 @@ import { Component, QueryList, ViewChildren } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { ɵRadioButtonModule } from '@sbb-esta/angular-core/radio-button';
 import { configureTestSuite } from 'ng-bullet';
 
 import { RadioButtonPanelModule } from '../radio-button-panel.module';
@@ -13,22 +14,14 @@ import { RadioButtonPanelComponent } from './radio-button-panel.component';
 @Component({
   selector: 'sbb-model-radio-button-panel-test',
   template: `
-    <sbb-radio-button-panel
-      [(ngModel)]="testValue"
-      inputId="test-option-1"
-      name="test-option"
-      value="1"
-    >
-      Test option selection 1
-    </sbb-radio-button-panel>
-    <sbb-radio-button-panel
-      [(ngModel)]="testValue"
-      inputId="test-option-2"
-      name="test-option"
-      value="2"
-    >
-      Test option selection 2
-    </sbb-radio-button-panel>
+    <sbb-radio-group [(ngModel)]="testValue">
+      <sbb-radio-button-panel value="1">
+        Test option selection 1
+      </sbb-radio-button-panel>
+      <sbb-radio-button-panel value="2">
+        Test option selection 2
+      </sbb-radio-button-panel>
+    </sbb-radio-group>
   `
 })
 class ModelOptionSelectionTestComponent {
@@ -68,7 +61,7 @@ describe('RadioButtonPanelComponent using mock component', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule, RadioButtonPanelModule],
+      imports: [FormsModule, RadioButtonPanelModule, ɵRadioButtonModule],
       declarations: [ModelOptionSelectionTestComponent]
     });
   });
@@ -121,7 +114,8 @@ describe('RadioButtonPanelComponent using mock component', () => {
 
     expect(opt1.checked).toBe(true);
 
-    opt2.checked = true;
+    const opt2Element = modelComponentFixture.debugElement.queryAll(By.css('label'))[1];
+    opt2Element.nativeElement.click();
     modelComponentFixture.detectChanges();
 
     await modelComponentFixture.whenStable();

--- a/projects/sbb-esta/angular-public/radio-button/src/radio-button/radio-button.component.spec.ts
+++ b/projects/sbb-esta/angular-public/radio-button/src/radio-button/radio-button.component.spec.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { ɵRadioButtonModule } from '@sbb-esta/angular-core/radio-button';
 import { configureTestSuite } from 'ng-bullet';
 
 import { RadioButtonComponent } from './radio-button.component';
@@ -11,12 +12,14 @@ import { RadioButtonComponent } from './radio-button.component';
 @Component({
   selector: 'sbb-model-radio-button-test',
   template: `
-    <sbb-radio-button [(ngModel)]="testValue" inputId="test-radio-1" name="test-radio" value="1">
-      Test radio button 1
-    </sbb-radio-button>
-    <sbb-radio-button [(ngModel)]="testValue" inputId="test-radio-2" name="test-radio" value="2">
-      Test radio button 2
-    </sbb-radio-button>
+    <sbb-radio-group name="test-radio" [(ngModel)]="testValue">
+      <sbb-radio-button value="1">
+        Test radio button 1
+      </sbb-radio-button>
+      <sbb-radio-button value="2">
+        Test radio button 2
+      </sbb-radio-button>
+    </sbb-radio-group>
   `
 })
 class ModelRadioButtonTestComponent {
@@ -58,7 +61,7 @@ describe('RadioButtonComponent using mock component', () => {
 
   configureTestSuite(() => {
     TestBed.configureTestingModule({
-      imports: [CommonModule, FormsModule],
+      imports: [CommonModule, FormsModule, ɵRadioButtonModule],
       declarations: [RadioButtonComponent, ModelRadioButtonTestComponent]
     }).overrideComponent(RadioButtonComponent, {
       set: { changeDetection: ChangeDetectionStrategy.Default }
@@ -87,9 +90,7 @@ describe('RadioButtonComponent using mock component', () => {
   });
 
   it('should check the radio button when click the label', () => {
-    const radiobuttonLabel = modelComponentFixture.debugElement.query(
-      By.css('label[for="test-radio-1"]')
-    );
+    const radiobuttonLabel = modelComponentFixture.debugElement.query(By.css('label'));
     expect(radiobuttonLabel).toBeTruthy();
 
     radiobuttonLabel.nativeElement.click();


### PR DESCRIPTION
BREAKING CHANGE: This change removes support for form control on a radio button. Use sbb-radio-button or sbb-radio-button-panel wrapped in a sbb-radio-group.