### PR TITLE
fix(business): remove dropdown module from header module

### DIFF
--- a/projects/sbb-esta/angular-business/header/src/header.module.ts
+++ b/projects/sbb-esta/angular-business/header/src/header.module.ts
@@ -1,7 +1,6 @@
 import { PortalModule } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { DropdownModule } from '@sbb-esta/angular-business/dropdown';
 import {
   IconChevronSmallDownModule,
   IconChevronSmallLeftModule,
@@ -27,8 +26,7 @@ import { HeaderComponent } from './header/header.component';
     IconCrossModule,
     IconChevronSmallDownModule,
     IconChevronSmallLeftModule,
-    IconChevronSmallUpModule,
-    DropdownModule
+    IconChevronSmallUpModule
   ],
   declarations: [
     HeaderComponent,
@@ -42,8 +40,7 @@ import { HeaderComponent } from './header/header.component';
     AppChooserSectionComponent,
     HeaderMenuComponent,
     HeaderMenuTriggerComponent,
-    HeaderMenuItemDirective,
-    DropdownModule
+    HeaderMenuItemDirective
   ],
   providers: [SBB_HEADER_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER]
 })


### PR DESCRIPTION
Closes #269

BREAKING CHANGE: The header module no longer exports the DropdownModule. If you use sbb-dropdown with the header, you either should switch to using sbb-header-menu where applicable or you need to add DropdownModule to the NgModule imports.