### PR TITLE
build: do not try to remove latest image

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -135,6 +135,4 @@ jobs:
     - name: "Publish: Docker image"
       run: docker push docker.pkg.github.com/sbb-design-systems/sbb-angular/showcase:${{ steps.docker_release_version.outputs.docker_release_version }}
     - name: "Publish: Docker image as latest"
-      run: |
-        docker rmi docker.pkg.github.com/sbb-design-systems/sbb-angular/showcase:latest
-        docker push docker.pkg.github.com/sbb-design-systems/sbb-angular/showcase:latest
+      run: docker push docker.pkg.github.com/sbb-design-systems/sbb-angular/showcase:latest


### PR DESCRIPTION
This only removes the local tag, not the tag in the registry.