### PR TITLE
fix(core/business-date-adapter): use year pivot to determine century of 2-digit year

### DIFF
--- a/src/angular-core/datetime/business-date-adapter.spec.ts
+++ b/src/angular-core/datetime/business-date-adapter.spec.ts
@@ -18,6 +18,7 @@ describe('BusinessDateAdapter', () => {
       { input: 'Sa,01012020', expectedYear: 2020, expectedMonth: 1, expectedDay: 1 },
       { input: '01012020', expectedYear: 2020, expectedMonth: 1, expectedDay: 1 },
       { input: '010100', expectedYear: 2000, expectedMonth: 1, expectedDay: 1 },
+      { input: '010199', expectedYear: 1999, expectedMonth: 1, expectedDay: 1 },
       { input: '01011802', expectedYear: 1802, expectedMonth: 1, expectedDay: 1 },
     ];
 

--- a/src/angular-core/datetime/business-date-adapter.ts
+++ b/src/angular-core/datetime/business-date-adapter.ts
@@ -21,9 +21,6 @@ export class BusinessDateAdapter extends NativeDateAdapter {
     if (!match) {
       return null;
     }
-    const year = +match[4];
-    return this._normalizeYear(
-      this._createDateWithOverflow(year < 100 ? 2000 + year : year, +match[3] - 1, +match[2])
-    );
+    return this._normalizeYear(this._createDateWithOverflow(+match[4], +match[3] - 1, +match[2]));
   }
 }


### PR DESCRIPTION
This should fix the issue mentioned in #613. From my point of view, there is no reason for the additional logic and it should be handled the same as when using the NativeDateAdapter.

Closes #613