### PR TITLE
feat(business): extract table business styling

### DIFF
--- a/src/angular-business/table/table-cell/table-cell.component.ts
+++ b/src/angular-business/table/table-cell/table-cell.component.ts
@@ -63,7 +63,6 @@ export class ColumnDefDirective extends CdkColumnDef {
   selector: 'sbbHeaderCell, th[sbbHeaderCell]',
 })
 export class HeaderCellDirective extends CdkHeaderCell {
-  @HostBinding('class.sbb-header-cell') sbbHeaderCell = true;
   @HostBinding('attr.role') gridCell = 'gridcell';
 
   constructor(columnDef: CdkColumnDef, elementRef: ElementRef<HTMLElement>) {
@@ -77,7 +76,6 @@ export class HeaderCellDirective extends CdkHeaderCell {
   selector: 'sbbFooterCell, td[sbbFooterCell]',
 })
 export class FooterCellDirective extends CdkFooterCell {
-  @HostBinding('class.sbb-footer-cell') sbbFooterCell = true;
   @HostBinding('attr.role') gridCell = 'gridcell';
 
   constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
@@ -91,7 +89,6 @@ export class FooterCellDirective extends CdkFooterCell {
   selector: 'sbbCell, td[sbbCell]',
 })
 export class CellDirective extends CdkCell {
-  @HostBinding('class.sbb-cell') sbbCell = true;
   @HostBinding('attr.role') gridCell = 'gridcell';
 
   constructor(columnDef: CdkColumnDef, elementRef: ElementRef<HTMLElement>) {

--- a/src/angular-business/table/table-cell/table-cell.component.ts
+++ b/src/angular-business/table/table-cell/table-cell.component.ts
@@ -63,6 +63,8 @@ export class ColumnDefDirective extends CdkColumnDef {
   selector: 'sbbHeaderCell, th[sbbHeaderCell]',
 })
 export class HeaderCellDirective extends CdkHeaderCell {
+  @HostBinding('class.sbb-header-cell') sbbHeaderCell = true;
+
   @HostBinding('attr.role') gridCell = 'gridcell';
 
   constructor(columnDef: CdkColumnDef, elementRef: ElementRef<HTMLElement>) {
@@ -76,6 +78,7 @@ export class HeaderCellDirective extends CdkHeaderCell {
   selector: 'sbbFooterCell, td[sbbFooterCell]',
 })
 export class FooterCellDirective extends CdkFooterCell {
+  @HostBinding('class.sbb-footer-cell') sbbFooterCell = true;
   @HostBinding('attr.role') gridCell = 'gridcell';
 
   constructor(columnDef: CdkColumnDef, elementRef: ElementRef) {
@@ -89,6 +92,7 @@ export class FooterCellDirective extends CdkFooterCell {
   selector: 'sbbCell, td[sbbCell]',
 })
 export class CellDirective extends CdkCell {
+  @HostBinding('class.sbb-cell') sbbCell = true;
   @HostBinding('attr.role') gridCell = 'gridcell';
 
   constructor(columnDef: CdkColumnDef, elementRef: ElementRef<HTMLElement>) {

--- a/src/angular-business/table/table-row/table-row.component.ts
+++ b/src/angular-business/table/table-row/table-row.component.ts
@@ -65,7 +65,6 @@ export class RowDefDirective<T> extends CdkRowDef<T> {}
   providers: [{ provide: CdkHeaderRow, useExisting: HeaderRowComponent }],
 })
 export class HeaderRowComponent extends CdkHeaderRow {
-  @HostBinding('class.sbb-header-row') sbbHeaderRow = true;
   @HostBinding('attr.role') row = 'row';
 }
 
@@ -81,7 +80,6 @@ export class HeaderRowComponent extends CdkHeaderRow {
   providers: [{ provide: CdkFooterRow, useExisting: FooterRowComponent }],
 })
 export class FooterRowComponent extends CdkFooterRow {
-  @HostBinding('class.sbb-footer-row') sbbFooterRow = true;
   @HostBinding('attr.role') row = 'row';
 }
 
@@ -97,6 +95,5 @@ export class FooterRowComponent extends CdkFooterRow {
   providers: [{ provide: CdkRow, useExisting: RowComponent }],
 })
 export class RowComponent extends CdkRow {
-  @HostBinding('class.sbb-row') sbbRow = true;
   @HostBinding('attr.role') row = 'row';
 }

--- a/src/angular-business/table/table-row/table-row.component.ts
+++ b/src/angular-business/table/table-row/table-row.component.ts
@@ -65,6 +65,7 @@ export class RowDefDirective<T> extends CdkRowDef<T> {}
   providers: [{ provide: CdkHeaderRow, useExisting: HeaderRowComponent }],
 })
 export class HeaderRowComponent extends CdkHeaderRow {
+  @HostBinding('class.sbb-header-row') sbbHeaderRow = true;
   @HostBinding('attr.role') row = 'row';
 }
 
@@ -80,6 +81,7 @@ export class HeaderRowComponent extends CdkHeaderRow {
   providers: [{ provide: CdkFooterRow, useExisting: FooterRowComponent }],
 })
 export class FooterRowComponent extends CdkFooterRow {
+  @HostBinding('class.sbb-footer-row') sbbFooterRow = true;
   @HostBinding('attr.role') row = 'row';
 }
 
@@ -95,5 +97,6 @@ export class FooterRowComponent extends CdkFooterRow {
   providers: [{ provide: CdkRow, useExisting: RowComponent }],
 })
 export class RowComponent extends CdkRow {
+  @HostBinding('class.sbb-row') sbbRow = true;
   @HostBinding('attr.role') row = 'row';
 }

--- a/src/angular-business/table/table/table.component.scss
+++ b/src/angular-business/table/table/table.component.scss
@@ -1,100 +1,39 @@
 $sbbBusiness: true;
 @import '../../../angular-core/styles/common';
 
-$sbb-row-height: 36px;
-$sbb-row-horizontal-padding: 16px;
-
-$inputBorderWidth: 1px;
-$inputPaddingLeft: 8px;
+$sbb-row-horizontal-padding: pxToEm(16);
+$inputBorderWidth: pxToEm(1);
+$inputPaddingLeft: pxToEm(8);
 $filterInputPadding: $sbb-row-horizontal-padding - $inputPaddingLeft - $inputBorderWidth;
 
 /**
  * Native HTML table structure
  */
 table.sbb-table {
-  border-spacing: 0;
-  width: 100%;
-  border-collapse: collapse;
-
-  tr.sbb-header-row,
-  tr.sbb-row,
-  tr.sbb-footer-row {
-    height: pxToEm($sbb-row-height);
-  }
-
-  tr.sbb-row {
-    background-color: $sbbColorWhite;
-    border-bottom: 1px solid $sbbColorAluminum;
-
-    &:hover {
-      background-color: $sbbColorCloud;
-    }
-  }
-
   th.sbb-header-cell {
-    text-align: left;
-    background-color: $sbbColorMilk;
+    &.sbb-table-filter {
+      padding: 0 $filterInputPadding $filterInputPadding $filterInputPadding;
+      font-family: $fontSbbRoman;
 
-    [dir='rtl'] & {
-      text-align: right;
+      input {
+        width: 100%;
+      }
     }
-  }
 
-  th.sbb-header-cell,
-  td.sbb-cell,
-  td.sbb-footer-cell {
-    padding: 0 $sbb-row-horizontal-padding;
-    border-right: 1px solid $sbbColorAluminum;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  th.sbb-header-cell.sbb-table-filter {
-    padding: 0 $filterInputPadding $filterInputPadding $filterInputPadding;
-    font-family: $fontSbbRoman;
-
-    input {
-      width: 100%;
-    }
-  }
-
-  // Note: we use `first-of-type`/`last-of-type` here in order to prevent extra
-  // elements like ripples or badges from throwing off the layout.
-  th.sbb-header-cell:first-of-type,
-  td.sbb-cell:first-of-type,
-  td.sbb-footer-cell:first-of-type {
-    padding-left: $sbb-row-horizontal-padding;
-    border-left: none;
-
-    [dir='rtl'] & {
-      padding-left: 0;
-      padding-right: $sbb-row-horizontal-padding;
-    }
-  }
-  th.sbb-header-cell:first-of-type.sbb-table-filter {
-    padding-left: $filterInputPadding;
-
-    [dir='rtl'] & {
-      padding-right: $filterInputPadding;
-    }
-  }
-
-  th.sbb-header-cell:last-of-type,
-  td.sbb-cell:last-of-type,
-  td.sbb-footer-cell:last-of-type {
-    padding-right: $sbb-row-horizontal-padding;
-    border-right: none;
-
-    [dir='rtl'] & {
-      padding-right: 0;
-      padding-left: $sbb-row-horizontal-padding;
-    }
-  }
-  th.sbb-header-cell:last-of-type.sbb-table-filter {
-    padding-right: $filterInputPadding;
-
-    [dir='rtl'] & {
+    &:first-of-type.sbb-table-filter {
       padding-left: $filterInputPadding;
+
+      [dir='rtl'] & {
+        padding-right: $filterInputPadding;
+      }
+    }
+
+    &:last-of-type.sbb-table-filter {
+      padding-right: $filterInputPadding;
+
+      [dir='rtl'] & {
+        padding-left: $filterInputPadding;
+      }
     }
   }
 

--- a/src/angular-core/styles/typography/_table.scss
+++ b/src/angular-core/styles/typography/_table.scss
@@ -9,6 +9,7 @@ $tableTheadCellPaddingMobile: pxToEm(29) pxToEm(12) pxToEm(30) pxToEm(12);
 $tableTheadCellPadding: pxToEm(29) pxToEm(16) pxToEm(30) pxToEm(16);
 $tableTbodyCellPaddingMobile: pxToEm(18) pxToEm(12) pxToEm(19) pxToEm(12);
 $tableTbodyCellPadding: pxToEm(18) pxToEm(16) pxToEm(19) pxToEm(16);
+$tableTrowHeightBusiness: pxToEm(36);
 $tableCaptionColor: $sbbColorGrey;
 
 @mixin tableCaption() {
@@ -23,7 +24,7 @@ $tableCaptionColor: $sbbColorGrey;
   @if $sbbBusiness {
     border-collapse: collapse;
   } @else {
-    padding-bottom: pxToEm(16);
+    padding-bottom: $tableTbodyPadding;
 
     @include mq($from: desktop4k) {
       font-size: toEm(1 * $scalingFactor4k);
@@ -108,29 +109,29 @@ $tableCaptionColor: $sbbColorGrey;
       th,
       td {
         @if $sbbBusiness {
-          height: pxToEm(36);
-          padding: 0 16px;
+          height: $tableTrowHeightBusiness;
+          padding: 0 $tableTbodyPadding;
           border-right: 1px solid $sbbColorAluminum;
           overflow: hidden;
           text-overflow: ellipsis;
 
-          &:first-of-type {
-            padding-left: 16px;
+          &:first-child {
+            padding-left: $tableTbodyPadding;
             border-left: none;
 
             [dir='rtl'] & {
               padding-left: 0;
-              padding-right: 16px;
+              padding-right: $tableTbodyPadding;
             }
           }
 
-          &:last-of-type {
-            padding-right: 16px;
+          &:last-child {
+            padding-right: $tableTbodyPadding;
             border-right: none;
 
             [dir='rtl'] & {
               padding-right: 0;
-              padding-left: 16px;
+              padding-left: $tableTbodyPadding;
             }
           }
         }

--- a/src/angular-core/styles/typography/_table.scss
+++ b/src/angular-core/styles/typography/_table.scss
@@ -1,3 +1,5 @@
+@import '../common';
+
 $tableBg: $sbbColorWhite;
 $tableTheadBgColor: $sbbColorCloud;
 $tableTbodyStripesBgColor: $sbbColorMilk;
@@ -17,33 +19,48 @@ $tableCaptionColor: $sbbColorGrey;
 @mixin table {
   border-spacing: 0;
   background-color: $tableBg;
-  padding-bottom: pxToEm(16);
 
-  @include mq($from: desktop4k) {
-    font-size: toEm(1 * $scalingFactor4k);
-  }
+  @if $sbbBusiness {
+    border-collapse: collapse;
+  } @else {
+    padding-bottom: pxToEm(16);
 
-  @include mq($from: desktop5k) {
-    font-size: toEm(1 * $scalingFactor5k);
+    @include mq($from: desktop4k) {
+      font-size: toEm(1 * $scalingFactor4k);
+    }
+
+    @include mq($from: desktop5k) {
+      font-size: toEm(1 * $scalingFactor5k);
+    }
   }
 
   thead {
-    background-color: $tableTheadBgColor;
+    @if $sbbBusiness {
+      text-align: left;
+      background-color: $sbbColorMilk;
+      border-bottom: 1px solid $sbbColorAluminum;
 
-    > tr {
-      th,
-      td {
-        padding: $tableTheadCellPaddingMobile;
+      [dir='rtl'] & {
+        text-align: right;
+      }
+    } @else {
+      background-color: $tableTheadBgColor;
 
-        @include mq($from: tabletPortrait) {
-          padding: $tableTheadCellPadding;
+      > tr {
+        th,
+        td {
+          padding: $tableTheadCellPaddingMobile;
 
-          &:first-child {
-            border-left: $tableTheadPadding solid $tableTheadBgColor;
-          }
+          @include mq($from: tabletPortrait) {
+            padding: $tableTheadCellPadding;
 
-          &:last-child {
-            border-right: $tableTheadPadding solid $tableTheadBgColor;
+            &:first-child {
+              border-left: $tableTheadPadding solid $tableTheadBgColor;
+            }
+
+            &:last-child {
+              border-right: $tableTheadPadding solid $tableTheadBgColor;
+            }
           }
         }
       }
@@ -52,23 +69,32 @@ $tableCaptionColor: $sbbColorGrey;
 
   tbody {
     > tr {
-      &:nth-child(even) {
-        background-color: $tableTbodyStripesBgColor;
-      }
+      @if $sbbBusiness {
+        background-color: $sbbColorWhite;
+        border-bottom: 1px solid $sbbColorAluminum;
 
-      th,
-      td {
-        padding: $tableTbodyCellPaddingMobile;
+        &:hover {
+          background-color: $sbbColorCloud;
+        }
+      } @else {
+        &:nth-child(even) {
+          background-color: $tableTbodyStripesBgColor;
+        }
 
-        @include mq($from: tabletPortrait) {
-          padding: $tableTbodyCellPadding;
+        th,
+        td {
+          padding: $tableTbodyCellPaddingMobile;
 
-          &:first-child {
-            border-left: $tableTheadPadding solid $tableBg;
-          }
+          @include mq($from: tabletPortrait) {
+            padding: $tableTbodyCellPadding;
 
-          &:last-child {
-            border-right: $tableTheadPadding solid $tableBg;
+            &:first-child {
+              border-left: $tableTheadPadding solid $tableBg;
+            }
+
+            &:last-child {
+              border-right: $tableTheadPadding solid $tableBg;
+            }
           }
         }
       }
@@ -81,6 +107,33 @@ $tableCaptionColor: $sbbColorGrey;
     > tr {
       th,
       td {
+        @if $sbbBusiness {
+          height: pxToEm(36);
+          padding: 0 16px;
+          border-right: 1px solid $sbbColorAluminum;
+          overflow: hidden;
+          text-overflow: ellipsis;
+
+          &:first-of-type {
+            padding-left: 16px;
+            border-left: none;
+
+            [dir='rtl'] & {
+              padding-left: 0;
+              padding-right: 16px;
+            }
+          }
+
+          &:last-of-type {
+            padding-right: 16px;
+            border-right: none;
+
+            [dir='rtl'] & {
+              padding-right: 0;
+              padding-left: 16px;
+            }
+          }
+        }
         &:first-child {
           &::after {
             opacity: 0;

--- a/src/angular-core/styles/typography/_table.scss
+++ b/src/angular-core/styles/typography/_table.scss
@@ -1,5 +1,3 @@
-@import '../common';
-
 $tableBg: $sbbColorWhite;
 $tableTheadBgColor: $sbbColorCloud;
 $tableTbodyStripesBgColor: $sbbColorMilk;
@@ -22,6 +20,7 @@ $tableCaptionColor: $sbbColorGrey;
   background-color: $tableBg;
 
   @if $sbbBusiness {
+    width: 100%;
     border-collapse: collapse;
   } @else {
     padding-bottom: $tableTbodyPadding;

--- a/src/showcase/styles.scss
+++ b/src/showcase/styles.scss
@@ -55,6 +55,7 @@ sbb-business,
     @include sbbSelect();
     @include sbbFieldset();
     @include sbbTimeInputField();
+    @include sbbTable();
   }
 }
 


### PR DESCRIPTION
I extracted the table styling from the business component and merged it with the existing table styles provided in core/typography. The old sbb-* classes now seemed unnecessary as styles are now controlled through standard html directives, so I removed them.
To test, the table provided in the typography documentation should now get styled correctly depending on the selected package (public/business).