### PR TITLE
refactor(keycloak): change idp hint from adfs to azure ad

### DIFF
--- a/projects/sbb-esta/angular-keycloak/README.md
+++ b/projects/sbb-esta/angular-keycloak/README.md
@@ -85,11 +85,11 @@ AuthModule.forRoot(
   loginOptions?: KeycloakLoginOptions)
 ```
 
-| Parameter    | Description                                                                                                           |
-| ------------ | --------------------------------------------------------------------------------------------------------------------- |
-| config       | **Required** Either a configuration object or an url where the configuration is provided in json format               |
-| options      | **Optional** Options object (defaults to { onLoad: 'check-sso', flow: 'implicit' })                                   |
-| loginOptions | **Optional** Login options object, which will be used on AuthService.login (defaults to { idpHint: 'adfs_sbb_prod' }) |
+| Parameter    | Description                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| config       | **Required** Either a configuration object or an url where the configuration is provided in json format                |
+| options      | **Optional** Options object (defaults to { onLoad: 'check-sso', flow: 'implicit' })                                    |
+| loginOptions | **Optional** Login options object, which will be used on AuthService.login (defaults to { idpHint: 'azure_sbb_prod' }) |
 
 ### Authentication Service
 

--- a/projects/sbb-esta/angular-keycloak/src/lib/auth/auth.module.ts
+++ b/projects/sbb-esta/angular-keycloak/src/lib/auth/auth.module.ts
@@ -12,13 +12,13 @@ export class AuthModule {
    * Configure keycloak via available parameters.
    * @param config A config object or an url to the config json.
    * @param options An options object. Defaults to { onLoad: 'check-sso', flow: 'implicit' }.
-   * @param loginOptions An object for login options. Defaults to { idpHint: 'adfs_sbb_prod' }.
+   * @param loginOptions An object for login options. Defaults to { idpHint: 'azure_sbb_prod' }.
    *  To avoid configuring an idpHint, provide an object with no idpHint key.
    */
   static forRoot(
     config: string | KeycloakConfig,
     options: KeycloakInitOptions = { onLoad: 'check-sso', flow: 'implicit' },
-    loginOptions: KeycloakLoginOptions = { idpHint: 'adfs_sbb_prod' }
+    loginOptions: KeycloakLoginOptions = { idpHint: 'azure_sbb_prod' }
   ): ModuleWithProviders<AuthModule> {
     return {
       ngModule: AuthModule,


### PR DESCRIPTION
Closes #97

BREAKING CHANGE: The default identity provider is changed from ADFS to Azure AD.