### PR TITLE
fix(accordion): toggle expansion-panel-header only if focused

### DIFF
--- a/src/angular-public/accordion/expansion-panel-header/expansion-panel-header.component.ts
+++ b/src/angular-public/accordion/expansion-panel-header/expansion-panel-header.component.ts
@@ -147,21 +147,21 @@ export class ExpansionPanelHeaderComponent implements OnDestroy, FocusableOption
   /** Handle keydown event calling to toggle() if appropriate. */
   @HostListener('keydown', ['$event'])
   keydown(event: KeyboardEvent) {
-    if (this.isFocused()) {
-      switch (event.keyCode) {
-        // Toggle for space and enter keys.
-        case SPACE:
-        case ENTER:
+    switch (event.keyCode) {
+      // Toggle for space and enter keys.
+      case SPACE:
+      case ENTER:
+        if (this._isFocused()) {
           event.preventDefault();
           this.toggle();
-          break;
-        default:
-          if (this.panel.accordion) {
-            this.panel.accordion.handleHeaderKeydown(event);
-          }
+        }
+        break;
+      default:
+        if (this.panel.accordion) {
+          this.panel.accordion.handleHeaderKeydown(event);
+        }
 
-          return;
-      }
+        return;
     }
   }
 
@@ -179,7 +179,7 @@ export class ExpansionPanelHeaderComponent implements OnDestroy, FocusableOption
     this._focusMonitor.stopMonitoring(this._element.nativeElement);
   }
 
-  private isFocused() {
+  private _isFocused() {
     return this._document?.activeElement === this._element.nativeElement;
   }
 }

--- a/src/angular-public/accordion/expansion-panel-header/expansion-panel-header.component.ts
+++ b/src/angular-public/accordion/expansion-panel-header/expansion-panel-header.component.ts
@@ -1,5 +1,6 @@
 import { FocusableOption, FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
 import { ENTER, SPACE } from '@angular/cdk/keycodes';
+import { DOCUMENT } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -8,6 +9,7 @@ import {
   Host,
   HostBinding,
   HostListener,
+  Inject,
   OnDestroy,
   ViewEncapsulation
 } from '@angular/core';
@@ -59,6 +61,8 @@ export class ExpansionPanelHeaderComponent implements OnDestroy, FocusableOption
 
   private _parentChangeSubscription = Subscription.EMPTY;
 
+  private _document: Document;
+
   constructor(
     /**
      * Class property that refers to the ExpansionPanelComponent.
@@ -66,7 +70,8 @@ export class ExpansionPanelHeaderComponent implements OnDestroy, FocusableOption
     @Host() public panel: ExpansionPanelComponent,
     private _element: ElementRef,
     private _focusMonitor: FocusMonitor,
-    private _changeDetectorRef: ChangeDetectorRef
+    private _changeDetectorRef: ChangeDetectorRef,
+    @Inject(DOCUMENT) document?: any
   ) {
     const accordionHideToggleChange = panel.accordion
       ? panel.accordion._stateChanges.pipe(filter(changes => !!changes.hideToggle))
@@ -91,6 +96,8 @@ export class ExpansionPanelHeaderComponent implements OnDestroy, FocusableOption
         panel.accordion.handleHeaderFocus(this);
       }
     });
+
+    this._document = document;
   }
 
   /**
@@ -140,19 +147,21 @@ export class ExpansionPanelHeaderComponent implements OnDestroy, FocusableOption
   /** Handle keydown event calling to toggle() if appropriate. */
   @HostListener('keydown', ['$event'])
   keydown(event: KeyboardEvent) {
-    switch (event.keyCode) {
-      // Toggle for space and enter keys.
-      case SPACE:
-      case ENTER:
-        event.preventDefault();
-        this.toggle();
-        break;
-      default:
-        if (this.panel.accordion) {
-          this.panel.accordion.handleHeaderKeydown(event);
-        }
+    if (this.isFocused()) {
+      switch (event.keyCode) {
+        // Toggle for space and enter keys.
+        case SPACE:
+        case ENTER:
+          event.preventDefault();
+          this.toggle();
+          break;
+        default:
+          if (this.panel.accordion) {
+            this.panel.accordion.handleHeaderKeydown(event);
+          }
 
-        return;
+          return;
+      }
     }
   }
 
@@ -168,5 +177,9 @@ export class ExpansionPanelHeaderComponent implements OnDestroy, FocusableOption
   ngOnDestroy() {
     this._parentChangeSubscription.unsubscribe();
     this._focusMonitor.stopMonitoring(this._element.nativeElement);
+  }
+
+  private isFocused() {
+    return this._document?.activeElement === this._element.nativeElement;
   }
 }

--- a/src/angular-public/accordion/expansion-panel/expansion-panel.component.spec.ts
+++ b/src/angular-public/accordion/expansion-panel/expansion-panel.component.spec.ts
@@ -237,6 +237,7 @@ describe('ExpansionPanelComponent', () => {
 
     spyOn(fixture.componentInstance.panel, 'toggle');
 
+    headerEl.focus();
     const event = dispatchKeyboardEvent(headerEl, 'keydown', SPACE);
     fixture.detectChanges();
 
@@ -252,6 +253,7 @@ describe('ExpansionPanelComponent', () => {
 
     spyOn(fixture.componentInstance.panel, 'toggle');
 
+    headerEl.focus();
     const event = dispatchKeyboardEvent(headerEl, 'keydown', ENTER);
     fixture.detectChanges();
 

--- a/src/showcase/app/public/public-examples/accordion-examples/accordion-example/accordion-example.component.html
+++ b/src/showcase/app/public/public-examples/accordion-examples/accordion-example/accordion-example.component.html
@@ -220,12 +220,6 @@
                 (click)="
                   logAndPreventOpeningPanel($event, 'clicked button and prevent panel to open')
                 "
-                (keydown)="
-                  logAndPreventOpeningPanelKeyDown(
-                    $event,
-                    'activated button with keyboard and prevent panel to open'
-                  )
-                "
               >
                 Test button
                 <sbb-icon-arrow-right *sbbIcon></sbb-icon-arrow-right>

--- a/src/showcase/app/public/public-examples/accordion-examples/accordion-example/accordion-example.component.ts
+++ b/src/showcase/app/public/public-examples/accordion-examples/accordion-example/accordion-example.component.ts
@@ -106,14 +106,6 @@ export class AccordionExampleComponent implements OnInit, OnDestroy {
     evt.stopPropagation();
   }
 
-  logAndPreventOpeningPanelKeyDown(evt: KeyboardEvent, message: any) {
-    if (evt.keyCode === 13 || evt.keyCode === 32) {
-      console.log(message);
-      evt.preventDefault();
-      evt.stopPropagation();
-    }
-  }
-
   ngOnDestroy() {
     this.onRadioChange.unsubscribe();
     this.onDisabledChange.unsubscribe();


### PR DESCRIPTION
Fixes #377

Currently SSO-int is not working, so I have some time for other stuff :smile:.

The `activeElement` solution is inspired by a similar implementation in the `expansion-panel.component.ts`. I thought about using the FocusMonitor but ultimately preferred a synchronous solution. Critical feedback appreciated.