### PR TITLE
fix: make notification component jump marks fault tolerant

### DIFF
--- a/projects/sbb-esta/angular-business/notification/src/notification/notification.component.ts
+++ b/projects/sbb-esta/angular-business/notification/src/notification/notification.component.ts
@@ -194,7 +194,7 @@ export class NotificationComponent {
   scrollTo($event: any, jumpMark: JumpMark) {
     $event.preventDefault();
     if (jumpMark.elementId) {
-      document.querySelector(jumpMark.elementId).scrollIntoView({ behavior: 'smooth' });
+      document.querySelector(jumpMark.elementId)?.scrollIntoView({ behavior: 'smooth' });
     }
     if (jumpMark.callback) {
       jumpMark.callback($event, jumpMark);

--- a/projects/sbb-esta/angular-public/notification/src/notification/notification.component.ts
+++ b/projects/sbb-esta/angular-public/notification/src/notification/notification.component.ts
@@ -124,7 +124,7 @@ export class NotificationComponent {
   scrollTo($event: any, jumpMark: JumpMark) {
     $event.preventDefault();
     if (jumpMark.elementId) {
-      document.querySelector(jumpMark.elementId).scrollIntoView({ behavior: 'smooth' });
+      document.querySelector(jumpMark.elementId)?.scrollIntoView({ behavior: 'smooth' });
     }
     if (jumpMark.callback) {
       jumpMark.callback($event, jumpMark);


### PR DESCRIPTION
This changes the jump mark logic to do nothing, if the referenced id is not found in the document.