### PR TITLE
docs(maps): add detailed CORS support explanation

### DIFF
--- a/src/angular-maps/esri-config/esri-standard-values.const.ts
+++ b/src/angular-maps/esri-config/esri-standard-values.const.ts
@@ -3,8 +3,6 @@ export class EsriConfigConsts {
     'geo-dev.sbb.ch',
     'geo-int.sbb.ch',
     'geo.sbb.ch',
-    'i89765.sbb.ch:5443',
-    'dfamobile.sbb.ch',
     'wms.geo.admin.ch',
   ];
 

--- a/src/angular-maps/getting-started.md
+++ b/src/angular-maps/getting-started.md
@@ -40,7 +40,7 @@ yarn add @types/arcgis-js-api esri-loader @sbb-esta/angular-maps
 
 ### Step 2: Configure the library
 
-Once the `@sbb-esta/angular-maps` package is installed, you are able to configure your application, in order to use a specific portal (by default the ArcGIS online portal is used), a different [ArcGIS Javascript API Version](https://developers.arcgis.com/javascript/latest/guide/get-api/) or some other settings.
+Once the `@sbb-esta/angular-maps` package is installed, you are able to configure your application, in order to use a specific portal (by default the ArcGIS online portal is used), a different version of [ArcGIS API for Javascript](https://developers.arcgis.com/javascript/latest/guide/get-api/) or some other settings.
 
 ```ts
 import { EsriConfigModule } from '@sbb-esta/angular-maps';
@@ -48,6 +48,25 @@ import { EsriConfigModule } from '@sbb-esta/angular-maps';
 @NgModule({
   ...
   imports: [EsriConfigModule.forRoot({ portalUrl: 'https://www.arcgis.com' })],
+  ...
+})
+export class TrainChooChooAppModule { }
+```
+
+The ArcGIS API for Javascript allows for cross origin requests made to associated servers to include credentials such as cookies and authorization headers. This is indicated by a list of named so called _trustedServers_ (see [documentation](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#request)). When using the SBB Geoportal, it's currently also required to add the same host names to the list of _originsWithCredentialsRequired_. Whenever a request is made to a server listed in _originsWithCredentialsRequired_ it is being intercepted (using _interceptors_ as [described](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#request)) and the [_withCredentials_ header](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) is set. [Read more on how the ArcGIS API for Javascript handles CORS](https://developers.arcgis.com/javascript/latest/guide/cors/index.html).
+
+Allowing a quick start in the SBB environment, the following hosts are preconfigured as _trustedServers_ and _originsWithCredentialsRequired_ in `@sbb-esta/angular-maps` by default: _geo-dev.sbb.ch_, _geo-int.sbb.ch_ and _geo.sbb.ch_. Additionally _wms.geo.admin.ch_ is preconfigured in _trustedServers_, too.
+
+```ts
+import { EsriConfigModule } from '@sbb-esta/angular-maps';
+
+@NgModule({
+  ...
+  imports: [EsriConfigModule.forRoot({
+      portalUrl: 'https://geo-dev.sbb.ch/portal',
+      trustedServers: ['geo-dev.sbb.ch'],
+      originsWithCredentialsRequired: ['geo-dev.sbb.ch']
+    })],
   ...
 })
 export class TrainChooChooAppModule { }


### PR DESCRIPTION
Add missing explanation of trustedServers and originsWithCredentialsRequired configuration options, cleaned up default CORS servers.