### PR TITLE
feat(stackblitz): allow opening examples in new Stackblitz project

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,4 @@ CONTRIBUTING.md
 *.bazel
 *.bzl
 WORKSPACE
+src/showcase/assets/stackblitz/*

--- a/src/showcase/app/business/BUILD.bazel
+++ b/src/showcase/app/business/BUILD.bazel
@@ -22,6 +22,7 @@ ng_module(
         "//src/angular-business/accordion",
         "//src/angular-business/sidebar",
         "//src/angular-business/tabs",
+        "//src/angular-core/icon",
         "//src/showcase/app/business/business-examples",
         "//src/showcase/app/shared",
         "//src/showcase/app/shared/component-viewer",

--- a/src/showcase/app/business/business-example-viewer/business-example-viewer.component.html
+++ b/src/showcase/app/business/business-example-viewer/business-example-viewer.component.html
@@ -13,6 +13,18 @@
       ></path>
     </svg>
   </button>
+
+  <button
+    type="button"
+    class="stackblitz-button"
+    (click)="openStackblitz()"
+    [disabled]="isStackblitzDisabled"
+    [attr.aria-label]="
+      isStackblitzDisabled ? 'Building StackBlitz example...' : 'Edit this example in StackBlitz'
+    "
+  >
+    <sbb-icon svgIcon="kom:link-external-small"></sbb-icon>
+  </button>
 </div>
 
 <sbb-tabs [hidden]="!showSource" class="sbbsc-tabs">

--- a/src/showcase/app/business/business-example-viewer/business-example-viewer.component.scss
+++ b/src/showcase/app/business/business-example-viewer/business-example-viewer.component.scss
@@ -30,6 +30,10 @@
         height: 24px;
         width: 24px;
       }
+
+      &.stackblitz-button {
+        margin-left: 0.5rem;
+      }
     }
   }
 }

--- a/src/showcase/app/business/business.module.ts
+++ b/src/showcase/app/business/business.module.ts
@@ -4,7 +4,9 @@ import { NgModule } from '@angular/core';
 import { SbbAccordionModule } from '@sbb-esta/angular-business/accordion';
 import { SbbSidebarModule } from '@sbb-esta/angular-business/sidebar';
 import { SbbTabsModule } from '@sbb-esta/angular-business/tabs';
+import { SbbIconModule } from '@sbb-esta/angular-core/icon';
 
+import { StackblitzWriterService } from '../shared/component-viewer/stackblitz-writer/stackblitz-writer.service';
 import { SharedModule } from '../shared/shared.module';
 
 import { BusinessComponentViewerComponent } from './business-component-viewer/business-component-viewer.component';
@@ -19,6 +21,7 @@ import { BusinessComponent } from './business/business.component';
     BusinessComponentViewerComponent,
     BusinessExampleViewerComponent,
   ],
+  providers: [StackblitzWriterService],
   imports: [
     CommonModule,
     PortalModule,
@@ -28,6 +31,7 @@ import { BusinessComponent } from './business/business.component';
     BusinessRoutingModule,
     SbbSidebarModule,
     SbbAccordionModule,
+    SbbIconModule,
   ],
 })
 export class BusinessModule {}

--- a/src/showcase/app/shared/component-viewer/BUILD.bazel
+++ b/src/showcase/app/shared/component-viewer/BUILD.bazel
@@ -18,6 +18,7 @@ ng_module(
     ] + glob(["**/*.html"]),
     tsconfig = "//src/showcase:tsconfig.json",
     deps = [
+        "//src/angular-core/icon",
         "//src/angular-public/tabs",
         "//src/showcase/app/shared",
         "@npm//@angular/cdk",

--- a/src/showcase/app/shared/component-viewer/component-viewer.module.ts
+++ b/src/showcase/app/shared/component-viewer/component-viewer.module.ts
@@ -1,13 +1,16 @@
 import { PortalModule } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { SbbIconModule } from '@sbb-esta/angular-core/icon';
 import { SbbTabsModule } from '@sbb-esta/angular-public/tabs';
 
 import { ComponentViewerComponent } from './component-viewer/component-viewer.component';
 import { ExampleViewerComponent } from './example-viewer/example-viewer.component';
+import { StackblitzWriterService } from './stackblitz-writer/stackblitz-writer.service';
 
 @NgModule({
   declarations: [ExampleViewerComponent, ComponentViewerComponent],
-  imports: [CommonModule, PortalModule, SbbTabsModule],
+  providers: [StackblitzWriterService],
+  imports: [CommonModule, PortalModule, SbbIconModule, SbbTabsModule],
 })
 export class ComponentViewerModule {}

--- a/src/showcase/app/shared/component-viewer/example-viewer/example-viewer.component.html
+++ b/src/showcase/app/shared/component-viewer/example-viewer/example-viewer.component.html
@@ -1,6 +1,6 @@
 <div>
   <h3>{{ label }}</h3>
-  <button type="button" (click)="showSource = !showSource">
+  <button type="button" (click)="showSource = !showSource" aria-label="View source">
     <svg
       focusable="false"
       preserveAspectRatio="xMidYMid meet"
@@ -12,6 +12,18 @@
         d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
       ></path>
     </svg>
+  </button>
+
+  <button
+    type="button"
+    class="stackblitz-button"
+    (click)="openStackblitz()"
+    [disabled]="isStackblitzDisabled"
+    [attr.aria-label]="
+      isStackblitzDisabled ? 'Building StackBlitz example...' : 'Edit this example in StackBlitz'
+    "
+  >
+    <sbb-icon svgIcon="kom:link-external-small"></sbb-icon>
   </button>
 </div>
 

--- a/src/showcase/app/shared/component-viewer/example-viewer/example-viewer.component.scss
+++ b/src/showcase/app/shared/component-viewer/example-viewer/example-viewer.component.scss
@@ -27,6 +27,10 @@
         height: 24px;
         width: 24px;
       }
+
+      &.stackblitz-button {
+        margin-left: 0.5rem;
+      }
     }
   }
 }

--- a/src/showcase/app/shared/component-viewer/example-viewer/example-viewer.component.ts
+++ b/src/showcase/app/shared/component-viewer/example-viewer/example-viewer.component.ts
@@ -1,10 +1,14 @@
 import { ComponentPortal } from '@angular/cdk/portal';
 import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { combineLatest, Observable } from 'rxjs';
+import { combineLatest, Observable, zip } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { HtmlLoader } from '../../html-loader.service';
+import {
+  ExampleData,
+  StackblitzWriterService,
+} from '../stackblitz-writer/stackblitz-writer.service';
 
 @Component({
   selector: 'sbb-example-viewer',
@@ -19,6 +23,10 @@ export class ExampleViewerComponent implements OnInit {
   scss: Observable<string>;
   showSource = false;
   title: Observable<string>;
+
+  isStackblitzDisabled = true;
+  stackBlitzForm: HTMLFormElement;
+
   get label() {
     return this.name
       .replace(/-/g, ' ')
@@ -26,7 +34,18 @@ export class ExampleViewerComponent implements OnInit {
       .replace(' Showcase', '');
   }
 
-  constructor(private _htmlLoader: HtmlLoader, private _route: ActivatedRoute) {}
+  get componentName() {
+    return this.name
+      .replace(/(^[a-z]|-[a-z])/g, (m) => m.toUpperCase())
+      .replace(/-/g, '')
+      .concat('Component');
+  }
+
+  constructor(
+    private _htmlLoader: HtmlLoader,
+    private _route: ActivatedRoute,
+    private _stackBlitzWriter: StackblitzWriterService
+  ) {}
 
   ngOnInit(): void {
     this.title = combineLatest([this._route.params, this._route.data]).pipe(
@@ -43,5 +62,43 @@ export class ExampleViewerComponent implements OnInit {
     this.ts = this._htmlLoader.with(this._route).fromExamples(this.name, 'ts').observe();
 
     this.scss = this._htmlLoader.with(this._route).fromExamples(this.name, 'scss').observe();
+
+    const exampleContents = ['ts', 'html', 'scss'].map((type: 'ts' | 'html' | 'scss') =>
+      this._htmlLoader
+        .with(this._route)
+        .fromSourceExamples(this.name, type)
+        .observe()
+        .pipe(map((content) => ({ name: `${this.name}.${type}`, content })))
+    );
+    zip(...exampleContents).subscribe((results) =>
+      this._createStackblitzForm(results.filter((result) => !!result.content))
+    );
+  }
+
+  private _createStackblitzForm(files: { name: string; content: string }[]) {
+    const example = new ExampleData({
+      componentName: this.componentName,
+      selectorName: `${this.name}`,
+      description: this.label,
+      indexFilename: files[0].name,
+      exampleFiles: files,
+      business: this._route.snapshot.data.library === 'business',
+    });
+    this._stackBlitzWriter
+      .constructStackBlitzForm(example)
+      .then((stackBlitzForm: HTMLFormElement) => {
+        this.stackBlitzForm = stackBlitzForm;
+        this.isStackblitzDisabled = false;
+      });
+  }
+
+  openStackblitz() {
+    // When the form is submitted, it must be in the document body. The standard of forms is not
+    // to submit if it is detached from the document. See the following chromium commit for
+    // more details:
+    // https://chromium.googlesource.com/chromium/src/+/962c2a22ddc474255c776aefc7abeba00edc7470%5E!
+    document.body.appendChild(this.stackBlitzForm);
+    this.stackBlitzForm.submit();
+    document.body.removeChild(this.stackBlitzForm);
   }
 }

--- a/src/showcase/app/shared/component-viewer/stackblitz-writer/stackblitz-writer.service.ts
+++ b/src/showcase/app/shared/component-viewer/stackblitz-writer/stackblitz-writer.service.ts
@@ -1,0 +1,218 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+export class ExampleData {
+  indexFilename: string;
+  description: string;
+  selectorName: string;
+  componentName: string;
+  exampleFiles: { name: string; content: string }[];
+  business: boolean;
+
+  constructor(data: { [P in keyof ExampleData]: ExampleData[P] }) {
+    this.indexFilename = data.indexFilename;
+    this.description = data.description;
+    this.selectorName = data.selectorName;
+    this.componentName = data.componentName;
+    this.exampleFiles = data.exampleFiles;
+    this.business = data.business;
+  }
+}
+
+const STACKBLITZ_URL = 'https://run.stackblitz.com/api/angular/v1';
+
+/**
+ * Path that refers to the docs-content from the "@angular/components-examples" package.
+ */
+const CONTENT_PATH = 'assets/docs-content/examples-source/';
+
+/**
+ * Path that refers to the generic project template files.
+ */
+const TEMPLATE_PATH = 'assets/stackblitz/';
+
+/**
+ * Filenames of the generic project template files.
+ */
+const TEMPLATE_FILES = [
+  'angular.json',
+  'tsconfig.json',
+  'src/main.ts',
+  'src/polyfills.ts',
+  'src/styles.css',
+  'src/app/app.module.ts',
+];
+
+/**
+ * Stackblitz tags
+ */
+const TAGS: string[] = ['sbb', 'angular', 'example'];
+
+/**
+ * Dependencies for the Stackblitz project
+ * '*': latest version
+ */
+const dependencies = {
+  '@angular/animations': '*',
+  '@angular/cdk': '*',
+  '@angular/common': '*',
+  '@angular/compiler': '*',
+  '@angular/core': '*',
+  '@angular/forms': '*',
+  '@angular/platform-browser': '*',
+  '@angular/platform-browser-dynamic': '*',
+  '@angular/router': '*',
+  '@sbb-esta/angular-core': '*',
+  '@sbb-esta/angular-icons': '*',
+  '@sbb-esta/angular-public': '*',
+  '@sbb-esta/angular-business': '*',
+  'core-js': '2.6.9',
+  rxjs: '>=6.5.5 <7.0.0',
+  tslib: '*',
+  'zone.js': '~0.10.3',
+};
+
+/**
+ * StackBlitz writer, write example files to StackBlitz.
+ *
+ * StackBlitz API
+ * URL: https://run.stackblitz.com/api/aio/v1/
+ * data: {
+ *   // File name, directory and content of files
+ *   files[file-name1]: file-content1,
+ *   files[directory-name/file-name2]: file-content2,
+ *   // Can add multiple tags
+ *   tags[0]: tag-0,
+ *   // Description of StackBlitz
+ *   description: description,
+ *   // Private or not
+ *   private: true
+ *  // Dependencies
+ *  dependencies: dependencies
+ * }
+ */
+@Injectable()
+export class StackblitzWriterService {
+  constructor(private _http: HttpClient) {}
+
+  /**
+   * Returns an HTMLFormElement that will open a new StackBlitz template with the example data when
+   * called with submit().
+   */
+  constructStackBlitzForm(data: ExampleData): Promise<HTMLFormElement> {
+    const form = this._createFormElement(data.indexFilename);
+
+    TAGS.forEach((tag, i) => this._appendFormInput(form, `tags[${i}]`, tag));
+    this._appendFormInput(form, 'private', 'true');
+    this._appendFormInput(form, 'description', data.description);
+    this._appendFormInput(form, 'dependencies', JSON.stringify(dependencies));
+
+    const moduleFile = data.business
+      ? 'src/app/sbb-business.module.ts'
+      : 'src/app/sbb-public.module.ts';
+
+    this._addFileToForm(
+      form,
+      data,
+      `<sbb-${data.selectorName}>loading</sbb-${data.selectorName}>`,
+      'src/index.html',
+      '',
+      false
+    );
+
+    return Promise.all(
+      TEMPLATE_FILES.map((file) =>
+        this._readFile(file, TEMPLATE_PATH)
+          .toPromise()
+          .then((response: string) => {
+            if (file.includes('app.module.ts')) {
+              // add currently selected component to declarations and bootstrap it
+              response = response
+                .replace(/\{componentName\}/g, data.componentName)
+                .replace(/\{selectorName\}/g, data.selectorName)
+                .replace(
+                  /\{moduleName\}/g,
+                  data.business ? 'sbb-business.module' : 'sbb-public.module'
+                );
+            }
+            this._addFileToForm(form, data, response, file, TEMPLATE_PATH, false);
+          })
+      ).concat(
+        this._readFile(moduleFile, TEMPLATE_PATH)
+          .toPromise()
+          .then((response: string) => {
+            response = response.replace(
+              /\{packageName\}/g,
+              data.business ? '@sbb-esta/angular-business' : '@sbb-esta/angular-public'
+            );
+            this._addFileToForm(form, data, response, moduleFile, TEMPLATE_PATH, false);
+          })
+      )
+    ).then(() => {
+      // remove ".component" filename section from html template URL
+      data.exampleFiles.forEach((file) => {
+        if (file.name.includes('.ts')) {
+          file.content = file.content.replace('component.html', 'html');
+          file.content = file.content.replace('component.css', 'scss');
+        }
+      });
+
+      data.exampleFiles.forEach((file) =>
+        this._addFileToForm(form, data, file.content, file.name, CONTENT_PATH)
+      );
+
+      return form;
+    });
+  }
+
+  /** Constructs a new form element that will navigate to the StackBlitz url. */
+  _createFormElement(indexFile: string): HTMLFormElement {
+    const form = document.createElement('form');
+    form.action = `${STACKBLITZ_URL}?file=src%2Fapp%2F${indexFile}`;
+    form.method = 'post';
+    form.target = '_blank';
+    return form;
+  }
+
+  /** Appends the name and value as an input to the form. */
+  _appendFormInput(form: HTMLFormElement, name: string, value: string): void {
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+
+  /**
+   * Reads the file and returns it as an Observable
+   * @param filename file name of the example
+   * @param path path to the src
+   */
+  _readFile(filename: string, path: string): Observable<any> {
+    return this._http.get(path + filename, { responseType: 'text' });
+  }
+
+  /**
+   * Adds the file text to the form.
+   * @param form the html form you are appending to
+   * @param data example metadata about the example
+   * @param content file contents
+   * @param filename file name of the example
+   * @param path path to the src
+   * @param prependApp whether to prepend the 'src/app' prefix to the path
+   */
+  _addFileToForm(
+    form: HTMLFormElement,
+    data: ExampleData,
+    content: string,
+    filename: string,
+    path: string,
+    prependApp = true
+  ) {
+    if (prependApp) {
+      filename = 'src/app/' + filename;
+    }
+    this._appendFormInput(form, `files[${filename}]`, content);
+  }
+}

--- a/src/showcase/app/shared/loader-builder.ts
+++ b/src/showcase/app/shared/loader-builder.ts
@@ -32,6 +32,13 @@ export class LoaderBuilder {
     );
   }
 
+  fromSourceExamples(example: string, type: 'html' | 'ts' | 'scss') {
+    return this.from(
+      (library, id) =>
+        `assets/docs-content/examples-source/app/${library}/${library}-examples/${id}-examples/${example}/${example}.component.${type}`
+    );
+  }
+
   observe(): Observable<string> {
     return combineLatest([this._route.params, this._route.data]).pipe(
       map(([p, d]) => ({ ...p, ...d })),

--- a/src/showcase/assets/BUILD.bazel
+++ b/src/showcase/assets/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//src/angular-business:config.bzl", "BUSINESS_ENTRYPOINTS")
+load("//src/angular-public:config.bzl", "PUBLIC_ENTRYPOINTS")
 load("//tools/package-docs-content:index.bzl", "package_docs_content")
 
 package(default_visibility = ["//visibility:public"])
@@ -10,7 +12,15 @@ filegroup(
         "**/*.jpg",
         "**/*.ico",
         "**/*.html",
-    ]) + [":docs-content"],
+        "**/*.json",
+        "**/*.ts",
+        "**/*.css",
+        "**/*.ts",
+    ]) + [
+        ":docs-content",
+        ":stackblitz/src/app/sbb-public.module.ts",
+        ":stackblitz/src/app/sbb-business.module.ts",
+    ],
     data = [":docs-content"],
 )
 
@@ -37,4 +47,32 @@ package_docs_content(
         "//src:api-docs": "",
     },
     tags = ["docs-package"],
+)
+
+genrule(
+    name = "sbb_module_public",
+    outs = ["stackblitz/src/app/sbb-public.module.ts"],
+    cmd = """
+      # Run the bazel entry-point for generating the sbb modules
+      # for the examples on StackBlitz info.
+      ./$(execpath //tools/stackblitz-module-template:bazel-bin) \
+          "$(execpath stackblitz/src/app/sbb-public.module.ts)" \
+          %s
+    """ % " ".join(PUBLIC_ENTRYPOINTS),
+    output_to_bindir = True,
+    tools = ["//tools/stackblitz-module-template:bazel-bin"],
+)
+
+genrule(
+    name = "sbb_module_business",
+    outs = ["stackblitz/src/app/sbb-business.module.ts"],
+    cmd = """
+      # Run the bazel entry-point for generating the sbb modules
+      # for the examples on StackBlitz info.
+      ./$(execpath //tools/stackblitz-module-template:bazel-bin) \
+          "$(execpath stackblitz/src/app/sbb-business.module.ts)" \
+          %s
+    """ % " ".join(BUSINESS_ENTRYPOINTS),
+    output_to_bindir = True,
+    tools = ["//tools/stackblitz-module-template:bazel-bin"],
 )

--- a/src/showcase/assets/stackblitz/angular.json
+++ b/src/showcase/assets/stackblitz/angular.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "demo": {
+      "root": "",
+      "sourceRoot": "src",
+      "projectType": "application",
+      "prefix": "app",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/demo",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "src/tsconfig.app.json",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.css",
+              "node_modules/@sbb-esta/angular-public/typography.css"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "demo:build"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "demo:build:production"
+            }
+          }
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "demo:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "src/tsconfig.spec.json",
+            "karmaConfig": "src/karma.conf.js",
+            "styles": [
+              "styles.css"
+            ],
+            "scripts": [],
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ]
+          }
+        },
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "src/tsconfig.app.json",
+              "src/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "demo"
+}

--- a/src/showcase/assets/stackblitz/src/app/app.module.ts
+++ b/src/showcase/assets/stackblitz/src/app/app.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { SbbModule } from './{moduleName}';
+import { {componentName} } from './{selectorName}';
+
+@NgModule({
+  imports:      [ BrowserModule, BrowserAnimationsModule, FormsModule, ReactiveFormsModule, SbbModule ],
+  declarations: [ {componentName} ],
+  bootstrap:    [ {componentName} ],
+})
+export class AppModule { }

--- a/src/showcase/assets/stackblitz/src/index.html
+++ b/src/showcase/assets/stackblitz/src/index.html
@@ -1,0 +1,1 @@
+<my-app>loading</my-app>

--- a/src/showcase/assets/stackblitz/src/main.ts
+++ b/src/showcase/assets/stackblitz/src/main.ts
@@ -1,0 +1,17 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app/app.module';
+import './polyfills';
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .then((ref) => {
+    // Ensure Angular destroys itself on hot reloads.
+    if (window['ngRef']) {
+      window['ngRef'].destroy();
+    }
+    window['ngRef'] = ref;
+
+    // Otherwise, log the boot error
+  })
+  .catch((err) => console.error(err));

--- a/src/showcase/assets/stackblitz/src/polyfills.ts
+++ b/src/showcase/assets/stackblitz/src/polyfills.ts
@@ -1,0 +1,60 @@
+/**
+ * This file includes polyfills needed by Angular and is loaded before the app.
+ * You can add your own extra polyfills to this file.
+ *
+ * This file is divided into 2 sections:
+ *   1. Browser polyfills. These are applied before loading ZoneJS and are sorted by browsers.
+ *   2. Application imports. Files imported after ZoneJS that should be loaded before your main
+ *      file.
+ *
+ * The current setup is for so-called "evergreen" browsers; the last versions of browsers that
+ * automatically update themselves. This includes Safari >= 10, Chrome >= 55 (including Opera),
+ * Edge >= 13 on the desktop, and iOS 10 and Chrome on mobile.
+ *
+ * Learn more in https://angular.io/docs/ts/latest/guide/browser-support.html
+ */
+
+/***************************************************************************************************
+ * BROWSER POLYFILLS
+ */
+
+/** IE9, IE10 and IE11 requires all of the following polyfills. **/
+// import 'core-js/es6/symbol';
+// import 'core-js/es6/object';
+// import 'core-js/es6/function';
+// import 'core-js/es6/parse-int';
+// import 'core-js/es6/parse-float';
+// import 'core-js/es6/number';
+// import 'core-js/es6/math';
+// import 'core-js/es6/string';
+// import 'core-js/es6/date';
+// import 'core-js/es6/array';
+// import 'core-js/es6/regexp';
+// import 'core-js/es6/map';
+// import 'core-js/es6/set';
+
+/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+// import 'classlist.js';  // Run `npm install --save classlist.js`.
+
+/** IE10 and IE11 requires the following to support `@angular/animation`. */
+// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
+
+/** Evergreen browsers require these. **/
+import 'core-js/es6/reflect';
+import 'core-js/es7/reflect';
+/** ALL Firefox browsers require the following to support `@angular/animation`. **/
+// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
+/***************************************************************************************************
+ * Zone JS is required by Angular itself.
+ */
+import 'zone.js/dist/zone'; // Included with Angular CLI.
+
+/***************************************************************************************************
+ * APPLICATION IMPORTS
+ */
+
+/**
+ * Date, currency, decimal and percent pipes.
+ * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
+ */
+// import 'intl';  // Run `npm install --save intl`.

--- a/src/showcase/assets/stackblitz/src/styles.css
+++ b/src/showcase/assets/stackblitz/src/styles.css
@@ -1,0 +1,1 @@
+/* Add application styles & imports to this file! */

--- a/src/showcase/assets/stackblitz/tsconfig.json
+++ b/src/showcase/assets/stackblitz/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2015",
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "lib": [
+      "es2018",
+      "dom"
+    ]
+  },
+  "angularCompilerOptions": {
+    "enableIvy": false,
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true
+  }
+}

--- a/tools/stackblitz-module-template/BUILD.bazel
+++ b/tools/stackblitz-module-template/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "stackblitz-module-template-lib",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["sbb-module.template.ts"],
+    ),
+    tsconfig = ":tsconfig.json",
+    deps = [
+        "@npm//@types/node",
+    ],
+)
+
+nodejs_binary(
+    name = "bazel-bin",
+    data = [
+        ":stackblitz-module-template-lib",
+    ],
+    entry_point = ":bazel-bin.ts",
+)

--- a/tools/stackblitz-module-template/bazel-bin.ts
+++ b/tools/stackblitz-module-template/bazel-bin.ts
@@ -1,0 +1,26 @@
+import { writeFileSync } from 'fs';
+
+if (require.main === module) {
+  const [targetPath, ...modules] = process.argv.slice(2);
+  const template = `import { NgModule } from '@angular/core';
+${modules.map((m) => `import { ${toModuleName(m)} } from '{packageName}/${m}';`).join('\n')}
+import { SbbIconModule, SBB_ICON_REGISTRY_PROVIDER } from '@sbb-esta/angular-core/icon';
+
+const modules = [
+  SbbIconModule,
+  ${modules.map(toModuleName).join(',\n  ')},
+];
+
+@NgModule({
+  imports: modules,
+  exports: modules,
+  providers: [SBB_ICON_REGISTRY_PROVIDER],
+})
+export class SbbModule {}
+`;
+  writeFileSync(targetPath, template, 'utf8');
+}
+
+function toModuleName(moduleName: string) {
+  return `Sbb${moduleName.replace(/(^\w|-\w)/g, (m) => m.replace(/-/, '').toUpperCase())}Module`;
+}

--- a/tools/stackblitz-module-template/tsconfig.json
+++ b/tools/stackblitz-module-template/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es5",
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "bazelOptions": {
+    "suppressTsconfigOverrideWarnings": true
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
     "node_modules/tslint-consistent-codestyle/rules"
   ],
   "linterOptions": {
-    "exclude": ["tools/dgeni/**/*.ts"]
+    "exclude": ["tools/dgeni/**/*.ts", "src/showcase/assets/stackblitz/**/*.ts"]
   },
   "rules": {
     "arrow-return-shorthand": true,


### PR DESCRIPTION
@kyubisation this is an initial draft of what the implementation of the Stackblitz example opener could look like. Before trying to tidy up the rough cut I'd like to get your opinion, especially on the following points:

- Most differences between this implementation and the Material Stackblitz opener lie in the StackblitzWriterService in the constructStackBlitzForm() function. I had to add a few lines of logic to be able to display examples with different file names / component names in the new Stackblitz project. I'm not particularly happy with the way this is constructed because it 1) creates linting errors through the "replacement placeholders" in the module files and 2) feels a bit sketchy as a whole. I'd be very much open for other ideas in this area.

- I set the dependency versions to be loaded by Stackblitz respectively to the latest available. If I knew a way, I would have set these to be the exact same as in the project, but I'm not sure how / if it is relevant.

- The solution relies on the fact that the file name uses the same wording as the Component name. Through some regexing and replacing the Component name is actually constructed from the file name provided. Again, I couldn't find a better way to define the Component name, which is needed to declare and bootstrap the chosen example in the app.module.

Feel free to comment as much as you like ;)