### PR TITLE
feat(tabs): allow tabs to be lazy rendered by sbbTabContent directive

### DIFF
--- a/src/angular-public/tabs/BUILD.bazel
+++ b/src/angular-public/tabs/BUILD.bazel
@@ -44,6 +44,7 @@ ng_test_library(
         ":tabs",
         "//src/angular-core/testing",
         "//src/angular-public/badge",
+        "@npm//@angular/cdk",
         "@npm//@angular/platform-browser",
     ],
 )

--- a/src/angular-public/tabs/public-api.ts
+++ b/src/angular-public/tabs/public-api.ts
@@ -1,3 +1,4 @@
 export * from './tabs.module';
 export * from './tab/tab.component';
+export * from './tab/tab-content';
 export * from './tabs/tabs.component';

--- a/src/angular-public/tabs/tab/tab-content.ts
+++ b/src/angular-public/tabs/tab/tab-content.ts
@@ -1,0 +1,10 @@
+import { Directive } from '@angular/core';
+
+/**
+ * Tab content that will be rendered lazily
+ * after the tab is active.
+ */
+@Directive({
+  selector: 'ng-template[sbbTabContent]',
+})
+export class TabContent {}

--- a/src/angular-public/tabs/tab/tab.component.html
+++ b/src/angular-public/tabs/tab/tab.component.html
@@ -1,1 +1,2 @@
 <ng-content *ngIf="active && !disabled"></ng-content>
+<ng-template [cdkPortalOutlet]="_contentPortal"></ng-template>

--- a/src/angular-public/tabs/tabs.md
+++ b/src/angular-public/tabs/tabs.md
@@ -20,3 +20,24 @@ You can use the tab component as seen below
   </sbb-tab>
 </sbb-tabs>
 ```
+
+### Lazy rendering
+
+By default, the tab contents will be initialized even when the tab is closed.
+To instead defer initialization until the tab is open, the content should be provided as an ng-template:
+
+```html
+<sbb-tabs>
+  <sbb-tab label="Tab 1" id="content1-tab" labelId="content1">
+    <ng-template sbbTabContent>
+      <h4>Lazy rendered tab content for tab 1</h4>
+    </ng-template>
+  </sbb-tab>
+
+  <sbb-tab label="Tab 2" id="content2-tab" labelId="content2">
+    <ng-template sbbTabContent>
+      <h4>Lazy rendered tab content for tab 2</h4>
+    </ng-template>
+  </sbb-tab>
+</sbb-tabs>
+```

--- a/src/angular-public/tabs/tabs.module.ts
+++ b/src/angular-public/tabs/tabs.module.ts
@@ -1,13 +1,15 @@
+import { PortalModule } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { BadgeModule } from '@sbb-esta/angular-public/badge';
 
+import { TabContent } from './tab/tab-content';
 import { TabComponent } from './tab/tab.component';
 import { TabsComponent } from './tabs/tabs.component';
 
 @NgModule({
-  imports: [CommonModule, BadgeModule],
-  declarations: [TabComponent, TabsComponent],
-  exports: [TabComponent, TabsComponent],
+  imports: [CommonModule, BadgeModule, PortalModule],
+  declarations: [TabComponent, TabsComponent, TabContent],
+  exports: [TabComponent, TabsComponent, TabContent],
 })
 export class TabsModule {}


### PR DESCRIPTION
Closes #456

Please have a look at the implementation code. If it is okay by you, I will add the necessary documentation for public and business before the merge. I used an implementation similar to the expansion panel and the tabs by Material.