### PR TITLE
fix: revert type imports

### DIFF
--- a/src/angular-public/autocomplete/autocomplete/autocomplete-trigger.directive.ts
+++ b/src/angular-public/autocomplete/autocomplete/autocomplete-trigger.directive.ts
@@ -30,8 +30,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { FORM_FIELD } from '@sbb-esta/angular-public/field';
-import type { FieldComponent } from '@sbb-esta/angular-public/field';
+import { FORM_FIELD, HasFormFieldControl } from '@sbb-esta/angular-public/field';
 import {
   countGroupLabelsBeforeOption,
   getOptionScrollPosition,
@@ -268,7 +267,8 @@ export class AutocompleteTriggerDirective
     @Inject(SBB_AUTOCOMPLETE_SCROLL_STRATEGY) private _scrollStrategy: any,
     private _viewportRuler: ViewportRuler,
     @Optional() @Inject(DOCUMENT) document: any,
-    @Optional() @Inject(FORM_FIELD) @Host() private _formField: FieldComponent
+    // TODO: Replace with type import of FieldComponent
+    @Optional() @Inject(FORM_FIELD) @Host() private _formField: HasFormFieldControl
   ) {
     this._document = document;
   }

--- a/src/angular-public/field/form-field-token.ts
+++ b/src/angular-public/field/form-field-token.ts
@@ -1,5 +1,6 @@
 import { InjectionToken } from '@angular/core';
 
-import type { FieldComponent } from './field/field.component';
+import { HasFormFieldControl } from './has-form-field-control';
 
-export const FORM_FIELD = new InjectionToken<FieldComponent>('SBB_FORM_FIELD');
+// TODO: Replace with type import of FieldComponent
+export const FORM_FIELD = new InjectionToken<HasFormFieldControl>('SBB_FORM_FIELD');

--- a/src/angular-public/field/has-form-field-control.ts
+++ b/src/angular-public/field/has-form-field-control.ts
@@ -1,6 +1,8 @@
+import { ElementRef } from '@angular/core';
 import { FormFieldControl } from '@sbb-esta/angular-core/forms';
 
-/** @deprecated */
+/** @deprecated Use type import of FieldComponent */
 export interface HasFormFieldControl {
   _control: FormFieldControl<any>;
+  _elementRef: ElementRef<HTMLElement>;
 }

--- a/src/angular-public/field/label/label.component.ts
+++ b/src/angular-public/field/label/label.component.ts
@@ -7,8 +7,8 @@ import {
   Optional,
 } from '@angular/core';
 
-import type { FieldComponent } from '../field/field.component';
 import { FORM_FIELD } from '../form-field-token';
+import { HasFormFieldControl } from '../has-form-field-control';
 
 @Component({
   selector: 'sbb-label',
@@ -29,7 +29,8 @@ export class LabelComponent {
   }
   private _for: string | null = null;
 
-  constructor(@Inject(FORM_FIELD) @Optional() private _formField: FieldComponent) {}
+  // TODO: Replace with type import of FieldComponent
+  constructor(@Inject(FORM_FIELD) @Optional() private _formField: HasFormFieldControl) {}
 
   private _inputId() {
     return this._hasFormFieldControl() ? this._formField._control.id : null;


### PR DESCRIPTION
TypeScript type imports (import type {...} from '...') break older TypeScript versions. We revert to fix compatibility.