### PR TITLE
refactor: deprecate inputId on form components

### DIFF
--- a/projects/sbb-esta/angular-core/base/src/checkbox-base.ts
+++ b/projects/sbb-esta/angular-core/base/src/checkbox-base.ts
@@ -29,8 +29,10 @@ export class SbbCheckboxChange<TCheckbox extends CheckboxBase = CheckboxBase> {
 export abstract class CheckboxBase implements ControlValueAccessor {
   /** A unique id for the checkbox input. If none is supplied, it will be auto-generated. */
   @Input() @HostBinding() id: string;
-  /** Identifier of a checkbox field */
-  // TODO: Refactor to a getter for Angular 9
+  /**
+   * Identifier of a checkbox field
+   * @deprecated This will be replaced by an internal getter, based on the id property.
+   */
   @Input() inputId: string;
   /** Value contained in a checkbox field */
   @Input() value: any;

--- a/projects/sbb-esta/angular-core/forms/src/form-field-control.ts
+++ b/projects/sbb-esta/angular-core/forms/src/form-field-control.ts
@@ -11,7 +11,10 @@ export abstract class FormFieldControl<TValue> {
   readonly stateChanges: Observable<void>;
   /** The id of the form field. */
   readonly id: string;
-  /** The id of the inner input field. Can be the same as the id property. */
+  /**
+   * The id of the inner input field. Can be the same as the id property.
+   * @deprecated This will be replaced by an internal getter, based on the id property.
+   */
   readonly inputId: string;
   /** The attached NgControl, if any exists. */
   readonly ngControl: NgControl | undefined;

--- a/projects/sbb-esta/angular-core/radio-button/src/radio-button.ts
+++ b/projects/sbb-esta/angular-core/radio-button/src/radio-button.ts
@@ -51,7 +51,10 @@ export abstract class RadioButton extends _RadioButtonMixinBase
   /** The id of this component. */
   // tslint:disable-next-line: no-input-rename
   @Input() @HostBinding('attr.id') id: string = this._uniqueId;
-  /** Radio input identifier. */
+  /**
+   * Radio input identifier.
+   * @deprecated This will be replaced by an internal getter, based on the id property.
+   */
   @Input() inputId = `${this.id}-input`;
   /** Analog to HTML 'name' attribute used to group radios for unique selection. */
   @Input() name: string;

--- a/projects/sbb-esta/angular-public/file-selector/src/file-selector/file-selector.component.ts
+++ b/projects/sbb-esta/angular-public/file-selector/src/file-selector/file-selector.component.ts
@@ -61,6 +61,7 @@ export class FileSelectorComponent implements ControlValueAccessor, FileSelector
 
   /**
    * Identifier of a sbb-file-selector component.
+   * @deprecated This will be replaced by an internal getter, based on the id property.
    */
   @Input() inputId = `sbb-file-selector-${counter++}`;
 

--- a/projects/sbb-esta/angular-public/input/src/input/input.directive.ts
+++ b/projects/sbb-esta/angular-public/input/src/input/input.directive.ts
@@ -113,6 +113,9 @@ export class InputDirective extends SbbNativeInputBase
   @Input()
   id = `sbb-native-input-${nextId++}`;
 
+  /**
+   * @deprecated This will be replaced by an internal getter, based on the id property.
+   */
   get inputId() {
     return this.id;
   }

--- a/projects/sbb-esta/angular-public/select/src/select/select.component.ts
+++ b/projects/sbb-esta/angular-public/select/src/select/select.component.ts
@@ -322,6 +322,7 @@ export class SelectComponent extends SbbSelectMixinBase
 
   /**
    * Implemented as part of FormFieldControl.
+   * @deprecated This will be replaced by an internal getter, based on the id property.
    * @docs-private
    */
   get inputId() {

--- a/projects/sbb-esta/angular-public/textarea/src/textarea/textarea.component.ts
+++ b/projects/sbb-esta/angular-public/textarea/src/textarea/textarea.component.ts
@@ -95,7 +95,10 @@ export class TextareaComponent implements ControlValueAccessor {
   private _required = false;
   /** Placeholder value for the textarea. */
   @Input() placeholder = '';
-  /** Identifier of textarea. */
+  /**
+   * Identifier of textarea.
+   * @deprecated This will be replaced by an internal getter, based on the id property.
+   */
   @Input() inputId = `sbb-textarea-input-id-${++nextId}`;
   /** @docs-private */
   @ViewChild('textarea', { static: true }) _textarea: ElementRef<HTMLTextAreaElement>;


### PR DESCRIPTION
The inputId property on form components will be replaced by an internal getter based on the id property. Where applicable, the form components will forward focus events (e.g. from a label) to the internal input element.