### PR TITLE
fix: change tooltip trigger css display from block to inline-block

### DIFF
--- a/src/angular-business/tooltip/tooltip.md
+++ b/src/angular-business/tooltip/tooltip.md
@@ -10,7 +10,7 @@ The tooltip consists of a question icon and the overlay.
 
 The overlay has got the following characteristics:
 
-- It will open when the user click on the question icon.
+- It will open when the user clicks on the question icon.
 - It also includes a close.
 - it has got two states: visible or hidden.
 

--- a/src/angular-business/tooltip/tooltip/tooltip.component.html
+++ b/src/angular-business/tooltip/tooltip/tooltip.component.html
@@ -1,7 +1,7 @@
 <button
   (click)="onClick($event)"
   #triggerButton
-  class="sbb-tooltip-trigger sbb-icon-fit"
+  class="sbb-tooltip-trigger sbb-tooltip-icon sbb-icon-fit"
   [class.sbb-tooltip-trigger-active]="overlayAttached"
   [attr.aria-describedby]="contentId"
   tabindex="0"
@@ -14,7 +14,11 @@
     <ng-content></ng-content>
   </div>
   <div class="sbb-tooltip-shadow"></div>
-  <button type="button" class="sbb-tooltip-close-icon sbb-icon-fit" (click)="onClick($event)">
+  <button
+    type="button"
+    class="sbb-tooltip-icon sbb-tooltip-close-icon sbb-icon-fit"
+    (click)="onClick($event)"
+  >
     <sbb-icon svgIcon="kom:cross-small"></sbb-icon>
   </button>
 </ng-template>

--- a/src/angular-business/tooltip/tooltip/tooltip.component.html
+++ b/src/angular-business/tooltip/tooltip/tooltip.component.html
@@ -14,7 +14,7 @@
     <ng-content></ng-content>
   </div>
   <div class="sbb-tooltip-shadow"></div>
-  <button type="button" class="sbb-tooltip-icon sbb-icon-fit" (click)="onClick($event)">
+  <button type="button" class="sbb-tooltip-close-icon sbb-icon-fit" (click)="onClick($event)">
     <sbb-icon svgIcon="kom:cross-small"></sbb-icon>
   </button>
 </ng-template>

--- a/src/angular-business/tooltip/tooltip/tooltip.component.scss
+++ b/src/angular-business/tooltip/tooltip/tooltip.component.scss
@@ -3,30 +3,20 @@ $sbbBusiness: true;
 @import '../../../angular-core/styles/common';
 
 $tooltipBorderRadius: 2;
-$tooltipBorderWidth: 2;
+$tooltipBorderWidth: if($sbbBusiness, 1, 2);
 $tooltipIconsBorderWidth: 1;
 $tooltipMaxWidth: 460;
 $tooltipIconsSize: 24;
-$tooltipContentPadding: 24;
-$tooltipColor: $sbbColorGrey;
-$tooltipBorderColor: $sbbColorGrey;
-$tooltipActiveColor: $sbbColorRed;
+$tooltipContentPadding: if($sbbBusiness, 8, 24);
+$tooltipColor: if($sbbBusiness, $sbbColorBlack, $sbbColorGrey);
+$tooltipBorderColor: if($sbbBusiness, $sbbColorIron, $sbbColorGrey);
+$tooltipActiveColor: if($sbbBusiness, $sbbColorRed125, $sbbColorRed);
 $tooltipBoxShadowColor: rgba(102, 102, 102, 0.15);
-$tooltipShadowSize: 8;
+$tooltipShadowSize: if($sbbBusiness, 4, 8);
 $tooltipContentArrowSize: 20;
 $tooltipShadowBorderWidth: 14;
 $tooltipArrowRightPosition: calc(100% - #{pxToEm(15.5)});
 $tooltipArrowLeftPosition: pxToEm(15.5);
-
-@if $sbbBusiness {
-  $tooltipContentPadding: 8;
-  $tooltipBorderWidth: 1;
-  $tooltipShadowSize: 4;
-  $tooltipShadowBorderWidth: 14;
-  $tooltipColor: $sbbColorBlack;
-  $tooltipBorderColor: $sbbColorIron;
-  $tooltipActiveColor: $sbbColorRed125;
-}
 
 @mixin tooltipIcon {
   @include buttonResetFrameless();
@@ -67,12 +57,10 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
   }
 }
 
-sbb-tooltip {
-  .sbb-tooltip-trigger {
-    @include tooltipIcon();
-    margin: auto;
-    display: inline-block;
-  }
+.sbb-tooltip-trigger {
+  @include tooltipIcon();
+  margin: auto;
+  display: inline-block;
 }
 
 .sbb-tooltip-content-above {
@@ -182,73 +170,77 @@ sbb-tooltip {
   display: block;
   background: $sbbColorWhite;
 
-  .sbb-tooltip-content-body {
-    padding-top: toPx($tooltipContentPadding);
-    padding-left: toPx($tooltipContentPadding);
-    padding-bottom: toPx($tooltipContentPadding);
-    padding-right: toPx($tooltipContentPadding + $tooltipIconsSize + $tooltipContentPadding);
-  }
-
   @include publicOnly() {
     @include mq($from: desktop4k) {
       font-size: $sizeFontBase * $scalingFactor4k;
       border: toPx($tooltipBorderWidth * $scalingFactor4k) solid $tooltipBorderColor;
       max-width: toPx($tooltipMaxWidth * $scalingFactor4k);
-      .sbb-tooltip-content-body {
-        padding-top: toPx($tooltipContentPadding * $scalingFactor4k);
-        padding-left: toPx($tooltipContentPadding * $scalingFactor4k);
-        padding-bottom: toPx($tooltipContentPadding * $scalingFactor4k);
-        padding-right: toPx(
-          $tooltipContentPadding * $scalingFactor4k + $tooltipIconsSize + $tooltipContentPadding *
-            $scalingFactor4k
-        );
-      }
     }
 
     @include mq($from: desktop5k) {
       font-size: $sizeFontBase * $scalingFactor5k;
       border: toPx($tooltipBorderWidth * $scalingFactor5k) solid $tooltipBorderColor;
       max-width: toPx($tooltipMaxWidth * $scalingFactor5k);
-      .sbb-tooltip-content-body {
-        padding-top: toPx($tooltipContentPadding * $scalingFactor5k);
-        padding-left: toPx($tooltipContentPadding * $scalingFactor5k);
-        padding-bottom: toPx($tooltipContentPadding * $scalingFactor5k);
-        padding-right: toPx(
-          $tooltipContentPadding * $scalingFactor5k + $tooltipIconsSize + $tooltipContentPadding *
-            $scalingFactor5k
-        );
-      }
     }
   }
+}
 
-  .sbb-tooltip-icon {
-    @include tooltipIcon();
-    border-color: $tooltipBorderColor;
-    border-width: pxToEm($tooltipIconsBorderWidth);
-    border-style: solid;
-    border-radius: 50%;
-    float: right;
-    position: absolute;
-    top: toPx($tooltipContentPadding);
-    right: toPx($tooltipContentPadding);
+.sbb-tooltip-close-icon {
+  @include tooltipIcon();
+  border-color: $tooltipBorderColor;
+  border-width: pxToEm($tooltipIconsBorderWidth);
+  border-style: solid;
+  border-radius: 50%;
+  float: right;
+  position: absolute;
+  top: toPx($tooltipContentPadding);
+  right: toPx($tooltipContentPadding);
 
-    @include businessOnly() {
-      &,
-      &:hover,
-      &:focus {
-        border-color: transparent;
-      }
+  @include businessOnly() {
+    &,
+    &:hover,
+    &:focus {
+      border-color: transparent;
     }
   }
+}
 
-  &.sbb-tooltip-trigger-hover {
-    .sbb-tooltip-icon {
-      display: none;
+.sbb-tooltip-content-body {
+  padding-top: toPx($tooltipContentPadding);
+  padding-left: toPx($tooltipContentPadding);
+  padding-bottom: toPx($tooltipContentPadding);
+  padding-right: toPx($tooltipContentPadding + $tooltipIconsSize + $tooltipContentPadding);
+
+  @include publicOnly() {
+    @include mq($from: desktop4k) {
+      padding-top: toPx($tooltipContentPadding * $scalingFactor4k);
+      padding-left: toPx($tooltipContentPadding * $scalingFactor4k);
+      padding-bottom: toPx($tooltipContentPadding * $scalingFactor4k);
+      padding-right: toPx(
+        $tooltipContentPadding * $scalingFactor4k + $tooltipIconsSize + $tooltipContentPadding *
+          $scalingFactor4k
+      );
     }
 
-    .sbb-tooltip-content-body {
-      padding-right: toPx($tooltipContentPadding);
+    @include mq($from: desktop5k) {
+      padding-top: toPx($tooltipContentPadding * $scalingFactor5k);
+      padding-left: toPx($tooltipContentPadding * $scalingFactor5k);
+      padding-bottom: toPx($tooltipContentPadding * $scalingFactor5k);
+      padding-right: toPx(
+        $tooltipContentPadding * $scalingFactor5k + $tooltipIconsSize + $tooltipContentPadding *
+          $scalingFactor5k
+      );
     }
+  }
+}
+
+.sbb-tooltip-trigger-hover {
+  .sbb-tooltip-close-icon {
+    display: none;
+  }
+
+  .sbb-tooltip-content-body {
+    padding-right: toPx($tooltipContentPadding);
   }
 }
 

--- a/src/angular-business/tooltip/tooltip/tooltip.component.scss
+++ b/src/angular-business/tooltip/tooltip/tooltip.component.scss
@@ -4,9 +4,8 @@ $sbbBusiness: true;
 
 $tooltipBorderRadius: 2;
 $tooltipBorderWidth: if($sbbBusiness, 1, 2);
-$tooltipIconsBorderWidth: 1;
 $tooltipMaxWidth: 460;
-$tooltipIconsSize: 24;
+$tooltipIconSize: 24;
 $tooltipContentPadding: if($sbbBusiness, 8, 24);
 $tooltipColor: if($sbbBusiness, $sbbColorBlack, $sbbColorGrey);
 $tooltipBorderColor: if($sbbBusiness, $sbbColorIron, $sbbColorGrey);
@@ -18,49 +17,19 @@ $tooltipShadowBorderWidth: 14;
 $tooltipArrowRightPosition: calc(100% - #{pxToEm(15.5)});
 $tooltipArrowLeftPosition: pxToEm(15.5);
 
-@mixin tooltipIcon {
-  @include buttonResetFrameless();
+@mixin tooltipIconActive {
   /* TODO: Remove with future release */
-  @include svgIconColor($tooltipColor);
-  color: $tooltipColor;
-  width: toPx($tooltipIconsSize);
-  height: toPx($tooltipIconsSize);
-  cursor: pointer;
-  text-decoration: none;
-  outline: 0;
-  line-height: 1;
-
-  &-active,
-  &:hover,
-  &:focus {
-    /* TODO: Remove with future release */
-    @include svgIconColor($tooltipActiveColor);
-    color: $tooltipActiveColor;
-    border-color: $tooltipActiveColor;
-  }
-
-  @include publicOnly() {
-    @include mq($from: desktop4k) {
-      width: toPx($tooltipIconsSize * $scalingFactor4k);
-      height: toPx($tooltipIconsSize * $scalingFactor4k);
-    }
-
-    @include mq($from: desktop5k) {
-      width: toPx($tooltipIconsSize * $scalingFactor5k);
-      height: toPx($tooltipIconsSize * $scalingFactor5k);
-    }
-  }
-
-  > * {
-    max-width: 100%;
-    max-height: 100%;
-  }
+  @include svgIconColor($tooltipActiveColor);
+  color: $tooltipActiveColor;
+  border-color: $tooltipActiveColor;
 }
 
 .sbb-tooltip-trigger {
-  @include tooltipIcon();
-  margin: auto;
   display: inline-block;
+}
+
+.sbb-tooltip-trigger-active {
+  @include tooltipIconActive;
 }
 
 .sbb-tooltip-content-above {
@@ -185,10 +154,44 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
   }
 }
 
+.sbb-tooltip-icon {
+  @include buttonResetFrameless();
+  /* TODO: Remove with future release */
+  @include svgIconColor($tooltipColor);
+  color: $tooltipColor;
+  width: toPx($tooltipIconSize);
+  height: toPx($tooltipIconSize);
+  cursor: pointer;
+  text-decoration: none;
+  outline: 0;
+  line-height: 1;
+
+  &:hover,
+  &:focus {
+    @include tooltipIconActive();
+  }
+
+  @include publicOnly() {
+    @include mq($from: desktop4k) {
+      width: toPx($tooltipIconSize * $scalingFactor4k);
+      height: toPx($tooltipIconSize * $scalingFactor4k);
+    }
+
+    @include mq($from: desktop5k) {
+      width: toPx($tooltipIconSize * $scalingFactor5k);
+      height: toPx($tooltipIconSize * $scalingFactor5k);
+    }
+  }
+
+  > * {
+    max-width: 100%;
+    max-height: 100%;
+  }
+}
+
 .sbb-tooltip-close-icon {
-  @include tooltipIcon();
   border-color: $tooltipBorderColor;
-  border-width: pxToEm($tooltipIconsBorderWidth);
+  border-width: pxToEm(1);
   border-style: solid;
   border-radius: 50%;
   float: right;
@@ -203,13 +206,17 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
       border-color: transparent;
     }
   }
+
+  .sbb-tooltip-trigger-hover & {
+    display: none;
+  }
 }
 
 .sbb-tooltip-content-body {
   padding-top: toPx($tooltipContentPadding);
   padding-left: toPx($tooltipContentPadding);
   padding-bottom: toPx($tooltipContentPadding);
-  padding-right: toPx($tooltipContentPadding + $tooltipIconsSize + $tooltipContentPadding);
+  padding-right: toPx($tooltipContentPadding + $tooltipIconSize + $tooltipContentPadding);
 
   @include publicOnly() {
     @include mq($from: desktop4k) {
@@ -217,7 +224,7 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
       padding-left: toPx($tooltipContentPadding * $scalingFactor4k);
       padding-bottom: toPx($tooltipContentPadding * $scalingFactor4k);
       padding-right: toPx(
-        $tooltipContentPadding * $scalingFactor4k + $tooltipIconsSize + $tooltipContentPadding *
+        $tooltipContentPadding * $scalingFactor4k + $tooltipIconSize + $tooltipContentPadding *
           $scalingFactor4k
       );
     }
@@ -227,19 +234,13 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
       padding-left: toPx($tooltipContentPadding * $scalingFactor5k);
       padding-bottom: toPx($tooltipContentPadding * $scalingFactor5k);
       padding-right: toPx(
-        $tooltipContentPadding * $scalingFactor5k + $tooltipIconsSize + $tooltipContentPadding *
+        $tooltipContentPadding * $scalingFactor5k + $tooltipIconSize + $tooltipContentPadding *
           $scalingFactor5k
       );
     }
   }
-}
 
-.sbb-tooltip-trigger-hover {
-  .sbb-tooltip-close-icon {
-    display: none;
-  }
-
-  .sbb-tooltip-content-body {
+  .sbb-tooltip-trigger-hover & {
     padding-right: toPx($tooltipContentPadding);
   }
 }

--- a/src/angular-business/tooltip/tooltip/tooltip.component.scss
+++ b/src/angular-business/tooltip/tooltip/tooltip.component.scss
@@ -71,8 +71,7 @@ sbb-tooltip {
   .sbb-tooltip-trigger {
     @include tooltipIcon();
     margin: auto;
-    // TODO: Remove display block for v11
-    display: block;
+    display: inline-block;
   }
 }
 

--- a/src/angular-public/tooltip/tooltip.md
+++ b/src/angular-public/tooltip/tooltip.md
@@ -10,7 +10,7 @@ The tooltip consists of a question icon and the overlay.
 
 The overlay has got the following characteristics:
 
-- It will open when the user click on the question icon.
+- It will open when the user clicks on the question icon.
 - It also includes a close.
 - it has got two states: visible or hidden.
 

--- a/src/angular-public/tooltip/tooltip/tooltip.component.html
+++ b/src/angular-public/tooltip/tooltip/tooltip.component.html
@@ -1,7 +1,7 @@
 <button
   (click)="onClick($event)"
   #triggerButton
-  class="sbb-tooltip-trigger sbb-icon-fit"
+  class="sbb-tooltip-trigger sbb-tooltip-icon sbb-icon-fit"
   [class.sbb-tooltip-trigger-active]="overlayAttached"
   [attr.aria-describedby]="contentId"
   tabindex="0"
@@ -14,7 +14,11 @@
     <ng-content></ng-content>
   </div>
   <div class="sbb-tooltip-shadow"></div>
-  <button type="button" class="sbb-tooltip-close-icon sbb-icon-fit" (click)="onClick($event)">
+  <button
+    type="button"
+    class="sbb-tooltip-icon sbb-tooltip-close-icon sbb-icon-fit"
+    (click)="onClick($event)"
+  >
     <sbb-icon svgIcon="kom:cross-small"></sbb-icon>
   </button>
 </ng-template>

--- a/src/angular-public/tooltip/tooltip/tooltip.component.html
+++ b/src/angular-public/tooltip/tooltip/tooltip.component.html
@@ -14,7 +14,7 @@
     <ng-content></ng-content>
   </div>
   <div class="sbb-tooltip-shadow"></div>
-  <button type="button" class="sbb-tooltip-icon sbb-icon-fit" (click)="onClick($event)">
+  <button type="button" class="sbb-tooltip-close-icon sbb-icon-fit" (click)="onClick($event)">
     <sbb-icon svgIcon="kom:cross-small"></sbb-icon>
   </button>
 </ng-template>

--- a/src/angular-public/tooltip/tooltip/tooltip.component.scss
+++ b/src/angular-public/tooltip/tooltip/tooltip.component.scss
@@ -2,9 +2,8 @@
 
 $tooltipBorderRadius: 2;
 $tooltipBorderWidth: if($sbbBusiness, 1, 2);
-$tooltipIconsBorderWidth: 1;
 $tooltipMaxWidth: 460;
-$tooltipIconsSize: 24;
+$tooltipIconSize: 24;
 $tooltipContentPadding: if($sbbBusiness, 8, 24);
 $tooltipColor: if($sbbBusiness, $sbbColorBlack, $sbbColorGrey);
 $tooltipBorderColor: if($sbbBusiness, $sbbColorIron, $sbbColorGrey);
@@ -16,49 +15,19 @@ $tooltipShadowBorderWidth: 14;
 $tooltipArrowRightPosition: calc(100% - #{pxToEm(15.5)});
 $tooltipArrowLeftPosition: pxToEm(15.5);
 
-@mixin tooltipIcon {
-  @include buttonResetFrameless();
+@mixin tooltipIconActive {
   /* TODO: Remove with future release */
-  @include svgIconColor($tooltipColor);
-  color: $tooltipColor;
-  width: toPx($tooltipIconsSize);
-  height: toPx($tooltipIconsSize);
-  cursor: pointer;
-  text-decoration: none;
-  outline: 0;
-  line-height: 1;
-
-  &-active,
-  &:hover,
-  &:focus {
-    /* TODO: Remove with future release */
-    @include svgIconColor($tooltipActiveColor);
-    color: $tooltipActiveColor;
-    border-color: $tooltipActiveColor;
-  }
-
-  @include publicOnly() {
-    @include mq($from: desktop4k) {
-      width: toPx($tooltipIconsSize * $scalingFactor4k);
-      height: toPx($tooltipIconsSize * $scalingFactor4k);
-    }
-
-    @include mq($from: desktop5k) {
-      width: toPx($tooltipIconsSize * $scalingFactor5k);
-      height: toPx($tooltipIconsSize * $scalingFactor5k);
-    }
-  }
-
-  > * {
-    max-width: 100%;
-    max-height: 100%;
-  }
+  @include svgIconColor($tooltipActiveColor);
+  color: $tooltipActiveColor;
+  border-color: $tooltipActiveColor;
 }
 
 .sbb-tooltip-trigger {
-  @include tooltipIcon();
-  margin: auto;
   display: inline-block;
+}
+
+.sbb-tooltip-trigger-active {
+  @include tooltipIconActive;
 }
 
 .sbb-tooltip-content-above {
@@ -183,10 +152,44 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
   }
 }
 
+.sbb-tooltip-icon {
+  @include buttonResetFrameless();
+  /* TODO: Remove with future release */
+  @include svgIconColor($tooltipColor);
+  color: $tooltipColor;
+  width: toPx($tooltipIconSize);
+  height: toPx($tooltipIconSize);
+  cursor: pointer;
+  text-decoration: none;
+  outline: 0;
+  line-height: 1;
+
+  &:hover,
+  &:focus {
+    @include tooltipIconActive();
+  }
+
+  @include publicOnly() {
+    @include mq($from: desktop4k) {
+      width: toPx($tooltipIconSize * $scalingFactor4k);
+      height: toPx($tooltipIconSize * $scalingFactor4k);
+    }
+
+    @include mq($from: desktop5k) {
+      width: toPx($tooltipIconSize * $scalingFactor5k);
+      height: toPx($tooltipIconSize * $scalingFactor5k);
+    }
+  }
+
+  > * {
+    max-width: 100%;
+    max-height: 100%;
+  }
+}
+
 .sbb-tooltip-close-icon {
-  @include tooltipIcon();
   border-color: $tooltipBorderColor;
-  border-width: pxToEm($tooltipIconsBorderWidth);
+  border-width: pxToEm(1);
   border-style: solid;
   border-radius: 50%;
   float: right;
@@ -201,13 +204,17 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
       border-color: transparent;
     }
   }
+
+  .sbb-tooltip-trigger-hover & {
+    display: none;
+  }
 }
 
 .sbb-tooltip-content-body {
   padding-top: toPx($tooltipContentPadding);
   padding-left: toPx($tooltipContentPadding);
   padding-bottom: toPx($tooltipContentPadding);
-  padding-right: toPx($tooltipContentPadding + $tooltipIconsSize + $tooltipContentPadding);
+  padding-right: toPx($tooltipContentPadding + $tooltipIconSize + $tooltipContentPadding);
 
   @include publicOnly() {
     @include mq($from: desktop4k) {
@@ -215,7 +222,7 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
       padding-left: toPx($tooltipContentPadding * $scalingFactor4k);
       padding-bottom: toPx($tooltipContentPadding * $scalingFactor4k);
       padding-right: toPx(
-        $tooltipContentPadding * $scalingFactor4k + $tooltipIconsSize + $tooltipContentPadding *
+        $tooltipContentPadding * $scalingFactor4k + $tooltipIconSize + $tooltipContentPadding *
           $scalingFactor4k
       );
     }
@@ -225,19 +232,13 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
       padding-left: toPx($tooltipContentPadding * $scalingFactor5k);
       padding-bottom: toPx($tooltipContentPadding * $scalingFactor5k);
       padding-right: toPx(
-        $tooltipContentPadding * $scalingFactor5k + $tooltipIconsSize + $tooltipContentPadding *
+        $tooltipContentPadding * $scalingFactor5k + $tooltipIconSize + $tooltipContentPadding *
           $scalingFactor5k
       );
     }
   }
-}
 
-.sbb-tooltip-trigger-hover {
-  .sbb-tooltip-close-icon {
-    display: none;
-  }
-
-  .sbb-tooltip-content-body {
+  .sbb-tooltip-trigger-hover & {
     padding-right: toPx($tooltipContentPadding);
   }
 }

--- a/src/angular-public/tooltip/tooltip/tooltip.component.scss
+++ b/src/angular-public/tooltip/tooltip/tooltip.component.scss
@@ -69,8 +69,7 @@ sbb-tooltip {
   .sbb-tooltip-trigger {
     @include tooltipIcon();
     margin: auto;
-    // TODO: Remove display block for v11
-    display: block;
+    display: inline-block;
   }
 }
 

--- a/src/angular-public/tooltip/tooltip/tooltip.component.scss
+++ b/src/angular-public/tooltip/tooltip/tooltip.component.scss
@@ -1,30 +1,20 @@
 @import '../../../angular-core/styles/common';
 
 $tooltipBorderRadius: 2;
-$tooltipBorderWidth: 2;
+$tooltipBorderWidth: if($sbbBusiness, 1, 2);
 $tooltipIconsBorderWidth: 1;
 $tooltipMaxWidth: 460;
 $tooltipIconsSize: 24;
-$tooltipContentPadding: 24;
-$tooltipColor: $sbbColorGrey;
-$tooltipBorderColor: $sbbColorGrey;
-$tooltipActiveColor: $sbbColorRed;
+$tooltipContentPadding: if($sbbBusiness, 8, 24);
+$tooltipColor: if($sbbBusiness, $sbbColorBlack, $sbbColorGrey);
+$tooltipBorderColor: if($sbbBusiness, $sbbColorIron, $sbbColorGrey);
+$tooltipActiveColor: if($sbbBusiness, $sbbColorRed125, $sbbColorRed);
 $tooltipBoxShadowColor: rgba(102, 102, 102, 0.15);
-$tooltipShadowSize: 8;
+$tooltipShadowSize: if($sbbBusiness, 4, 8);
 $tooltipContentArrowSize: 20;
 $tooltipShadowBorderWidth: 14;
 $tooltipArrowRightPosition: calc(100% - #{pxToEm(15.5)});
 $tooltipArrowLeftPosition: pxToEm(15.5);
-
-@if $sbbBusiness {
-  $tooltipContentPadding: 8;
-  $tooltipBorderWidth: 1;
-  $tooltipShadowSize: 4;
-  $tooltipShadowBorderWidth: 14;
-  $tooltipColor: $sbbColorBlack;
-  $tooltipBorderColor: $sbbColorIron;
-  $tooltipActiveColor: $sbbColorRed125;
-}
 
 @mixin tooltipIcon {
   @include buttonResetFrameless();
@@ -65,12 +55,10 @@ $tooltipArrowLeftPosition: pxToEm(15.5);
   }
 }
 
-sbb-tooltip {
-  .sbb-tooltip-trigger {
-    @include tooltipIcon();
-    margin: auto;
-    display: inline-block;
-  }
+.sbb-tooltip-trigger {
+  @include tooltipIcon();
+  margin: auto;
+  display: inline-block;
 }
 
 .sbb-tooltip-content-above {
@@ -180,72 +168,83 @@ sbb-tooltip {
   display: block;
   background: $sbbColorWhite;
 
-  .sbb-tooltip-content-body {
-    padding-top: toPx($tooltipContentPadding);
-    padding-left: toPx($tooltipContentPadding);
-    padding-bottom: toPx($tooltipContentPadding);
-    padding-right: toPx($tooltipContentPadding + $tooltipIconsSize + $tooltipContentPadding);
-  }
-
   @include publicOnly() {
     @include mq($from: desktop4k) {
       font-size: $sizeFontBase * $scalingFactor4k;
       border: toPx($tooltipBorderWidth * $scalingFactor4k) solid $tooltipBorderColor;
       max-width: toPx($tooltipMaxWidth * $scalingFactor4k);
-      .sbb-tooltip-content-body {
-        padding-top: toPx($tooltipContentPadding * $scalingFactor4k);
-        padding-left: toPx($tooltipContentPadding * $scalingFactor4k);
-        padding-bottom: toPx($tooltipContentPadding * $scalingFactor4k);
-        padding-right: toPx(
-          $tooltipContentPadding * $scalingFactor4k + $tooltipIconsSize + $tooltipContentPadding *
-            $scalingFactor4k
-        );
-      }
     }
 
     @include mq($from: desktop5k) {
       font-size: $sizeFontBase * $scalingFactor5k;
       border: toPx($tooltipBorderWidth * $scalingFactor5k) solid $tooltipBorderColor;
       max-width: toPx($tooltipMaxWidth * $scalingFactor5k);
-      .sbb-tooltip-content-body {
-        padding-top: toPx($tooltipContentPadding * $scalingFactor5k);
-        padding-left: toPx($tooltipContentPadding * $scalingFactor5k);
-        padding-bottom: toPx($tooltipContentPadding * $scalingFactor5k);
-        padding-right: toPx(
-          $tooltipContentPadding * $scalingFactor5k + $tooltipIconsSize + $tooltipContentPadding *
-            $scalingFactor5k
-        );
-      }
     }
   }
+}
 
-  .sbb-tooltip-icon {
-    @include tooltipIcon();
-    border-color: $tooltipBorderColor;
-    border-width: pxToEm($tooltipIconsBorderWidth);
-    border-style: solid;
-    border-radius: 50%;
-    float: right;
-    position: absolute;
-    top: toPx($tooltipContentPadding);
-    right: toPx($tooltipContentPadding);
+.sbb-tooltip-close-icon {
+  @include tooltipIcon();
+  border-color: $tooltipBorderColor;
+  border-width: pxToEm($tooltipIconsBorderWidth);
+  border-style: solid;
+  border-radius: 50%;
+  float: right;
+  position: absolute;
+  top: toPx($tooltipContentPadding);
+  right: toPx($tooltipContentPadding);
 
-    @include businessOnly() {
-      &,
-      &:hover,
-      &:focus {
-        border-color: transparent;
-      }
+  @include businessOnly() {
+    &,
+    &:hover,
+    &:focus {
+      border-color: transparent;
     }
   }
+}
 
-  &.sbb-tooltip-trigger-hover {
-    .sbb-tooltip-icon {
-      display: none;
+.sbb-tooltip-content-body {
+  padding-top: toPx($tooltipContentPadding);
+  padding-left: toPx($tooltipContentPadding);
+  padding-bottom: toPx($tooltipContentPadding);
+  padding-right: toPx($tooltipContentPadding + $tooltipIconsSize + $tooltipContentPadding);
+
+  @include publicOnly() {
+    @include mq($from: desktop4k) {
+      padding-top: toPx($tooltipContentPadding * $scalingFactor4k);
+      padding-left: toPx($tooltipContentPadding * $scalingFactor4k);
+      padding-bottom: toPx($tooltipContentPadding * $scalingFactor4k);
+      padding-right: toPx(
+        $tooltipContentPadding * $scalingFactor4k + $tooltipIconsSize + $tooltipContentPadding *
+          $scalingFactor4k
+      );
     }
 
-    .sbb-tooltip-content-body {
-      padding-right: toPx($tooltipContentPadding);
+    @include mq($from: desktop5k) {
+      padding-top: toPx($tooltipContentPadding * $scalingFactor5k);
+      padding-left: toPx($tooltipContentPadding * $scalingFactor5k);
+      padding-bottom: toPx($tooltipContentPadding * $scalingFactor5k);
+      padding-right: toPx(
+        $tooltipContentPadding * $scalingFactor5k + $tooltipIconsSize + $tooltipContentPadding *
+          $scalingFactor5k
+      );
     }
   }
+}
+
+.sbb-tooltip-trigger-hover {
+  .sbb-tooltip-close-icon {
+    display: none;
+  }
+
+  .sbb-tooltip-content-body {
+    padding-right: toPx($tooltipContentPadding);
+  }
+}
+
+.sbb-tooltip-panel {
+  // The overlay reference updates the pointer-events style property directly on the HTMLElement
+  // depending on the state of the overlay. For tooltips the overlay panel should never enable
+  // pointer events. To overwrite the inline CSS from the overlay reference `!important` is needed.
+  pointer-events: none !important;
 }

--- a/src/angular-public/tooltip/tooltip/tooltip.component.spec.ts
+++ b/src/angular-public/tooltip/tooltip/tooltip.component.spec.ts
@@ -108,9 +108,8 @@ describe('SbbTooltip using mock component for single tooltip', () => {
     buttonQuestionMark.click();
     singleFixtureTest.detectChanges();
 
-    expect(buttonQuestionMark.attributes['class'].value).toBe(
-      'sbb-tooltip-trigger sbb-icon-fit sbb-tooltip-trigger-active'
-    );
+    expect(buttonQuestionMark.classList.contains('sbb-tooltip-trigger')).toBeTrue();
+    expect(buttonQuestionMark.classList.contains('sbb-tooltip-trigger-active')).toBeTrue();
 
     const tooltipElement = singleFixtureTest.debugElement.query(By.css('.sbb-tooltip'));
 
@@ -127,7 +126,8 @@ describe('SbbTooltip using mock component for single tooltip', () => {
     buttonQuestionMark.click();
     singleFixtureTest.detectChanges();
 
-    expect(buttonQuestionMark.attributes['class'].value).toBe('sbb-tooltip-trigger sbb-icon-fit');
+    expect(buttonQuestionMark.classList.contains('sbb-tooltip-trigger')).toBeTrue();
+    expect(buttonQuestionMark.classList.contains('sbb-tooltip-trigger-active')).toBeFalse();
 
     const tooltipElement = singleFixtureTest.debugElement.query(By.css('.sbb-tooltip'));
 
@@ -160,7 +160,9 @@ describe('SbbTooltip using mock component for single tooltip', () => {
 
     singleComponentTest.t1.close();
 
-    expect(buttonQuestionMark.attributes['class'].value).toBe('sbb-tooltip-trigger sbb-icon-fit');
+    expect(buttonQuestionMark.classList.contains('sbb-tooltip-trigger')).toBeTrue();
+    expect(buttonQuestionMark.classList.contains('sbb-tooltip-trigger-active')).toBeFalse();
+
     expect(singleComponentTest.t1.overlayAttached).toBe(false);
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: This commit changes the css display property of the tooltip trigger
from block to inline-block.
If you still like to use the block variant, use the following css definition: 
`.sbb-tooltip-trigger { display: block; }`.