### PR TITLE
refactor: change @sbb-esta/angular-core to be a peer dependency

### DIFF
--- a/projects/sbb-esta/angular-business/getting-started.md
+++ b/projects/sbb-esta/angular-business/getting-started.md
@@ -22,16 +22,16 @@ You can create now your project as described in the official [Angular CLI docume
 
 ## Step 1: Install the library
 
-Just after you created your own Angular project, in order to include the library, you have to install the `@sbb-esta/angular-business`, `@sbb-esta/angular-icons` and `@angular/cdk` dependencies:
+Just after you created your own Angular project, in order to include the library, you have to install the `@sbb-esta/angular-business`, `@sbb-esta/angular-core`, `@sbb-esta/angular-icons` and `@angular/cdk` dependencies:
 
 ```sh
-npm install --save @sbb-esta/angular-business @sbb-esta/angular-icons @angular/cdk
+npm install --save @sbb-esta/angular-business @sbb-esta/angular-core @sbb-esta/angular-icons @angular/cdk
 ```
 
 or, if using yarn:
 
 ```sh
-yarn add @sbb-esta/angular-business @sbb-esta/angular-icons @angular/cdk
+yarn add @sbb-esta/angular-business @sbb-esta/angular-core @sbb-esta/angular-icons @angular/cdk
 ```
 
 ## Step 2: Configure animations

--- a/projects/sbb-esta/angular-business/ng-package.json
+++ b/projects/sbb-esta/angular-business/ng-package.json
@@ -1,7 +1,6 @@
 {
   "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../../dist/sbb-esta/angular-business",
-  "whitelistedNonPeerDependencies": ["tslib", "@sbb-esta/angular-core", "@types/grecaptcha"],
   "lib": {
     "entryFile": "public-api.ts",
     "umdModuleIds": {

--- a/projects/sbb-esta/angular-business/package.json
+++ b/projects/sbb-esta/angular-business/package.json
@@ -19,10 +19,8 @@
     "@angular/cdk": "^9.0.0",
     "@angular/forms": "^9.0.0",
     "@angular/router": "^9.0.0",
+    "@sbb-esta/angular-core": "0.0.0-PLACEHOLDER",
     "@sbb-esta/angular-icons": "0.0.0-PLACEHOLDER"
-  },
-  "dependencies": {
-    "@sbb-esta/angular-core": "0.0.0-PLACEHOLDER"
   },
   "ng-update": {
     "packageGroup": [

--- a/projects/sbb-esta/angular-public/getting-started.md
+++ b/projects/sbb-esta/angular-public/getting-started.md
@@ -22,16 +22,16 @@ You can create now your project as described in the official [Angular CLI docume
 
 ## Step 1: Install the library
 
-Just after you created your own Angular project, in order to include the library, you have to install the `@sbb-esta/angular-public`, `@sbb-esta/angular-icons` and `@angular/cdk` dependencies:
+Just after you created your own Angular project, in order to include the library, you have to install the `@sbb-esta/angular-public`, `@sbb-esta/angular-core`, `@sbb-esta/angular-icons` and `@angular/cdk` dependencies:
 
 ```sh
-npm install --save @sbb-esta/angular-public @sbb-esta/angular-icons @angular/cdk
+npm install --save @sbb-esta/angular-public @sbb-esta/angular-core @sbb-esta/angular-icons @angular/cdk
 ```
 
 or, if using yarn:
 
 ```sh
-yarn add @sbb-esta/angular-public @sbb-esta/angular-icons @angular/cdk
+yarn add @sbb-esta/angular-public @sbb-esta/angular-core @sbb-esta/angular-icons @angular/cdk
 ```
 
 ## Step 2: Configure animations

--- a/projects/sbb-esta/angular-public/ng-package.json
+++ b/projects/sbb-esta/angular-public/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../../dist/sbb-esta/angular-public",
-  "whitelistedNonPeerDependencies": ["tslib", "@sbb-esta/angular-core", "@types/grecaptcha"],
+  "whitelistedNonPeerDependencies": ["tslib", "@types/grecaptcha"],
   "lib": {
     "entryFile": "public-api.ts",
     "umdModuleIds": {

--- a/projects/sbb-esta/angular-public/package.json
+++ b/projects/sbb-esta/angular-public/package.json
@@ -19,10 +19,10 @@
     "@angular/cdk": "^9.0.0",
     "@angular/forms": "^9.0.0",
     "@angular/router": "^9.0.0",
+    "@sbb-esta/angular-core": "0.0.0-PLACEHOLDER",
     "@sbb-esta/angular-icons": "0.0.0-PLACEHOLDER"
   },
   "dependencies": {
-    "@sbb-esta/angular-core": "0.0.0-PLACEHOLDER",
     "@types/grecaptcha": "^2.0.36"
   },
   "ng-update": {


### PR DESCRIPTION
BREAKING CHANGE: @sbb-esta/angular-core is now a peer dependency of @sbb-esta/angular-public and @sbb-esta/angular-business. This means consumers of this library will need to install @sbb-esta/angular-core manually via `npm install --save @sbb-esta/angular-core`.