### PR TITLE
fix(business): adapt CDK changes for sbb-table

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "schematics": "./schematics/collection.json",
   "dependencies": {
     "@angular/animations": "10.0.8",
-    "@angular/cdk": "10.1.2",
+    "@angular/cdk": "10.2.1",
     "@angular/common": "10.0.8",
     "@angular/core": "10.0.8",
     "@angular/forms": "10.0.8",

--- a/src/angular-business/table/table/table.component.ts
+++ b/src/angular-business/table/table/table.component.ts
@@ -1,8 +1,10 @@
+import { _DisposeViewRepeaterStrategy, _VIEW_REPEATER_STRATEGY } from '@angular/cdk/collections';
 import {
   CdkTable,
+  CDK_TABLE,
   CDK_TABLE_TEMPLATE,
-  DataSource,
   _CoalescedStyleScheduler,
+  _COALESCED_STYLE_SCHEDULER,
 } from '@angular/cdk/table';
 import {
   AfterViewInit,
@@ -24,7 +26,18 @@ import { SbbTableDataSource } from './table-data-source';
   exportAs: 'sbbTable',
   template: CDK_TABLE_TEMPLATE,
   styleUrls: ['table.component.css'],
-  providers: [{ provide: CdkTable, useExisting: TableComponent }, _CoalescedStyleScheduler],
+  providers: [
+    // TODO(michaeljamesparsons) Abstract the view repeater strategy to a directive API so this code
+    //  is only included in the build if used.
+    { provide: _VIEW_REPEATER_STRATEGY, useClass: _DisposeViewRepeaterStrategy },
+    { provide: CdkTable, useExisting: TableComponent },
+    { provide: CDK_TABLE, useExisting: TableComponent },
+    { provide: _COALESCED_STYLE_SCHEDULER, useClass: _CoalescedStyleScheduler },
+  ],
+  // The "OnPush" status for the `SbbTable` component is effectively a noop, so we are removing it.
+  // The view for `SbbTable` consists entirely of templates declared in other views. As they are
+  // declared elsewhere, they are checked when their declaration points are checked.
+  // tslint:disable-next-line:validate-decorators
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.Default,
 })
@@ -36,8 +49,6 @@ export class TableComponent<T> extends CdkTable<T> implements AfterViewInit {
 
   @ContentChildren(CellDirective, { descendants: true, read: ElementRef })
   rowElements: QueryList<ElementRef>;
-
-  dataSource: DataSource<T>;
 
   /** Overrides the sticky CSS class set by the `CdkTable`. */
   // tslint:disable-next-line:naming-convention

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,10 +79,10 @@
     shelljs "0.8.2"
     tsickle "^0.38.0"
 
-"@angular/cdk@10.1.2":
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-10.1.2.tgz#0c16ad767be4daaeb13d16652ba66bcfd79d5e1e"
-  integrity sha512-nK2+UppQvD8wz4Ur0MAa9mVKa1rZsJLYmJtZzQ0tRNFdgdhCQZe/PIYxvrR0uByoe5lYsjtKESjltb9PxZE08g==
+"@angular/cdk@10.2.1":
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-10.2.1.tgz#7ca0fe7220ca97bdf8e73a40105212749427a88f"
+  integrity sha512-67nPfteerlGPlwBeKt+EEOgEo2zm3+U6FzwhXVqwEeBxCZ7PWelMDiartHC7zZnzIKkcNEO0Uptq7Bzl2gdU0w==
   dependencies:
     tslib "^2.0.0"
   optionalDependencies:


### PR DESCRIPTION
The Angular CDK introduced a breaking change in version 10.1.2 and again in 10.2.0, which was fixed in 10.2.1: https://github.com/angular/components/pull/20425
Since we adapted to the 10.1.2 change, we also need to adapt to the 10.2.0 change.