### PR TITLE
test: mark warnings or errors from console as failure

### DIFF
--- a/src/angular-public/ghettobox/ghettobox-container/ghettobox-container.component.spec.ts
+++ b/src/angular-public/ghettobox/ghettobox-container/ghettobox-container.component.spec.ts
@@ -6,7 +6,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { LinkGeneratorResult } from '@sbb-esta/angular-core/models';
 import { IconArrowRightModule } from '@sbb-esta/angular-icons/arrow';
-import { IconHimInfoModule } from '@sbb-esta/angular-icons/him-cus';
+import { IconHimInfoModule, IconHimReplacementbusModule } from '@sbb-esta/angular-icons/him-cus';
 import { IconCrossModule } from '@sbb-esta/angular-icons/navigation';
 
 import { Ghettobox } from '../ghettobox/ghettobox-ref';
@@ -56,6 +56,7 @@ describe('GhettoboxContainerComponent', () => {
         IconCrossModule,
         IconArrowRightModule,
         IconHimInfoModule,
+        IconHimReplacementbusModule,
         NoopAnimationsModule,
         PortalModule,
       ],

--- a/src/angular-public/ghettobox/ghettobox/ghettobox.component.spec.ts
+++ b/src/angular-public/ghettobox/ghettobox/ghettobox.component.spec.ts
@@ -5,7 +5,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IconDirectiveModule } from '@sbb-esta/angular-core/icon-directive';
 import { IconArrowRightModule } from '@sbb-esta/angular-icons/arrow';
-import { IconHimInfoModule } from '@sbb-esta/angular-icons/him-cus';
+import { IconHimDisruptionModule, IconHimInfoModule } from '@sbb-esta/angular-icons/him-cus';
 import { IconCrossModule } from '@sbb-esta/angular-icons/navigation';
 
 import { GhettoboxComponent } from './ghettobox.component';
@@ -44,6 +44,7 @@ describe('GhettoboxComponent', () => {
         IconCrossModule,
         IconArrowRightModule,
         IconHimInfoModule,
+        IconHimDisruptionModule,
         IconDirectiveModule,
       ],
       declarations: [GhettoboxTestComponent, GhettoboxComponent],

--- a/src/angular-public/links/social-link/social-link.component.spec.ts
+++ b/src/angular-public/links/social-link/social-link.component.spec.ts
@@ -4,11 +4,9 @@ import { By } from '@angular/platform-browser';
 
 import { LinksModule } from '../links.module';
 
-import { SocialLinkComponent } from './social-link.component';
-
 @Component({
   selector: 'sbb-test-social-link',
-  template: ` <a sbbSocialLink [mode]="mode" [icon]="icon">test</a> `,
+  template: ` <a sbbSocialLink [icon]="icon">test</a> `,
 })
 class TestSocialLinkComponent {
   icon: 'facebook' | 'instagram' | 'linkedin' | 'pinterest' | 'twitter' | 'xing' | 'youtube';


### PR DESCRIPTION
Ivy currently only outputs certain errors to the console. This patch fixes this by
catching the errors on the console and throwing them as an error.