### PR TITLE
fix(business): filter null/undefined in table data source

### DIFF
--- a/src/angular-business/table/table/table-data-source.spec.ts
+++ b/src/angular-business/table/table/table-data-source.spec.ts
@@ -98,7 +98,7 @@ describe('SbbTableDataSource', () => {
       ];
 
       params.forEach((param) =>
-        expect(dataTableSource.filterPredicate(testRow, param.filter)).toBe(param.expected)
+        expect(dataTableSource.filterPredicate(testRow, param.filter)).toBe(param.expected, param)
       );
     });
 
@@ -118,11 +118,11 @@ describe('SbbTableDataSource', () => {
         { filter: { colString: '', colNumber: undefined }, expected: true },
         { filter: { colNumber: undefined }, expected: true },
         { filter: { _: '' }, expected: true },
-        { filter: { colNull: 'search' }, expected: true },
+        { filter: { colNull: 'search' }, expected: false },
         { filter: { colNull: null } as any, expected: true },
         { filter: { colString: null } as any, expected: true },
-        { filter: { colUndefined: 'search' }, expected: true },
-        { filter: { colNonexistent: 'search' }, expected: true },
+        { filter: { colUndefined: 'search' }, expected: false },
+        { filter: { colNonexistent: 'search' }, expected: false },
         { filter: { colNumber: 1 }, expected: true },
         { filter: { colString: '  Content  ' }, expected: true },
         { filter: { colString: 'CONTENT' }, expected: true },
@@ -138,7 +138,10 @@ describe('SbbTableDataSource', () => {
       ];
 
       params.forEach((param) =>
-        expect(dataTableSource.filterPredicate(testRowAdvanced, param.filter)).toBe(param.expected)
+        expect(dataTableSource.filterPredicate(testRowAdvanced, param.filter)).toBe(
+          param.expected,
+          param
+        )
       );
     });
 
@@ -160,7 +163,10 @@ describe('SbbTableDataSource', () => {
       ];
 
       params.forEach((param) =>
-        expect(dataTableSource.filterPredicate(dataRowWith0, param.filter)).toBe(param.expected)
+        expect(dataTableSource.filterPredicate(dataRowWith0, param.filter)).toBe(
+          param.expected,
+          param
+        )
       );
     });
 
@@ -181,9 +187,9 @@ describe('SbbTableDataSource', () => {
         { filter: { colNumber: [] }, expected: true },
         { filter: { colNumber: [] }, expected: true },
         { filter: { _: '' }, expected: true },
-        { filter: { colNull: ['search'] }, expected: true },
-        { filter: { colUndefined: ['search'] }, expected: true },
-        { filter: { colNonexistent: ['search'] }, expected: true },
+        { filter: { colNull: ['search'] }, expected: false },
+        { filter: { colUndefined: ['search'] }, expected: false },
+        { filter: { colNonexistent: ['search'] }, expected: false },
         { filter: { colNumber: [1] }, expected: true },
         { filter: { colString: ['  Content  '] }, expected: true },
         { filter: { colString: ['CONTENT'] }, expected: true },
@@ -207,7 +213,10 @@ describe('SbbTableDataSource', () => {
       ];
 
       params.forEach((param) =>
-        expect(dataTableSource.filterPredicate(testRowAdvanced, param.filter)).toBe(param.expected)
+        expect(dataTableSource.filterPredicate(testRowAdvanced, param.filter)).toBe(
+          param.expected,
+          param
+        )
       );
     });
   });

--- a/src/angular-business/table/table/table-data-source.ts
+++ b/src/angular-business/table/table/table-data-source.ts
@@ -413,13 +413,14 @@ export class SbbTableDataSource<
     propertyFilters: { [key: string]: string[] },
     tableData: { [p: string]: any }
   ): boolean {
-    return Object.keys(propertyFilters)
-      .filter((key) => typeof tableData[key] !== 'undefined' && tableData[key] !== null)
-      .every((key) =>
-        propertyFilters[key].some((value) =>
+    return Object.keys(propertyFilters).every((key) =>
+      propertyFilters[key].some(
+        (value) =>
+          typeof tableData[key] !== 'undefined' &&
+          tableData[key] !== null &&
           this._matchesStringCaseInsensitive(`${tableData[key]}`, value)
-        )
-      );
+      )
+    );
   }
 
   /**

--- a/src/showcase/app/business/business-examples/table-examples/BUILD.bazel
+++ b/src/showcase/app/business/business-examples/table-examples/BUILD.bazel
@@ -1,6 +1,7 @@
 load(
     "//tools:defaults.bzl",
     "ng_ts_library",
+    "sass_binary",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -18,6 +19,7 @@ ng_ts_library(
         "table-examples.module.ts",
     ],
     assets = [
+        ":filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.css",
         "filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.html",
         "grouped-columns-table-example/grouped-columns-table-example.component.html",
         "grouped-rows-and-columns-table-example/grouped-rows-and-columns-table-example.component.html",
@@ -49,4 +51,9 @@ filegroup(
         "**/*.scss",
         "**/*.ts",
     ]),
+)
+
+sass_binary(
+    name = "filter_sort_paginator_table_example_filter_sort_paginator_table_example_component_scss",
+    src = "filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.scss",
 )

--- a/src/showcase/app/business/business-examples/table-examples/filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.html
+++ b/src/showcase/app/business/business-examples/table-examples/filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.html
@@ -27,7 +27,7 @@
       </th>
     </ng-container>
     <ng-container sbbColumnDef="filter-category">
-      <th sbbHeaderCell *sbbHeaderCellDef class="sbb-table-filter" style="max-width:0">
+      <th sbbHeaderCell *sbbHeaderCellDef class="sbb-table-filter">
         <sbb-select formControlName="category" multiple>
           <sbb-option *ngFor="let category of categories" [value]="category">{{
             category

--- a/src/showcase/app/business/business-examples/table-examples/filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.html
+++ b/src/showcase/app/business/business-examples/table-examples/filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.html
@@ -27,7 +27,7 @@
       </th>
     </ng-container>
     <ng-container sbbColumnDef="filter-category">
-      <th sbbHeaderCell *sbbHeaderCellDef class="sbb-table-filter">
+      <th sbbHeaderCell *sbbHeaderCellDef class="sbb-table-filter" style="max-width:0">
         <sbb-select formControlName="category" multiple>
           <sbb-option *ngFor="let category of categories" [value]="category">{{
             category

--- a/src/showcase/app/business/business-examples/table-examples/filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.scss
+++ b/src/showcase/app/business/business-examples/table-examples/filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.scss
@@ -1,0 +1,3 @@
+.sbb-column-filter-category {
+  max-width: 0;
+}

--- a/src/showcase/app/business/business-examples/table-examples/filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.ts
+++ b/src/showcase/app/business/business-examples/table-examples/filter-sort-paginator-table-example/filter-sort-paginator-table-example.component.ts
@@ -26,6 +26,7 @@ interface VehicleFilter extends TableFilter {
 
 @Component({
   selector: 'sbb-filter-sort-paginator-table-example',
+  styleUrls: ['./filter-sort-paginator-table-example.component.css'],
   templateUrl: './filter-sort-paginator-table-example.component.html',
 })
 export class FilterSortPaginatorTableExampleComponent implements AfterViewInit, OnDestroy {


### PR DESCRIPTION
This PR will change the behaviour of SbbDataTableSource. Previously when a property was filtered, null and undefined was still included. Now we no longer include these data entries.

Closes #445