### PR TITLE
fix(timeinput): fix height for 4k and 5k screens/breakpoints

### DIFF
--- a/src/angular-core/styles/typography/_form.scss
+++ b/src/angular-core/styles/typography/_form.scss
@@ -47,12 +47,12 @@
 
     @include mq($from: desktop4k) {
       width: toPx($timeInputWidth * $scalingFactor4k);
-      height: toPx($timeInputWidth * $scalingFactor4k);
+      height: toPx($timeInputHeight * $scalingFactor4k);
     }
 
     @include mq($from: desktop5k) {
       width: toPx($timeInputWidth * $scalingFactor5k);
-      height: toPx($timeInputWidth * $scalingFactor5k);
+      height: toPx($timeInputHeight * $scalingFactor5k);
     }
   }
 


### PR DESCRIPTION
Align height of timeinput with other inputs on large screens.
Before the height was too large.

closes #587