### PR TITLE
feat(business): add .sbb-active as active link highlight

### DIFF
--- a/projects/sbb-esta/angular-business/header/src/header/header.component.scss
+++ b/projects/sbb-esta/angular-business/header/src/header/header.component.scss
@@ -114,7 +114,8 @@ nav {
 
     &:hover,
     &:active,
-    &:focus {
+    &:focus,
+    &.sbb-active {
       color: $sbbColorRed125;
     }
   }


### PR DESCRIPTION
Setting routerLinkActive="sbb-active" will apply the active color (darker red) to the element.

Closes #253