### PR TITLE
chore: deprecate @sbb-esta/angular-keycloak

### DIFF
--- a/src/angular-keycloak/README.md
+++ b/src/angular-keycloak/README.md
@@ -1,6 +1,12 @@
 # SBB Keycloak Library for Angular
 
-🛈 We recommend [angular-oauth2-oidc](https://www.npmjs.com/package/angular-oauth2-oidc) to be used for authentication. See the [documentation](https://manfredsteyer.github.io/angular-oauth2-oidc/docs/index.html) for details.
+🛈 We recommend [angular-oauth2-oidc](https://www.npmjs.com/package/angular-oauth2-oidc) to be used for authentication.
+See the [documentation](https://manfredsteyer.github.io/angular-oauth2-oidc/docs/index.html) for details.
+
+# 🛈 Deprecation Notice
+
+The `@sbb-esta/angular-keycloak` package ist deprecated and will be removed with the next major version.
+As mentioned above, we strongly recommend [angular-oauth2-oidc](https://www.npmjs.com/package/angular-oauth2-oidc).
 
 ## Getting started
 

--- a/src/angular-keycloak/src/auth.init.ts
+++ b/src/angular-keycloak/src/auth.init.ts
@@ -8,6 +8,9 @@ import { KeycloakConfig } from './keycloak-config';
 // tslint:disable-next-line: naming-convention
 const Keycloak = Keycloak_;
 
+/**
+ * @deprecated Use the angular-oauth2-oidc package.
+ */
 export function authInit(
   keycloakOptions: KeycloakInitOptions,
   keycloakConfig: string | KeycloakConfig,

--- a/src/angular-keycloak/src/auth.interceptor.ts
+++ b/src/angular-keycloak/src/auth.interceptor.ts
@@ -17,6 +17,9 @@ enum HttpStatusCode {
   FORBIDDEN = 403,
 }
 
+/**
+ * @deprecated Use the angular-oauth2-oidc package.
+ */
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
   constructor(private _authService: AuthService) {}
@@ -34,6 +37,9 @@ export class AuthInterceptor implements HttpInterceptor {
   }
 }
 
+/**
+ * @deprecated Use the angular-oauth2-oidc package.
+ */
 export const AUTH_INTERCEPTOR: ClassProvider = {
   provide: HTTP_INTERCEPTORS,
   useClass: AuthInterceptor,

--- a/src/angular-keycloak/src/auth.module.ts
+++ b/src/angular-keycloak/src/auth.module.ts
@@ -6,6 +6,9 @@ import { AuthService } from './auth.service';
 import { KEYCLOAK_CONFIG, KEYCLOAK_LOGIN_OPTIONS, KEYCLOAK_OPTIONS } from './auth.tokens';
 import { KeycloakConfig } from './keycloak-config';
 
+/**
+ * @deprecated Use the angular-oauth2-oidc package.
+ */
 @NgModule()
 export class AuthModule {
   /**
@@ -14,6 +17,7 @@ export class AuthModule {
    * @param options An options object. Defaults to { onLoad: 'check-sso', flow: 'implicit' }.
    * @param loginOptions An object for login options. Defaults to { idpHint: 'azure_sbb_prod' }.
    *  To avoid configuring an idpHint, provide an object with no idpHint key.
+   * @deprecated Use the angular-oauth2-oidc package.
    */
   static forRoot(
     config: string | KeycloakConfig,

--- a/src/angular-keycloak/src/auth.service.ts
+++ b/src/angular-keycloak/src/auth.service.ts
@@ -5,6 +5,9 @@ import { from, Observable, of } from 'rxjs';
 
 import { KEYCLOAK_LOGIN_OPTIONS } from './auth.tokens';
 
+/**
+ * @deprecated Use the angular-oauth2-oidc package.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/src/angular-keycloak/src/auth.tokens.ts
+++ b/src/angular-keycloak/src/auth.tokens.ts
@@ -3,8 +3,19 @@ import { KeycloakInitOptions } from 'keycloak-js';
 
 import { KeycloakConfig } from './keycloak-config';
 
+/**
+ * @deprecated Use the angular-oauth2-oidc package.
+ */
 export const KEYCLOAK_OPTIONS = new InjectionToken<KeycloakInitOptions>('keycloak.options');
+
+/**
+ * @deprecated Use the angular-oauth2-oidc package.
+ */
 export const KEYCLOAK_LOGIN_OPTIONS = new InjectionToken<string | KeycloakConfig>(
   'keycloak.loginOptions'
 );
+
+/**
+ * @deprecated Use the angular-oauth2-oidc package.
+ */
 export const KEYCLOAK_CONFIG = new InjectionToken<string | KeycloakConfig>('keycloak.config');

--- a/src/angular-keycloak/src/keycloak-config.ts
+++ b/src/angular-keycloak/src/keycloak-config.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Use the angular-oauth2-oidc package.
+ */
 export interface KeycloakConfig {
   url?: string;
   realm?: string;

--- a/src/showcase/app/app.component.html
+++ b/src/showcase/app/app.component.html
@@ -18,7 +18,7 @@
       >@sbb-esta/angular-icons</a
     >
     <a sbbHeaderMenuItem routerLink="/keycloak" routerLinkActive="sbb-active"
-      >@sbb-esta/angular-keycloak</a
+      >@sbb-esta/angular-keycloak (deprecated)</a
     >
     <a sbbHeaderMenuItem routerLink="/maps" routerLinkActive="sbb-active">@sbb-esta/angular-maps</a>
   </sbb-header-menu>

--- a/src/showcase/app/introduction/introduction.component.html
+++ b/src/showcase/app/introduction/introduction.component.html
@@ -71,7 +71,9 @@
           <img alt="@sbb-esta/angular-keycloak" src="assets/keycloak.jpg" />
         </div>
         <span class="title">@sbb-esta/angular-keycloak</span>
-        <span class="text">Authentication module for use with keycloak (sso.sbb.ch).</span>
+        <span class="text"
+          ><b>Deprecated</b> Authentication module for use with keycloak (sso.sbb.ch).</span
+        >
       </a>
     </li>
     <li>


### PR DESCRIPTION
This deprecates the @sbb-esta/angular-keycloak package. We stronlgy recommend using angular-oauth2-oidc instead.