### PR TITLE
refactor: replace first() operator with simpler take(1)

### DIFF
--- a/src/angular-business/dialog/dialog/dialog-ref.ts
+++ b/src/angular-business/dialog/dialog/dialog-ref.ts
@@ -2,7 +2,7 @@ import { ESCAPE } from '@angular/cdk/keycodes';
 import { GlobalPositionStrategy, OverlayRef } from '@angular/cdk/overlay';
 import { Location } from '@angular/common';
 import { Observable, Subject, Subscription, SubscriptionLike } from 'rxjs';
-import { filter, first } from 'rxjs/operators';
+import { filter, take } from 'rxjs/operators';
 
 import { DialogContainerComponent } from '../dialog-container/dialog-container.component';
 
@@ -53,7 +53,7 @@ export class DialogRef<T, R = any> {
     containerInstance.animationStateChanged
       .pipe(
         filter((event) => event.phaseName === 'done' && event.toState === 'enter'),
-        first()
+        take(1)
       )
       .subscribe(() => {
         this._afterOpen.next();
@@ -64,7 +64,7 @@ export class DialogRef<T, R = any> {
     containerInstance.animationStateChanged
       .pipe(
         filter((event) => event.phaseName === 'done' && event.toState === 'exit'),
-        first()
+        take(1)
       )
       .subscribe(() => this._overlayRef.dispose());
 
@@ -111,7 +111,7 @@ export class DialogRef<T, R = any> {
     this.containerInstance.animationStateChanged
       .pipe(
         filter((event) => event.phaseName === 'start'),
-        first()
+        take(1)
       )
       .subscribe(() => {
         this._beforeClose.next(dialogResult);

--- a/src/angular-core/base/tooltip/tooltip-base.ts
+++ b/src/angular-core/base/tooltip/tooltip-base.ts
@@ -24,7 +24,7 @@ import {
 } from '@angular/core';
 import { IconDirective } from '@sbb-esta/angular-core/icon-directive';
 import { fromEvent, merge, Observable, of, Subject, Subscription } from 'rxjs';
-import { filter, first, map, switchMap } from 'rxjs/operators';
+import { filter, map, switchMap, take } from 'rxjs/operators';
 
 import { TooltipRegistryService } from './tooltip-registry.service';
 
@@ -314,7 +314,7 @@ export abstract class TooltipBase implements OnDestroy {
    * stream every time the option list changes.
    */
   private _subscribeToClosingActions(): Subscription {
-    const firstStable = this._zone.onStable.asObservable().pipe(first());
+    const firstStable = this._zone.onStable.asObservable().pipe(take(1));
 
     // When the zone is stable initially, and when the option list changes...
     return (
@@ -326,7 +326,7 @@ export abstract class TooltipBase implements OnDestroy {
             return this.panelClosingActions;
           }),
           // when the first closing event occurs...
-          first()
+          take(1)
         )
         // set the value, close the panel, and complete.
         .subscribe(() => {

--- a/src/angular-public/accordion/expansion-panel/expansion-panel.component.ts
+++ b/src/angular-public/accordion/expansion-panel/expansion-panel.component.ts
@@ -26,7 +26,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { Subject } from 'rxjs';
-import { filter, first, startWith } from 'rxjs/operators';
+import { filter, startWith, take } from 'rxjs/operators';
 
 import { sbbExpansionAnimations } from '../accordion/accordion-animations';
 import { IAccordionBase, SBB_ACCORDION } from '../accordion/accordion-base';
@@ -152,7 +152,7 @@ export class ExpansionPanelComponent extends CdkAccordionItem
         .pipe(
           startWith(true),
           filter(() => this.expanded && !this.portal),
-          first()
+          take(1)
         )
         .subscribe(() => {
           this.portal = new TemplatePortal(this.lazyContent._template, this._viewContainerRef);

--- a/src/angular-public/breadcrumb/breadcrumbs/breadcrumbs.component.ts
+++ b/src/angular-public/breadcrumb/breadcrumbs/breadcrumbs.component.ts
@@ -6,10 +6,9 @@ import {
   ContentChildren,
   HostBinding,
   QueryList,
-  TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { first } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 
 import {
   BreadcrumbComponent,
@@ -57,7 +56,7 @@ export class BreadcrumbsComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     if (this.levels && this.levels.first) {
-      this.levels.first.expandEvent.pipe(first()).subscribe(() => {
+      this.levels.first.expandEvent.pipe(take(1)).subscribe(() => {
         this._expanded = true;
         this._changeDetectorRef.markForCheck();
       });

--- a/src/angular-public/datepicker/calendar-body/calendar-body.component.ts
+++ b/src/angular-public/datepicker/calendar-body/calendar-body.component.ts
@@ -12,7 +12,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { DateFormats, SBB_DATE_FORMATS } from '@sbb-esta/angular-core/datetime';
-import { first } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 
 /**
  * An internal class that represents the data corresponding to a single calendar cell.
@@ -119,7 +119,7 @@ export class CalendarBodyComponent {
     this._ngZone.runOutsideAngular(() => {
       this._ngZone.onStable
         .asObservable()
-        .pipe(first())
+        .pipe(take(1))
         .subscribe(() => {
           const activeCell: HTMLElement | null = this._elementRef.nativeElement.querySelector(
             '.sbb-calendar-body-active'

--- a/src/angular-public/datepicker/datepicker/datepicker.component.ts
+++ b/src/angular-public/datepicker/datepicker/datepicker.component.ts
@@ -29,7 +29,7 @@ import {
 } from '@angular/core';
 import { DateAdapter } from '@sbb-esta/angular-core/datetime';
 import { merge, Subject, Subscription } from 'rxjs';
-import { bufferCount, filter, first, mapTo, tap } from 'rxjs/operators';
+import { bufferCount, filter, mapTo, take, tap } from 'rxjs/operators';
 
 import { DateInputDirective } from '../date-input/date-input.directive';
 import { DatepickerContentComponent } from '../datepicker-content/datepicker-content.component';
@@ -443,7 +443,7 @@ export class DatepickerComponent<D> implements OnDestroy {
       // Update the position once the calendar has rendered.
       this._ngZone.onStable
         .asObservable()
-        .pipe(first())
+        .pipe(take(1))
         .subscribe(() => {
           this.popupRef.updatePosition();
         });

--- a/src/angular-public/dropdown/dropdown-trigger.directive.ts
+++ b/src/angular-public/dropdown/dropdown-trigger.directive.ts
@@ -47,7 +47,7 @@ import {
   Subject,
   Subscription,
 } from 'rxjs';
-import { delay, filter, first, map, switchMap, take, tap } from 'rxjs/operators';
+import { delay, filter, map, switchMap, take, tap } from 'rxjs/operators';
 
 import {
   DropdownItemDirective,
@@ -431,7 +431,7 @@ export class DropdownTriggerDirective implements OnDestroy {
    * stream every time the option list changes.
    */
   private _subscribeToClosingActions(): Subscription {
-    const firstStable = this._zone.onStable.asObservable().pipe(first());
+    const firstStable = this._zone.onStable.asObservable().pipe(take(1));
     const optionChanges = this.dropdown.options.changes.pipe(
       tap(() => this._positionStrategy.reapplyLastPosition()),
       // Defer emitting to the stream until the next tick, because changing
@@ -457,7 +457,7 @@ export class DropdownTriggerDirective implements OnDestroy {
             return this.panelClosingActions;
           }),
           // when the first closing event occurs...
-          first()
+          take(1)
         )
         // set the value, close the panel, and complete.
         .subscribe((event) => this._setValueAndClose(event))

--- a/src/angular-public/ghettobox/ghettobox/ghettobox-ref.ts
+++ b/src/angular-public/ghettobox/ghettobox/ghettobox-ref.ts
@@ -1,7 +1,7 @@
 import { ComponentRef, TemplateRef } from '@angular/core';
 import { LinkGeneratorResult } from '@sbb-esta/angular-core/models';
 import { Subject } from 'rxjs';
-import { filter, first } from 'rxjs/operators';
+import { filter, take } from 'rxjs/operators';
 
 import { GhettoboxComponent, GhettoboxDeletedEvent } from './ghettobox.component';
 
@@ -42,7 +42,7 @@ export class GhettoboxRef {
   constructor(private _ref: ComponentRef<GhettoboxComponent> | GhettoboxComponent) {
     this.afterDelete
       .pipe(
-        first(),
+        take(1),
         filter(() => this._ref instanceof ComponentRef)
       )
       .subscribe(() => this._ref.destroy());

--- a/src/angular-public/lightbox/lightbox/lightbox-ref.ts
+++ b/src/angular-public/lightbox/lightbox/lightbox-ref.ts
@@ -2,7 +2,7 @@ import { ESCAPE } from '@angular/cdk/keycodes';
 import { OverlayRef } from '@angular/cdk/overlay';
 import { Location } from '@angular/common';
 import { Observable, Subject, Subscription, SubscriptionLike } from 'rxjs';
-import { filter, first } from 'rxjs/operators';
+import { filter, take } from 'rxjs/operators';
 
 import { LightboxContainerComponent } from './lightbox-container.component';
 
@@ -51,7 +51,7 @@ export class LightboxRef<T, R = any> {
     containerInstance.animationStateChanged
       .pipe(
         filter((event) => event.phaseName === 'done' && event.toState === 'enter'),
-        first()
+        take(1)
       )
       .subscribe(() => {
         this._afterOpen.next();
@@ -62,7 +62,7 @@ export class LightboxRef<T, R = any> {
     containerInstance.animationStateChanged
       .pipe(
         filter((event) => event.phaseName === 'done' && event.toState === 'exit'),
-        first()
+        take(1)
       )
       .subscribe(() => this._overlayRef.dispose());
 
@@ -109,7 +109,7 @@ export class LightboxRef<T, R = any> {
     this.containerInstance.animationStateChanged
       .pipe(
         filter((event) => event.phaseName === 'start'),
-        first()
+        take(1)
       )
       .subscribe(() => {
         this._beforeClose.next(lightboxResult);

--- a/src/angular-public/search/search/search.component.ts
+++ b/src/angular-public/search/search/search.component.ts
@@ -61,7 +61,7 @@ import {
   Subject,
   Subscription,
 } from 'rxjs';
-import { delay, filter, first, map, startWith, switchMap, tap } from 'rxjs/operators';
+import { delay, filter, map, startWith, switchMap, take, tap } from 'rxjs/operators';
 
 /** Injection token that determines the scroll handling while the calendar is open. */
 export const SBB_SEARCH_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrategy>(
@@ -289,7 +289,7 @@ export class SearchComponent implements ControlValueAccessor, OnDestroy, AfterVi
     // If there are any subscribers before `ngAfterViewInit`, the `autocomplete` will be undefined.
     // Return a stream that we'll replace with the real one once everything is in place.
     return this._zone.onStable.asObservable().pipe(
-      first(),
+      take(1),
       switchMap(() => this.optionSelections)
     );
   });
@@ -641,7 +641,7 @@ export class SearchComponent implements ControlValueAccessor, OnDestroy, AfterVi
    * stream every time the option list changes.
    */
   private _subscribeToClosingActions(): Subscription {
-    const firstStable = this._zone.onStable.asObservable().pipe(first());
+    const firstStable = this._zone.onStable.asObservable().pipe(take(1));
     const optionChanges = this.autocomplete.options.changes.pipe(
       tap(() => this._positionStrategy.reapplyLastPosition()),
       // Defer emitting to the stream until the next tick, because changing
@@ -667,7 +667,7 @@ export class SearchComponent implements ControlValueAccessor, OnDestroy, AfterVi
             return this.panelClosingActions;
           }),
           // when the first closing event occurs...
-          first()
+          take(1)
         )
         // set the value, close the panel, and complete.
         .subscribe((event) => {

--- a/src/angular-public/select/select/select.component.ts
+++ b/src/angular-public/select/select/select.component.ts
@@ -66,7 +66,7 @@ import {
   SBB_OPTION_PARENT_COMPONENT,
 } from '@sbb-esta/angular-public/option';
 import { defer, merge, Observable, Subject } from 'rxjs';
-import { filter, first, map, startWith, switchMap, takeUntil } from 'rxjs/operators';
+import { filter, map, startWith, switchMap, take, takeUntil } from 'rxjs/operators';
 
 let nextUniqueId = 0;
 
@@ -326,7 +326,7 @@ export class SelectComponent extends SbbSelectMixinBase
     }
 
     return this._ngZone.onStable.asObservable().pipe(
-      first(),
+      take(1),
       switchMap(() => this.optionSelectionChanges)
     );
   }) as Observable<SBBOptionSelectionChange>;
@@ -659,7 +659,7 @@ export class SelectComponent extends SbbSelectMixinBase
     // Set the font size on the panel element once it exists.
     this._ngZone.onStable
       .asObservable()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         if (
           this.triggerFontSize &&
@@ -848,7 +848,7 @@ export class SelectComponent extends SbbSelectMixinBase
    * Callback that is invoked when the overlay panel has been attached.
    */
   onAttached(): void {
-    this.overlayDir.positionChange.pipe(first()).subscribe((positions) => {
+    this.overlayDir.positionChange.pipe(take(1)).subscribe((positions) => {
       if (positions.connectionPair.originY === 'top') {
         this.panel.nativeElement.classList.add('sbb-select-panel-above');
       } else {

--- a/src/angular-public/tag/tag/tag.component.ts
+++ b/src/angular-public/tag/tag/tag.component.ts
@@ -20,7 +20,7 @@ import {
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { CheckboxBase, SbbCheckboxChange } from '@sbb-esta/angular-core/base/checkbox';
 import { Subject } from 'rxjs';
-import { first } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 
 /**
  * Injection token used to provide the parent component to TagComponent.
@@ -114,7 +114,7 @@ export class TagComponent extends CheckboxBase<TagChange> implements OnInit, OnD
       this.tagChecking$.next(e.checked);
     });
     this._zone.onStable
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => this._zone.run(() => this.tagChecking$.next(this.checked)));
   }
 

--- a/src/angular-public/textarea/textarea/textarea.component.ts
+++ b/src/angular-public/textarea/textarea/textarea.component.ts
@@ -31,7 +31,7 @@ import {
 import { ErrorStateMatcher } from '@sbb-esta/angular-core/error';
 import { FormFieldControl } from '@sbb-esta/angular-core/forms';
 import { BehaviorSubject, fromEvent, Subject } from 'rxjs';
-import { auditTime, first, takeUntil } from 'rxjs/operators';
+import { auditTime, take, takeUntil } from 'rxjs/operators';
 
 let nextId = 0;
 
@@ -248,7 +248,7 @@ export class TextareaComponent extends SbbTextareaMixinBase
    * Trigger the resize of the textarea to fit the content
    */
   triggerResize() {
-    this._ngZone.onStable.pipe(first()).subscribe(() => this.autosize.resizeToFitContent());
+    this._ngZone.onStable.pipe(take(1)).subscribe(() => this.autosize.resizeToFitContent());
   }
 
   /**

--- a/src/angular-public/toggle/toggle/toggle.component.ts
+++ b/src/angular-public/toggle/toggle/toggle.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { RadioGroupDirective } from '@sbb-esta/angular-core/radio-button';
-import { first } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'sbb-toggle',
@@ -42,7 +42,7 @@ export class ToggleComponent extends RadioGroupDirective
 
   ngAfterContentInit() {
     super.ngAfterContentInit();
-    this._zone.onStable.pipe(first()).subscribe(() =>
+    this._zone.onStable.pipe(take(1)).subscribe(() =>
       this._zone.run(() => {
         this._checkNumOfOptions();
         if (this._radios.toArray().every((r) => this.value !== r.value)) {

--- a/src/showcase/app/public/public-examples/ghettobox-examples/ghettobox-example/ghettobox-example.component.ts
+++ b/src/showcase/app/public/public-examples/ghettobox-examples/ghettobox-example/ghettobox-example.component.ts
@@ -13,7 +13,7 @@ import {
   GhettoboxService,
 } from '@sbb-esta/angular-public/ghettobox';
 import { Subscription } from 'rxjs';
-import { first } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'sbb-ghettobox-example',
@@ -64,7 +64,7 @@ export class GhettoboxExampleComponent implements OnDestroy {
   }
 
   private _subscribeToAfterDeleteResponse(ghetto: GhettoboxRef) {
-    ghetto.afterDelete.pipe(first()).subscribe((evt: GhettoboxDeletedEvent) => {
+    ghetto.afterDelete.pipe(take(1)).subscribe((evt: GhettoboxDeletedEvent) => {
       this.afterDeleteContainer(evt);
     });
   }

--- a/src/showcase/app/shared/component-viewer-base.ts
+++ b/src/showcase/app/shared/component-viewer-base.ts
@@ -2,7 +2,7 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { AfterViewInit, Directive, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Observable, Subject } from 'rxjs';
-import { distinctUntilChanged, filter, first, map, skip, takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, skip, take, takeUntil } from 'rxjs/operators';
 
 import { ExampleProvider } from './example-provider';
 import { HtmlLoader } from './html-loader.service';
@@ -36,7 +36,7 @@ export class ComponentViewerBase implements OnInit, AfterViewInit, OnDestroy {
   ngAfterViewInit(): void {
     this._route.params
       .pipe(
-        first(),
+        take(1),
         filter((p) => p.section),
         map((p) => (p.section === 'api' ? 1 : 2))
       )


### PR DESCRIPTION
Use take(1) instead of first(), since the implementation of tak(1) is far smaller.