### PR TITLE
feat: provide translations for german, french and italian

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "ts-node-script ./scripts/build.ts",
     "build:public2business": "ng g .:public2business",
     "build:schematics": "rollup --config schematics/rollup.config.js",
+    "build:i18n": "ts-node-script ./scripts/build.ts i18n",
     "watch:public2business": "node ./scripts/public2business-watcher.js",
     "generate:bazel": "ng g .:bazel",
     "generate:examples": "ng g .:normalize-examples && yarn -s generate:bazel",
@@ -34,7 +35,9 @@
     "format": "yarn -s format:prettier && yarn -s format:bazel",
     "migrate": "node ./scripts/run-migration.js",
     "release": "standard-version --tag-prefix=\"\"",
-    "forceinstall-husky": "node node_modules/husky/lib/installer/bin install"
+    "forceinstall-husky": "node node_modules/husky/lib/installer/bin install",
+    "t9n:xlf": "ng-t9n t9n-xlf.json",
+    "t9n:xlf2": "ng-t9n t9n-xlf2.json"
   },
   "repository": {
     "type": "git",
@@ -101,6 +104,7 @@
     "@types/parse5": "^5.0.3",
     "@types/svgo": "^1.3.3",
     "@wessberg/rollup-plugin-ts": "^1.3.7",
+    "angular-t9n": "^11.1.2",
     "codelyzer": "^6.0.0-next.1",
     "dgeni": "^0.4.12",
     "dgeni-packages": "^0.28.4",

--- a/schematics/bazel/files/ngPackage/BUILD.bazel
+++ b/schematics/bazel/files/ngPackage/BUILD.bazel
@@ -104,7 +104,7 @@ ng_package(
         ":styles_bundle",<% } %><% if (hasTypography) { %>
         ":typography",<% } %><% if (name === 'angular-core') { %>
         "//src/angular-core/styles:legacy_scss",<% } %>
-    ],
+    ]<% if (name === 'angular-core') { %> + glob(["i18n/**/*.xlf"]) <% } %>,
     entry_point = ":public-api.ts",
     entry_point_name = "<%= name %>",<% if (hasSchematics) { %>
     nested_packages = ["//src/<%= name %>/schematics:npm_package"],<% } %><% if (hasReadme) { %>

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -32,6 +32,8 @@ if (module === require.main) {
      * output directory.
      */
     packages: () => buildReleasePackages(false, join(projectDir, 'dist/releases')),
+    i18n: () =>
+      buildI18n(join(projectDir, 'dist/releases'), join(projectDir, 'src/angular-core/i18n')),
     showcase: () => buildShowcase(join(projectDir, 'dist/releases')),
     'icon-registry': () => generateIconRegistry(),
   };
@@ -114,6 +116,18 @@ function getPackageNamesOfTargets(targets: string[]) {
     }
     return matches[1];
   });
+}
+
+function buildI18n(distPath: string, i18nDistPath: string) {
+  buildReleasePackages(true, distPath);
+  for (const format of ['xlf', 'xlf2']) {
+    const relativeDistPath = relative(projectDir, distPath);
+    const outPath = join(i18nDistPath, format, 'messages.xlf');
+    exec(
+      `"node_modules/.bin/localize-extract" -l en-CH -s "${relativeDistPath}/**/fesm2015/*.js" -f ${format} -o "${outPath}"`
+    );
+    console.log(`Updated ${relative(projectDir, outPath)}`);
+  }
 }
 
 /**

--- a/src/angular-business/BUILD.bazel
+++ b/src/angular-business/BUILD.bazel
@@ -53,6 +53,7 @@ markdown_to_html(
     name = "overview",
     srcs = [
         ":getting-started.md",
+        ":i18n.md",
         ":typography.md",
     ],
 )

--- a/src/angular-business/button/button/button.component.spec.ts
+++ b/src/angular-business/button/button/button.component.spec.ts
@@ -6,7 +6,6 @@ import { SbbIconTestingModule } from '@sbb-esta/angular-core/icon/testing';
 
 import { SbbButton } from './button.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-button-test',
   template: `
@@ -20,7 +19,6 @@ export class ButtonTestComponent {
   testClick() {}
 }
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-button-icon-test',
   template: `

--- a/src/angular-business/checkbox/checkbox/checkbox.component.spec.ts
+++ b/src/angular-business/checkbox/checkbox/checkbox.component.spec.ts
@@ -9,7 +9,6 @@ import { dispatchMouseEvent } from '@sbb-esta/angular-core/testing';
 
 import { SbbCheckbox } from './checkbox.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-model-checkbox-test',
   template: `

--- a/src/angular-business/getting-started.md
+++ b/src/angular-business/getting-started.md
@@ -145,17 +145,7 @@ export class SbbModule {}
 
 Whichever approach you use, be sure to import the modules after Angular's BrowserModule, as the import order matters for NgModules.
 
-## Step 3: i18n
-
-This library uses [Angular i18n](https://angular.io/guide/i18n). All translatables have an id with the pattern "sbb*Component*".
-Run `ng xi18n` in your project (after using components of this library in your code) to generate the list of translatables.
-
-### Datepicker i18n:
-
-The datepicker uses the CLDR data [provided by Angular](https://angular.io/guide/i18n#setting-up-the-locale-of-your-app).
-This means it uses the locale data configured via the `i18nLocale` entry in your angular.json `build` options or configurations.
-
-## Step 4 (Optional): Use mixins and functions from the library
+## Step 3 (Optional): Use mixins and functions from the library
 
 If you need to reuse some mixins from the library, you have to configure your own Angular application in
 SCSS mode and import `_styles.scss` from the library into your `styles.scss`:

--- a/src/angular-business/header/header-menu/header-menu.component.html
+++ b/src/angular-business/header/header-menu/header-menu.component.html
@@ -1,6 +1,6 @@
 <button type="button" class="sbb-header-menu-back" (click)="open = false">
   <sbb-icon svgIcon="kom:chevron-small-left-small"></sbb-icon>
-  <span i18n="Go back to the app chooser navigation@@sbbHeaderMenuBack">Zurück</span>
+  <span i18n="Go back to the app chooser navigation@@sbbHeaderMenuBack">Back</span>
 </button>
 
 <div class="sbb-header-menu-title">

--- a/src/angular-business/header/header/header.component.html
+++ b/src/angular-business/header/header/header.component.html
@@ -8,7 +8,7 @@
   [class.sbb-header-app-chooser-available]="_appChooserSections.length"
   (click)="openMenu('mouse')"
   (keydown)="_openOnKeydownTrigger($event)"
-  aria-label-i18n="@@sbbHeaderOpenMenu"
+  aria-label-i18n="Button label to open the sidebar of the header@@sbbHeaderOpenMenu"
   aria-label="Open Menu"
 >
   <sbb-icon svgIcon="kom:hamburger-menu-small"></sbb-icon>
@@ -60,7 +60,7 @@
       class="sbb-header-close-menu"
       (click)="closeMenu()"
       (keydown)="_closeOnKeydownTrigger($event)"
-      aria-label-i18n="@@sbbHeaderCloseMenu"
+      aria-label-i18n="Button label to close the sidebar of the header@@sbbHeaderCloseMenu"
       aria-label="Close Menu"
     >
       <sbb-icon svgIcon="kom:cross-small"></sbb-icon>

--- a/src/angular-business/i18n.md
+++ b/src/angular-business/i18n.md
@@ -1,0 +1,42 @@
+# i18n
+
+This library uses [Angular i18n](https://angular.io/guide/i18n). All translatables have an id with the pattern "sbb*Component*".
+Run `ng xi18n` in your project (after using components of this library in your code) to generate the list of translatables.
+
+### Provided translations
+
+Our components use english as the default. We provide german (de-CH), french (fr-CH) and italian (it-CH)
+translations in XLIFF 1.2 and 2.0 variants. These are located in
+`node_modules/@sbb-esta/angular-core/i18n/xlf/messages.*.xlf` for XLIFF 1.2 and in
+`node_modules/@sbb-esta/angular-core/i18n/xlf2/messages.*.xlf` for XLIFF 2.0.
+
+Add them to your angular.json as follows (change `xlf` to `xlf2` for XLIFF 2.0):
+
+```json
+    "your-project-name": {
+      ...
+      "i18n": {
+        ...
+        "locales": {
+          "de-CH": [
+            "your-translation.xlf",
+            "node_modules/@sbb-esta/angular-core/i18n/xlf/messages.de-CH.xlf"
+          ],
+          "fr-CH": [
+            "your-translation.xlf",
+            "node_modules/@sbb-esta/angular-core/i18n/xlf/messages.fr-CH.xlf"
+          ],
+          "it-CH": [
+            "your-translation.xlf",
+            "node_modules/@sbb-esta/angular-core/i18n/xlf/messages.it-CH.xlf"
+          ],
+        }
+      },
+      ...
+    }
+```
+
+### Datepicker
+
+The datepicker uses the CLDR data [provided by Angular](https://angular.io/guide/i18n#setting-up-the-locale-of-your-app).
+This is configured via the `i18n` entry in your angular.json.

--- a/src/angular-business/sidebar/icon-sidebar/icon-sidebar.html
+++ b/src/angular-business/sidebar/icon-sidebar/icon-sidebar.html
@@ -15,16 +15,14 @@
       [attr.aria-hidden]="!expanded"
       class="sbb-icon-sidebar-item-label"
       i18n="Label to 'collapse' icon sidebar@@sbbSidebarCollapse"
+      >Collapse</span
     >
-      Collapse
-    </span>
 
     <span
       [attr.aria-hidden]="expanded"
       class="sbb-icon-sidebar-item-label cdk-visually-hidden"
       i18n="Label to 'expand' icon sidebar@@sbbSidebarExpand"
+      >Expand</span
     >
-      Expand
-    </span>
   </button>
 </div>

--- a/src/angular-business/sidebar/sidebar/sidebar-container.html
+++ b/src/angular-business/sidebar/sidebar/sidebar-container.html
@@ -3,7 +3,7 @@
     type="button"
     class="sbb-sidebar-mobile-menu-bar-trigger sbb-icon-fit"
     (click)="toggleSidebar()"
-    aria-label-i18n="@@sbbSidebarOpenSidebar"
+    aria-label-i18n="Button label to open the sidebar@@sbbSidebarOpenSidebar"
     aria-label="Open Sidebar"
   >
     <sbb-icon svgIcon="kom:hamburger-menu-small"></sbb-icon>

--- a/src/angular-business/sidebar/sidebar/sidebar.html
+++ b/src/angular-business/sidebar/sidebar/sidebar.html
@@ -4,7 +4,7 @@
       type="button"
       class="sbb-sidebar-mobile-menu-bar-close sbb-icon-fit"
       (click)="_container.toggleSidebar()"
-      aria-label-i18n="@@sbbSidebarCloseSidebar"
+      aria-label-i18n="Button label to close the sidebar@@sbbSidebarCloseSidebar"
       aria-label="Close Sidebar"
     >
       <sbb-icon svgIcon="kom:cross-small"></sbb-icon>

--- a/src/angular-business/table/BUILD.bazel
+++ b/src/angular-business/table/BUILD.bazel
@@ -26,6 +26,7 @@ ng_module(
         "@npm//@angular/cdk",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//@angular/localize",
         "@npm//rxjs",
     ],
 )

--- a/src/angular-business/table/sort-header/sort-header.component.html
+++ b/src/angular-business/table/sort-header/sort-header.component.html
@@ -6,8 +6,7 @@
   <button
     class="sbb-sort-header-button"
     type="button"
-    i18n-aria-label="@@tableChangeSorting"
-    attr.aria-label="Change sorting for {{ id }}"
+    [attr.aria-label]="_ariaLabelChangeSorting"
     (focus)="_setIndicatorHintVisible(true)"
     (blur)="_setIndicatorHintVisible(false)"
   >

--- a/src/angular-business/table/sort-header/sort-header.component.ts
+++ b/src/angular-business/table/sort-header/sort-header.component.ts
@@ -88,7 +88,6 @@ export class SbbSortHeaderComponent implements SbbSortable, OnDestroy, OnInit {
     this._disableClear = coerceBooleanProperty(v);
   }
 
-  /** @docs-private */
   get _ariaLabelChangeSorting() {
     return typeof $localize === 'function'
       ? $localize`:Button label to change the sorting of column@@sbbTableChangeSorting:Change sorting for ${this.id}`

--- a/src/angular-business/table/sort-header/sort-header.component.ts
+++ b/src/angular-business/table/sort-header/sort-header.component.ts
@@ -1,3 +1,6 @@
+// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
+/// <reference types="@angular/localize/init" />
+
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
@@ -85,6 +88,13 @@ export class SbbSortHeaderComponent implements SbbSortable, OnDestroy, OnInit {
     this._disableClear = coerceBooleanProperty(v);
   }
 
+  /** @docs-private */
+  get _ariaLabelChangeSorting() {
+    return typeof $localize === 'function'
+      ? $localize`:Button label to change the sorting of column@@sbbTableChangeSorting:Change sorting for ${this.id}`
+      : `Change sorting for ${this.id}`;
+  }
+
   private _rerenderSubscription: Subscription;
 
   constructor(
@@ -150,7 +160,6 @@ export class SbbSortHeaderComponent implements SbbSortable, OnDestroy, OnInit {
    * ID of this sort header. If used within the context of a CdkColumnDef, this will default to
    * the column's name.
    */
-  // tslint:disable-next-line:no-input-rename
   @Input('sbbSortHeader') id: string;
 
   /** Sets the position of the arrow that displays when sorted. */

--- a/src/angular-core/BUILD.bazel
+++ b/src/angular-core/BUILD.bazel
@@ -63,7 +63,7 @@ ng_package(
     data = [
         ":styles_bundle",
         "//src/angular-core/styles:legacy_scss",
-    ],
+    ] + glob(["i18n/**/*.xlf"]),
     entry_point = ":public-api.ts",
     entry_point_name = "angular-core",
     nested_packages = ["//src/angular-core/schematics:npm_package"],

--- a/src/angular-core/i18n/xlf/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.de-CH.xlf
@@ -81,7 +81,7 @@
       </trans-unit>
       <trans-unit id="sbbUsermenuLogin" datatype="html">
         <source>Login</source>
-        <target state="signed-off">Login</target>
+        <target state="signed-off">Anmelden</target>
       </trans-unit>
       <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
         <source>Close message</source>

--- a/src/angular-core/i18n/xlf/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.de-CH.xlf
@@ -105,7 +105,7 @@
         <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
     "/>. Click or press enter to close user menu.</source>
         <target state="translated">Angemeldet als <x id="PH" equiv-text="this.displayName || this.userName
-"/>. Klicke oder drück Enter, um das Usermenü zu schliessen.</target>
+"/>. Klicken oder Enter drücken, um das Benutzermenü zu schliessen.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/angular-core/i18n/xlf/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.de-CH.xlf
@@ -99,7 +99,7 @@
         <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
     "/>. Click or press enter to open user menu.</source>
         <target state="translated">Angemeldet als <x id="PH" equiv-text="this.displayName || this.userName
-"/>. Klicke oder drück Enter, um das Usermenü zu öffnen.</target>
+"/>. Klicken oder Enter drücken, um das Benutzermenü zu öffnen.</target>
       </trans-unit>
       <trans-unit id="sbbUsermenuClosePanel" datatype="html">
         <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName

--- a/src/angular-core/i18n/xlf/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.de-CH.xlf
@@ -56,7 +56,7 @@
       </trans-unit>
       <trans-unit id="sbbSidebarExpand" datatype="html">
         <source>Expand</source>
-        <target state="translated">Expandieren</target>
+        <target state="translated">Erweitern</target>
       </trans-unit>
       <trans-unit id="8389639288060911431" datatype="html">
         <source>Change sorting for <x id="PH" equiv-text="this.id"/></source>

--- a/src/angular-core/i18n/xlf/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.de-CH.xlf
@@ -60,7 +60,7 @@
       </trans-unit>
       <trans-unit id="8389639288060911431" datatype="html">
         <source>Change sorting for <x id="PH" equiv-text="this.id"/></source>
-        <target state="translated">Ändere die Sortierung für <x id="PH" equiv-text="this.id"/></target>
+        <target state="translated">Sortierung für <x id="PH" equiv-text="this.id"/> ändern</target>
       </trans-unit>
       <trans-unit id="sbbTabsBadgePillAmountOfEntries" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entries</source>

--- a/src/angular-core/i18n/xlf/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.de-CH.xlf
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en-CH" datatype="plaintext" original="ng2.template" target-language="de-CH">
+    <body>
+      <trans-unit id="sbbDatepickerSwitchToPreviousMonth" datatype="html">
+        <source>Change to the previous month</source>
+        <target state="signed-off">Zum letzten Monat wechseln</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToNextMonth" datatype="html">
+        <source>Change to the next month</source>
+        <target state="signed-off">Zum nächsten Monat wechseln</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToPreviousYear" datatype="html">
+        <source>Change to the previous year</source>
+        <target state="signed-off">Zum letzten Jahr wechseln</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToNextYear" datatype="html">
+        <source>Change to the next year</source>
+        <target state="signed-off">Zum nächsten Jahr wechseln</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerOpenCalendar" datatype="html">
+        <source>Show calendar</source>
+        <target state="signed-off">Kalender anzeigen</target>
+      </trans-unit>
+      <trans-unit id="sbbFileSelectorUploadFile" datatype="html">
+        <source>Upload file</source>
+        <target state="signed-off">Datei hochladen</target>
+      </trans-unit>
+      <trans-unit id="sbbFileSelectorRemoveFile" datatype="html">
+        <source>Remove file</source>
+        <target state="signed-off">Datei entfernen</target>
+      </trans-unit>
+      <trans-unit id="sbbHeaderMenuBack" datatype="html">
+        <source>Back</source>
+        <target state="signed-off">Zurück</target>
+      </trans-unit>
+      <trans-unit id="sbbNavigationPreviousPage" datatype="html">
+        <source>Previous Page</source>
+        <target state="signed-off">Vorherige Seite</target>
+      </trans-unit>
+      <trans-unit id="sbbNavigationNextPage" datatype="html">
+        <source>Next Page</source>
+        <target state="signed-off">Nächste Seite</target>
+      </trans-unit>
+      <trans-unit id="sbbPaginationPreviousPage" datatype="html">
+        <source>Previous Page</source>
+        <target state="signed-off">Vorherige Seite</target>
+      </trans-unit>
+      <trans-unit id="sbbPaginationNextPage" datatype="html">
+        <source>Next Page</source>
+        <target state="signed-off">Nächste Seite</target>
+      </trans-unit>
+      <trans-unit id="sbbSidebarCollapse" datatype="html">
+        <source>Collapse</source>
+        <target state="translated">Zusammenklappen</target>
+      </trans-unit>
+      <trans-unit id="sbbSidebarExpand" datatype="html">
+        <source>Expand</source>
+        <target state="translated">Expandieren</target>
+      </trans-unit>
+      <trans-unit id="8389639288060911431" datatype="html">
+        <source>Change sorting for <x id="PH" equiv-text="this.id"/></source>
+        <target state="translated">Ändere die Sortierung für <x id="PH" equiv-text="this.id"/></target>
+      </trans-unit>
+      <trans-unit id="sbbTabsBadgePillAmountOfEntries" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entries</source>
+        <target state="signed-off"><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> Einträge</target>
+      </trans-unit>
+      <trans-unit id="sbbTextareaCounterText" datatype="html">
+        <source> <x id="INTERPOLATION" equiv-text="  {{ _counter | async "/> characters remaining
+</source>
+        <target state="signed-off">Noch <x id="INTERPOLATION" equiv-text=" {{ _counter | async "/> Zeichen</target>
+      </trans-unit>
+      <trans-unit id="sbbTextexpandShowLess" datatype="html">
+        <source>Show less</source>
+        <target state="signed-off">Weniger anzeigen</target>
+      </trans-unit>
+      <trans-unit id="sbbTextexpandShowMore" datatype="html">
+        <source>Show more</source>
+        <target state="signed-off">Mehr anzeigen</target>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuLogin" datatype="html">
+        <source>Login</source>
+        <target state="signed-off">Login</target>
+      </trans-unit>
+      <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
+        <source>Close message</source>
+        <target state="signed-off">Hinweismeldung schliessen</target>
+      </trans-unit>
+      <trans-unit id="sbbTagBadgePillAmountOfResults" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> results available</source>
+        <target state="signed-off"><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> Resultate verfügbar</target>
+      </trans-unit>
+      <trans-unit id="sbbTagsAll" datatype="html">
+        <source>All</source>
+        <target state="signed-off">Alle</target>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuOpenPanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+    "/>. Click or press enter to open user menu.</source>
+        <target state="translated">Angemeldet als <x id="PH" equiv-text="this.displayName || this.userName
+"/>. Klicke oder drück Enter, um das Usermenü zu öffnen.</target>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuClosePanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+    "/>. Click or press enter to close user menu.</source>
+        <target state="translated">Angemeldet als <x id="PH" equiv-text="this.displayName || this.userName
+"/>. Klicke oder drück Enter, um das Usermenü zu schliessen.</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/angular-core/i18n/xlf/messages.fr-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.fr-CH.xlf
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en-CH" datatype="plaintext" original="ng2.template" target-language="fr-CH">
+    <body>
+      <trans-unit id="sbbDatepickerSwitchToPreviousMonth" datatype="html">
+        <source>Change to the previous month</source>
+        <target state="signed-off">Passer au mois précédent</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToNextMonth" datatype="html">
+        <source>Change to the next month</source>
+        <target state="signed-off">Passer au mois suivant</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToPreviousYear" datatype="html">
+        <source>Change to the previous year</source>
+        <target state="signed-off">Passer à l'année précédente</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToNextYear" datatype="html">
+        <source>Change to the next year</source>
+        <target state="signed-off">Passer à l'année suivante</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerOpenCalendar" datatype="html">
+        <source>Show calendar</source>
+        <target state="signed-off">Afficher le calendrier</target>
+      </trans-unit>
+      <trans-unit id="sbbFileSelectorUploadFile" datatype="html">
+        <source>Upload file</source>
+        <target state="translated">Télécharger le fichier</target>
+      </trans-unit>
+      <trans-unit id="sbbFileSelectorRemoveFile" datatype="html">
+        <source>Remove file</source>
+        <target state="translated">Effacer le fichier</target>
+      </trans-unit>
+      <trans-unit id="sbbHeaderMenuBack" datatype="html">
+        <source>Back</source>
+        <target state="signed-off">Retour</target>
+      </trans-unit>
+      <trans-unit id="sbbNavigationPreviousPage" datatype="html">
+        <source>Previous Page</source>
+        <target state="translated">Page précédente</target>
+      </trans-unit>
+      <trans-unit id="sbbNavigationNextPage" datatype="html">
+        <source>Next Page</source>
+        <target state="translated">Page suivante</target>
+      </trans-unit>
+      <trans-unit id="sbbPaginationPreviousPage" datatype="html">
+        <source>Previous Page</source>
+        <target state="translated">Page précédente</target>
+      </trans-unit>
+      <trans-unit id="sbbPaginationNextPage" datatype="html">
+        <source>Next Page</source>
+        <target state="translated">Page suivante</target>
+      </trans-unit>
+      <trans-unit id="sbbSidebarCollapse" datatype="html">
+        <source>Collapse</source>
+        <target state="translated">Développer</target>
+      </trans-unit>
+      <trans-unit id="sbbSidebarExpand" datatype="html">
+        <source>Expand</source>
+        <target state="translated">Réduire</target>
+      </trans-unit>
+      <trans-unit id="8389639288060911431" datatype="html">
+        <source>Change sorting for <x id="PH" equiv-text="this.id"/></source>
+        <target state="translated">Modifier le tri pour <x id="PH" equiv-text="this.id"/></target>
+      </trans-unit>
+      <trans-unit id="sbbTabsBadgePillAmountOfEntries" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entries</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entrées</target>
+      </trans-unit>
+      <trans-unit id="sbbTextareaCounterText" datatype="html">
+        <source> <x id="INTERPOLATION" equiv-text="  {{ _counter | async "/> characters remaining
+</source>
+        <target state="translated"> <x id="INTERPOLATION" equiv-text="  {{ _counter | async "/> caractères restants</target>
+      </trans-unit>
+      <trans-unit id="sbbTextexpandShowLess" datatype="html">
+        <source>Show less</source>
+        <target state="translated">Afficher moins</target>
+      </trans-unit>
+      <trans-unit id="sbbTextexpandShowMore" datatype="html">
+        <source>Show more</source>
+        <target state="translated">Afficher plus</target>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuLogin" datatype="html">
+        <source>Login</source>
+        <target state="translated">Connexion</target>
+      </trans-unit>
+      <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
+        <source>Close message</source>
+        <target state="translated">Fermer message</target>
+      </trans-unit>
+      <trans-unit id="sbbTagBadgePillAmountOfResults" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> results available</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> resultats disponbiles</target>
+      </trans-unit>
+      <trans-unit id="sbbTagsAll" datatype="html">
+        <source>All</source>
+        <target state="translated">Tous</target>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuOpenPanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+    "/>. Click or press enter to open user menu.</source>
+        <target state="translated">Connecté en tant que <x id="PH" equiv-text="this.displayName || this.userName
+"/>. Cliquez ou appuyez sur Entrée pour ouvrir le menu utilisateur.</target>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuClosePanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+    "/>. Click or press enter to close user menu.</source>
+        <target state="translated">Connecté en tant que <x id="PH" equiv-text="this.displayName || this.userName
+"/>. Cliquez ou appuyez sur Entrée pour fermer le menu utilisateur.</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/angular-core/i18n/xlf/messages.fr-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.fr-CH.xlf
@@ -81,7 +81,7 @@
       </trans-unit>
       <trans-unit id="sbbUsermenuLogin" datatype="html">
         <source>Login</source>
-        <target state="translated">Connexion</target>
+        <target state="translated">Se connecter</target>
       </trans-unit>
       <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
         <source>Close message</source>

--- a/src/angular-core/i18n/xlf/messages.it-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.it-CH.xlf
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en-CH" datatype="plaintext" original="ng2.template" target-language="it-CH">
+    <body>
+      <trans-unit id="sbbDatepickerSwitchToPreviousMonth" datatype="html">
+        <source>Change to the previous month</source>
+        <target state="signed-off">Passare al mese precedente</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToNextMonth" datatype="html">
+        <source>Change to the next month</source>
+        <target state="signed-off">Passare al mese successivo</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToPreviousYear" datatype="html">
+        <source>Change to the previous year</source>
+        <target state="signed-off">Passare all’anno precedente</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToNextYear" datatype="html">
+        <source>Change to the next year</source>
+        <target state="signed-off">Passare all’anno successivo</target>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerOpenCalendar" datatype="html">
+        <source>Show calendar</source>
+        <target state="signed-off">Visualizzare calendario</target>
+      </trans-unit>
+      <trans-unit id="sbbFileSelectorUploadFile" datatype="html">
+        <source>Upload file</source>
+        <target state="translated">Caricare un file</target>
+      </trans-unit>
+      <trans-unit id="sbbFileSelectorRemoveFile" datatype="html">
+        <source>Remove file</source>
+        <target state="translated">Rimuovi il file</target>
+      </trans-unit>
+      <trans-unit id="sbbHeaderMenuBack" datatype="html">
+        <source>Back</source>
+        <target state="signed-off">Indietro</target>
+      </trans-unit>
+      <trans-unit id="sbbNavigationPreviousPage" datatype="html">
+        <source>Previous Page</source>
+        <target state="translated">Pagina precedente</target>
+      </trans-unit>
+      <trans-unit id="sbbNavigationNextPage" datatype="html">
+        <source>Next Page</source>
+        <target state="translated">Pagina successiva</target>
+      </trans-unit>
+      <trans-unit id="sbbPaginationPreviousPage" datatype="html">
+        <source>Previous Page</source>
+        <target state="translated">Pagina precedente</target>
+      </trans-unit>
+      <trans-unit id="sbbPaginationNextPage" datatype="html">
+        <source>Next Page</source>
+        <target state="translated">Pagina successiva</target>
+      </trans-unit>
+      <trans-unit id="sbbSidebarCollapse" datatype="html">
+        <source>Collapse</source>
+        <target state="translated">Comprimi</target>
+      </trans-unit>
+      <trans-unit id="sbbSidebarExpand" datatype="html">
+        <source>Expand</source>
+        <target state="translated">Espandi</target>
+      </trans-unit>
+      <trans-unit id="8389639288060911431" datatype="html">
+        <source>Change sorting for <x id="PH" equiv-text="this.id"/></source>
+        <target state="translated">Cambia l'ordinamento per <x id="PH" equiv-text="this.id"/></target>
+      </trans-unit>
+      <trans-unit id="sbbTabsBadgePillAmountOfEntries" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entries</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> voci</target>
+      </trans-unit>
+      <trans-unit id="sbbTextareaCounterText" datatype="html">
+        <source> <x id="INTERPOLATION" equiv-text="  {{ _counter | async "/> characters remaining
+</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text=" {{ _counter | async "/> caratteri rimanenti</target>
+      </trans-unit>
+      <trans-unit id="sbbTextexpandShowLess" datatype="html">
+        <source>Show less</source>
+        <target state="signed-off">Visualizzare di meno</target>
+      </trans-unit>
+      <trans-unit id="sbbTextexpandShowMore" datatype="html">
+        <source>Show more</source>
+        <target state="signed-off">Visualizzare di più</target>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuLogin" datatype="html">
+        <source>Login</source>
+        <target state="signed-off">Accedi</target>
+      </trans-unit>
+      <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
+        <source>Close message</source>
+        <target state="translated">Chiudere il messaggio</target>
+      </trans-unit>
+      <trans-unit id="sbbTagBadgePillAmountOfResults" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> results available</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> risultati disponibili</target>
+      </trans-unit>
+      <trans-unit id="sbbTagsAll" datatype="html">
+        <source>All</source>
+        <target state="translated">Tutte</target>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuOpenPanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+    "/>. Click or press enter to open user menu.</source>
+        <target state="translated">Accesso eseguito come <x id="PH" equiv-text="this.displayName || this.userName
+"/>. Fare clic o premere Invio per aprire il menu utente.</target>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuClosePanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+    "/>. Click or press enter to close user menu.</source>
+        <target state="translated">Accesso eseguito come <x id="PH" equiv-text="this.displayName || this.userName
+"/>. Fare clic o premere Invio per chiudere il menu utente.</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/angular-core/i18n/xlf/messages.xlf
+++ b/src/angular-core/i18n/xlf/messages.xlf
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en-CH" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="sbbDatepickerSwitchToPreviousMonth" datatype="html">
+        <source>Change to the previous month</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/datepicker/calendar/calendar-header.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/datepicker/calendar/calendar-header.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Button label to switch to the previous month</note>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToNextMonth" datatype="html">
+        <source>Change to the next month</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/datepicker/calendar/calendar-header.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/datepicker/calendar/calendar-header.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Button label to switch to the next month</note>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToPreviousYear" datatype="html">
+        <source>Change to the previous year</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/datepicker/calendar/calendar-header.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/datepicker/calendar/calendar-header.component.html</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+        <note priority="1" from="description">Button label to switch to the previous year</note>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerSwitchToNextYear" datatype="html">
+        <source>Change to the next year</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/datepicker/calendar/calendar-header.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/datepicker/calendar/calendar-header.component.html</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+        <note priority="1" from="description">Button label to switch to the next year</note>
+      </trans-unit>
+      <trans-unit id="sbbDatepickerOpenCalendar" datatype="html">
+        <source>Show calendar</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/datepicker/datepicker-toggle/datepicker-toggle.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/datepicker/datepicker-toggle/datepicker-toggle.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Open calendar</note>
+      </trans-unit>
+      <trans-unit id="sbbFileSelectorUploadFile" datatype="html">
+        <source>Upload file</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/file-selector/file-selector/file-selector.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/file-selector/file-selector/file-selector.component.html</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">Button label to select files for upload</note>
+      </trans-unit>
+      <trans-unit id="sbbFileSelectorRemoveFile" datatype="html">
+        <source>Remove file</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/file-selector/file-selector/file-selector.component.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/file-selector/file-selector/file-selector.component.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+        <note priority="1" from="description">Hidden button label to remove a file from the selection list</note>
+      </trans-unit>
+      <trans-unit id="sbbHeaderMenuBack" datatype="html">
+        <source>Back</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/header/header-menu/header-menu.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <note priority="1" from="description">Go back to the app chooser navigation</note>
+      </trans-unit>
+      <trans-unit id="sbbNavigationPreviousPage" datatype="html">
+        <source>Previous Page</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/pagination/navigation/navigation.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/pagination/navigation/navigation.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Button label to navigate to the previous page</note>
+      </trans-unit>
+      <trans-unit id="sbbNavigationNextPage" datatype="html">
+        <source>Next Page</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/pagination/navigation/navigation.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/pagination/navigation/navigation.component.html</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">Button label to navigate to the next page</note>
+      </trans-unit>
+      <trans-unit id="sbbPaginationPreviousPage" datatype="html">
+        <source>Previous Page</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/pagination/pagination/pagination.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/pagination/paginator/paginator.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/pagination/pagination/pagination.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/pagination/paginator/paginator.component.html</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">Button label to navigate to the previous page</note>
+      </trans-unit>
+      <trans-unit id="sbbPaginationNextPage" datatype="html">
+        <source>Next Page</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/pagination/pagination/pagination.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/pagination/paginator/paginator.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/pagination/pagination/pagination.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/pagination/paginator/paginator.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+        <note priority="1" from="description">Button label to navigate to the next page</note>
+      </trans-unit>
+      <trans-unit id="sbbSidebarCollapse" datatype="html">
+        <source>Collapse</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">Label to &apos;collapse&apos; icon sidebar</note>
+      </trans-unit>
+      <trans-unit id="sbbSidebarExpand" datatype="html">
+        <source>Expand</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <note priority="1" from="description">Label to &apos;expand&apos; icon sidebar</note>
+      </trans-unit>
+      <trans-unit id="sbbTableChangeSorting" datatype="html">
+        <source>Change sorting for <x id="PH" equiv-text="this.id"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/table/sort-header/sort-header.component.ts</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+        <note priority="1" from="description">Button label to change the sorting of column</note>
+      </trans-unit>
+      <trans-unit id="sbbTabsBadgePillAmountOfEntries" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entries</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/tabs/tabs/tabs.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/tabs/tabs/tabs.component.html</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">Aria label for amount of entries displayed in badge pill</note>
+      </trans-unit>
+      <trans-unit id="sbbTextareaCounterText" datatype="html">
+        <source> <x id="INTERPOLATION" equiv-text="  {{ _counter | async "/> characters remaining
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/textarea/textarea/textarea.component.html</context>
+          <context context-type="linenumber">19,20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/textarea/textarea/textarea.component.html</context>
+          <context context-type="linenumber">19,20</context>
+        </context-group>
+        <note priority="1" from="description">Counter text for textarea</note>
+      </trans-unit>
+      <trans-unit id="sbbTextexpandShowLess" datatype="html">
+        <source>Show less</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/textexpand/textexpand/textexpand.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/textexpand/textexpand/textexpand.component.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+        <note priority="1" from="description">Button label for showing less</note>
+      </trans-unit>
+      <trans-unit id="sbbTextexpandShowMore" datatype="html">
+        <source>Show more</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/textexpand/textexpand/textexpand.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/textexpand/textexpand/textexpand.component.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <note priority="1" from="description">Button label for showing more</note>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuLogin" datatype="html">
+        <source>Login</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/usermenu/usermenu.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/usermenu/usermenu.html</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">Button label for login</note>
+      </trans-unit>
+      <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
+        <source>Close message</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/ghettobox/ghettobox/ghettobox.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <note priority="1" from="description">Hidden button label to close the ghettobox</note>
+      </trans-unit>
+      <trans-unit id="sbbTagBadgePillAmountOfResults" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> results available</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/tag/tag/tag.component.html</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/tag/tag/tag.component.html</context>
+          <context context-type="linenumber">43</context>
+        </context-group>
+        <note priority="1" from="description">Aria label for amount of results displayed in badge pill</note>
+      </trans-unit>
+      <trans-unit id="sbbTagsAll" datatype="html">
+        <source>All</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/tag/tags/tags.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">Label for the &apos;All&apos; tag</note>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuOpenPanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+    "/>. Click or press enter to open user menu.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/usermenu/usermenu.ts</context>
+          <context context-type="linenumber">196,198</context>
+        </context-group>
+        <note priority="1" from="description">Aria label to open user menu</note>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuClosePanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+    "/>. Click or press enter to close user menu.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/usermenu/usermenu.ts</context>
+          <context context-type="linenumber">203,205</context>
+        </context-group>
+        <note priority="1" from="description">Aria label to close user menu</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/angular-core/i18n/xlf2/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.de-CH.xlf
@@ -145,7 +145,7 @@
         <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
     "/>. Click or press enter to open user menu.</source>
         <target>Angemeldet als <ph id="0" equiv="PH" disp="this.displayName || this.userName
-"/>. Klicke oder drück Enter, um das Usermenü zu öffnen.</target>
+"/>. Klicken oder Enter drücken, um das Benutzermenü zu öffnen.</target>
       </segment>
     </unit>
     <unit id="sbbUsermenuClosePanel">

--- a/src/angular-core/i18n/xlf2/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.de-CH.xlf
@@ -153,7 +153,7 @@
         <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
     "/>. Click or press enter to close user menu.</source>
         <target>Angemeldet als <ph id="0" equiv="PH" disp="this.displayName || this.userName
-"/>. Klicke oder drück Enter, um das Usermenü zu schliessen.</target>
+"/>. Klicken oder Enter drücken, um das Benutzermenü zu schliessen.</target>
       </segment>
     </unit>
   </file>

--- a/src/angular-core/i18n/xlf2/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.de-CH.xlf
@@ -82,7 +82,7 @@
     <unit id="sbbSidebarExpand">
       <segment state="translated">
         <source>Expand</source>
-        <target>Expandieren</target>
+        <target>Erweitern</target>
       </segment>
     </unit>
     <unit id="8389639288060911431">

--- a/src/angular-core/i18n/xlf2/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.de-CH.xlf
@@ -88,7 +88,7 @@
     <unit id="8389639288060911431">
       <segment state="translated">
         <source>Change sorting for <ph id="0" equiv="PH" disp="this.id"/></source>
-        <target>Ändere die Sortierung für  <ph id="0" equiv="PH" disp="this.id"/></target>
+        <target>Sortierung für <ph id="0" equiv="PH" disp="this.id"/> ändern</target>
       </segment>
     </unit>
     <unit id="sbbTabsBadgePillAmountOfEntries">

--- a/src/angular-core/i18n/xlf2/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.de-CH.xlf
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-CH" trgLang="de-CH">
+  <file original="ng.template" id="ngi18n">
+    <unit id="sbbDatepickerSwitchToPreviousMonth">
+      <segment state="reviewed">
+        <source>Change to the previous month</source>
+        <target>Zum letzten Monat wechseln</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToNextMonth">
+      <segment state="reviewed">
+        <source>Change to the next month</source>
+        <target>Zum nächsten Monat wechseln</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToPreviousYear">
+      <segment state="reviewed">
+        <source>Change to the previous year</source>
+        <target>Zum letzten Jahr wechseln</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToNextYear">
+      <segment state="reviewed">
+        <source>Change to the next year</source>
+        <target>Zum nächsten Jahr wechseln</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerOpenCalendar">
+      <segment state="reviewed">
+        <source>Show calendar</source>
+        <target>Kalender anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="sbbFileSelectorUploadFile">
+      <segment state="reviewed">
+        <source>Upload file</source>
+        <target>Datei hochladen</target>
+      </segment>
+    </unit>
+    <unit id="sbbFileSelectorRemoveFile">
+      <segment state="reviewed">
+        <source>Remove file</source>
+        <target>Datei entfernen</target>
+      </segment>
+    </unit>
+    <unit id="sbbHeaderMenuBack">
+      <segment state="reviewed">
+        <source>Back</source>
+        <target>Zurück</target>
+      </segment>
+    </unit>
+    <unit id="sbbNavigationPreviousPage">
+      <segment state="reviewed">
+        <source>Previous Page</source>
+        <target>Vorherige Seite</target>
+      </segment>
+    </unit>
+    <unit id="sbbNavigationNextPage">
+      <segment state="reviewed">
+        <source>Next Page</source>
+        <target>Nächste Seite</target>
+      </segment>
+    </unit>
+    <unit id="sbbPaginationPreviousPage">
+      <segment state="reviewed">
+        <source>Previous Page</source>
+        <target>Vorherige Seite</target>
+      </segment>
+    </unit>
+    <unit id="sbbPaginationNextPage">
+      <segment state="reviewed">
+        <source>Next Page</source>
+        <target>Nächste Seite</target>
+      </segment>
+    </unit>
+    <unit id="sbbSidebarCollapse">
+      <segment state="translated">
+        <source>Collapse</source>
+        <target>Zusammenklappen</target>
+      </segment>
+    </unit>
+    <unit id="sbbSidebarExpand">
+      <segment state="translated">
+        <source>Expand</source>
+        <target>Expandieren</target>
+      </segment>
+    </unit>
+    <unit id="8389639288060911431">
+      <segment state="translated">
+        <source>Change sorting for <ph id="0" equiv="PH" disp="this.id"/></source>
+        <target>Ändere die Sortierung für  <ph id="0" equiv="PH" disp="this.id"/></target>
+      </segment>
+    </unit>
+    <unit id="sbbTabsBadgePillAmountOfEntries">
+      <segment state="reviewed">
+        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> entries</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> Einträge</target>
+      </segment>
+    </unit>
+    <unit id="sbbTextareaCounterText">
+      <segment state="reviewed">
+        <source> <ph id="0" equiv="INTERPOLATION" disp="  {{ _counter | async "/> characters remaining
+</source>
+        <target>Noch <ph id="0" equiv="INTERPOLATION" disp=" {{ _counter | async "/> Zeichen</target>
+      </segment>
+    </unit>
+    <unit id="sbbTextexpandShowLess">
+      <segment state="reviewed">
+        <source>Show less</source>
+        <target>Weniger anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="sbbTextexpandShowMore">
+      <segment state="reviewed">
+        <source>Show more</source>
+        <target>Mehr anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuLogin">
+      <segment state="reviewed">
+        <source>Login</source>
+        <target>Login</target>
+      </segment>
+    </unit>
+    <unit id="sbbGhettoboxCloseGhettobox">
+      <segment state="reviewed">
+        <source>Close message</source>
+        <target>Hinweismeldung schliessen</target>
+      </segment>
+    </unit>
+    <unit id="sbbTagBadgePillAmountOfResults">
+      <segment state="reviewed">
+        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> results available</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> Resultate verfügbar</target>
+      </segment>
+    </unit>
+    <unit id="sbbTagsAll">
+      <segment state="reviewed">
+        <source>All</source>
+        <target>Alle</target>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuOpenPanel">
+      <segment state="translated">
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+    "/>. Click or press enter to open user menu.</source>
+        <target>Angemeldet als <ph id="0" equiv="PH" disp="this.displayName || this.userName
+"/>. Klicke oder drück Enter, um das Usermenü zu öffnen.</target>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuClosePanel">
+      <segment state="translated">
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+    "/>. Click or press enter to close user menu.</source>
+        <target>Angemeldet als <ph id="0" equiv="PH" disp="this.displayName || this.userName
+"/>. Klicke oder drück Enter, um das Usermenü zu schliessen.</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/src/angular-core/i18n/xlf2/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.de-CH.xlf
@@ -119,7 +119,7 @@
     <unit id="sbbUsermenuLogin">
       <segment state="reviewed">
         <source>Login</source>
-        <target>Login</target>
+        <target>Anmelden</target>
       </segment>
     </unit>
     <unit id="sbbGhettoboxCloseGhettobox">

--- a/src/angular-core/i18n/xlf2/messages.fr-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.fr-CH.xlf
@@ -119,7 +119,7 @@
     <unit id="sbbUsermenuLogin">
       <segment state="translated">
         <source>Login</source>
-        <target>Connexion</target>
+        <target>Se connecter</target>
       </segment>
     </unit>
     <unit id="sbbGhettoboxCloseGhettobox">

--- a/src/angular-core/i18n/xlf2/messages.fr-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.fr-CH.xlf
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-CH" trgLang="fr-CH">
+  <file original="ng.template" id="ngi18n">
+    <unit id="sbbDatepickerSwitchToPreviousMonth">
+      <segment state="reviewed">
+        <source>Change to the previous month</source>
+        <target>Passer au mois précédent</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToNextMonth">
+      <segment state="reviewed">
+        <source>Change to the next month</source>
+        <target>Passer au mois suivant</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToPreviousYear">
+      <segment state="reviewed">
+        <source>Change to the previous year</source>
+        <target>Passer à l'année précédente</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToNextYear">
+      <segment state="reviewed">
+        <source>Change to the next year</source>
+        <target>Passer à l'année suivante</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerOpenCalendar">
+      <segment state="reviewed">
+        <source>Show calendar</source>
+        <target>Afficher le calendrier</target>
+      </segment>
+    </unit>
+    <unit id="sbbFileSelectorUploadFile">
+      <segment state="translated">
+        <source>Upload file</source>
+        <target>Télécharger le fichier</target>
+      </segment>
+    </unit>
+    <unit id="sbbFileSelectorRemoveFile">
+      <segment state="translated">
+        <source>Remove file</source>
+        <target>Effacer le fichier</target>
+      </segment>
+    </unit>
+    <unit id="sbbHeaderMenuBack">
+      <segment state="reviewed">
+        <source>Back</source>
+        <target>Retour</target>
+      </segment>
+    </unit>
+    <unit id="sbbNavigationPreviousPage">
+      <segment state="translated">
+        <source>Previous Page</source>
+        <target>Page précédente</target>
+      </segment>
+    </unit>
+    <unit id="sbbNavigationNextPage">
+      <segment state="translated">
+        <source>Next Page</source>
+        <target>Page suivante</target>
+      </segment>
+    </unit>
+    <unit id="sbbPaginationPreviousPage">
+      <segment state="translated">
+        <source>Previous Page</source>
+        <target>Page précédente</target>
+      </segment>
+    </unit>
+    <unit id="sbbPaginationNextPage">
+      <segment state="translated">
+        <source>Next Page</source>
+        <target>Page suivante</target>
+      </segment>
+    </unit>
+    <unit id="sbbSidebarCollapse">
+      <segment state="translated">
+        <source>Collapse</source>
+        <target>Développer</target>
+      </segment>
+    </unit>
+    <unit id="sbbSidebarExpand">
+      <segment state="translated">
+        <source>Expand</source>
+        <target>Réduire</target>
+      </segment>
+    </unit>
+    <unit id="8389639288060911431">
+      <segment state="translated">
+        <source>Change sorting for <ph id="0" equiv="PH" disp="this.id"/></source>
+        <target>Modifier le tri pour <ph id="0" equiv="PH" disp="this.id"/></target>
+      </segment>
+    </unit>
+    <unit id="sbbTabsBadgePillAmountOfEntries">
+      <segment state="translated">
+        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> entries</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> entrées</target>
+      </segment>
+    </unit>
+    <unit id="sbbTextareaCounterText">
+      <segment state="translated">
+        <source> <ph id="0" equiv="INTERPOLATION" disp="  {{ _counter | async "/> characters remaining
+</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp=" {{ _counter | async "/> caractères restants</target>
+      </segment>
+    </unit>
+    <unit id="sbbTextexpandShowLess">
+      <segment state="translated">
+        <source>Show less</source>
+        <target>Afficher moins</target>
+      </segment>
+    </unit>
+    <unit id="sbbTextexpandShowMore">
+      <segment state="translated">
+        <source>Show more</source>
+        <target>Afficher plus</target>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuLogin">
+      <segment state="translated">
+        <source>Login</source>
+        <target>Connexion</target>
+      </segment>
+    </unit>
+    <unit id="sbbGhettoboxCloseGhettobox">
+      <segment state="translated">
+        <source>Close message</source>
+        <target>Fermer message</target>
+      </segment>
+    </unit>
+    <unit id="sbbTagBadgePillAmountOfResults">
+      <segment state="translated">
+        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> results available</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> resultats disponbiles</target>
+      </segment>
+    </unit>
+    <unit id="sbbTagsAll">
+      <segment state="translated">
+        <source>All</source>
+        <target>Tous</target>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuOpenPanel">
+      <segment state="translated">
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+    "/>. Click or press enter to open user menu.</source>
+        <target>Connecté en tant que <ph id="0" equiv="PH" disp="this.displayName || this.userName
+"/>. Cliquez ou appuyez sur Entrée pour ouvrir le menu utilisateur.</target>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuClosePanel">
+      <segment state="translated">
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+    "/>. Click or press enter to close user menu.</source>
+        <target>Connecté en tant que <ph id="0" equiv="PH" disp="this.displayName || this.userName
+"/>. Cliquez ou appuyez sur Entrée pour fermer le menu utilisateur.</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/src/angular-core/i18n/xlf2/messages.it-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.it-CH.xlf
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-CH" trgLang="it-CH">
+  <file original="ng.template" id="ngi18n">
+    <unit id="sbbDatepickerSwitchToPreviousMonth">
+      <segment state="reviewed">
+        <source>Change to the previous month</source>
+        <target>Passare al mese precedente</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToNextMonth">
+      <segment state="reviewed">
+        <source>Change to the next month</source>
+        <target>Passare al mese successivo</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToPreviousYear">
+      <segment state="reviewed">
+        <source>Change to the previous year</source>
+        <target>Passare all’anno precedente</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToNextYear">
+      <segment state="reviewed">
+        <source>Change to the next year</source>
+        <target>Passare all’anno successivo</target>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerOpenCalendar">
+      <segment state="reviewed">
+        <source>Show calendar</source>
+        <target>Visualizzare calendario</target>
+      </segment>
+    </unit>
+    <unit id="sbbFileSelectorUploadFile">
+      <segment state="translated">
+        <source>Upload file</source>
+        <target>Caricare un file</target>
+      </segment>
+    </unit>
+    <unit id="sbbFileSelectorRemoveFile">
+      <segment state="translated">
+        <source>Remove file</source>
+        <target>Rimuovi il file</target>
+      </segment>
+    </unit>
+    <unit id="sbbHeaderMenuBack">
+      <segment state="translated">
+        <source>Back</source>
+        <target>Indietro</target>
+      </segment>
+    </unit>
+    <unit id="sbbNavigationPreviousPage">
+      <segment state="translated">
+        <source>Previous Page</source>
+        <target>Pagina precedente</target>
+      </segment>
+    </unit>
+    <unit id="sbbNavigationNextPage">
+      <segment state="translated">
+        <source>Next Page</source>
+        <target>Pagina successiva</target>
+      </segment>
+    </unit>
+    <unit id="sbbPaginationPreviousPage">
+      <segment state="translated">
+        <source>Previous Page</source>
+        <target>Pagina precedente</target>
+      </segment>
+    </unit>
+    <unit id="sbbPaginationNextPage">
+      <segment state="translated">
+        <source>Next Page</source>
+        <target>Pagina successiva</target>
+      </segment>
+    </unit>
+    <unit id="sbbSidebarCollapse">
+      <segment state="translated">
+        <source>Collapse</source>
+        <target>Comprimi</target>
+      </segment>
+    </unit>
+    <unit id="sbbSidebarExpand">
+      <segment state="translated">
+        <source>Expand</source>
+        <target>Espandi</target>
+      </segment>
+    </unit>
+    <unit id="8389639288060911431">
+      <segment state="translated">
+        <source>Change sorting for <ph id="0" equiv="PH" disp="this.id"/></source>
+        <target>Cambia l'ordinamento per <ph id="0" equiv="PH" disp="this.id"/></target>
+      </segment>
+    </unit>
+    <unit id="sbbTabsBadgePillAmountOfEntries">
+      <segment state="translated">
+        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> entries</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> voci</target>
+      </segment>
+    </unit>
+    <unit id="sbbTextareaCounterText">
+      <segment state="translated">
+        <source> <ph id="0" equiv="INTERPOLATION" disp="  {{ _counter | async "/> characters remaining
+</source>
+        <target><x id="INTERPOLATION" equiv-text=" {{ _counter | async "/> caratteri rimanenti</target>
+      </segment>
+    </unit>
+    <unit id="sbbTextexpandShowLess">
+      <segment state="translated">
+        <source>Show less</source>
+        <target>Visualizzare di meno</target>
+      </segment>
+    </unit>
+    <unit id="sbbTextexpandShowMore">
+      <segment state="translated">
+        <source>Show more</source>
+        <target>Visualizzare di più</target>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuLogin">
+      <segment state="translated">
+        <source>Login</source>
+        <target>Accedi</target>
+      </segment>
+    </unit>
+    <unit id="sbbGhettoboxCloseGhettobox">
+      <segment state="translated">
+        <source>Close message</source>
+        <target>Chiudere il messaggio</target>
+      </segment>
+    </unit>
+    <unit id="sbbTagBadgePillAmountOfResults">
+      <segment state="translated">
+        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> results available</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> risultati disponibili</target>
+      </segment>
+    </unit>
+    <unit id="sbbTagsAll">
+      <segment state="translated">
+        <source>All</source>
+        <target>Tutte</target>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuOpenPanel">
+      <segment state="translated">
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+    "/>. Click or press enter to open user menu.</source>
+        <target>Accesso eseguito come <ph id="0" equiv="PH" disp="this.displayName || this.userName
+"/>. Fare clic o premere Invio per aprire il menu utente.</target>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuClosePanel">
+      <segment state="translated">
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+    "/>. Click or press enter to close user menu.</source>
+        <target>Accesso eseguito come <ph id="0" equiv="PH" disp="this.displayName || this.userName
+"/>. Fare clic o premere Invio per chiudere il menu utente.</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/src/angular-core/i18n/xlf2/messages.xlf
+++ b/src/angular-core/i18n/xlf2/messages.xlf
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-CH">
+  <file id="ngi18n" original="ng.template">
+    <unit id="sbbDatepickerSwitchToPreviousMonth">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/datepicker/calendar/calendar-header.component.html:11</note>
+        <note category="location">../../../../../../src/angular-public/datepicker/calendar/calendar-header.component.html:11</note>
+        <note category="description">Button label to switch to the previous month</note>
+      </notes>
+      <segment>
+        <source>Change to the previous month</source>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToNextMonth">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/datepicker/calendar/calendar-header.component.html:27</note>
+        <note category="location">../../../../../../src/angular-public/datepicker/calendar/calendar-header.component.html:27</note>
+        <note category="description">Button label to switch to the next month</note>
+      </notes>
+      <segment>
+        <source>Change to the next month</source>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToPreviousYear">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/datepicker/calendar/calendar-header.component.html:40</note>
+        <note category="location">../../../../../../src/angular-public/datepicker/calendar/calendar-header.component.html:40</note>
+        <note category="description">Button label to switch to the previous year</note>
+      </notes>
+      <segment>
+        <source>Change to the previous year</source>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerSwitchToNextYear">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/datepicker/calendar/calendar-header.component.html:53</note>
+        <note category="location">../../../../../../src/angular-public/datepicker/calendar/calendar-header.component.html:53</note>
+        <note category="description">Button label to switch to the next year</note>
+      </notes>
+      <segment>
+        <source>Change to the next year</source>
+      </segment>
+    </unit>
+    <unit id="sbbDatepickerOpenCalendar">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/datepicker/datepicker-toggle/datepicker-toggle.component.html:4</note>
+        <note category="location">../../../../../../src/angular-public/datepicker/datepicker-toggle/datepicker-toggle.component.html:4</note>
+        <note category="description">Open calendar</note>
+      </notes>
+      <segment>
+        <source>Show calendar</source>
+      </segment>
+    </unit>
+    <unit id="sbbFileSelectorUploadFile">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/file-selector/file-selector/file-selector.component.html:16</note>
+        <note category="location">../../../../../../src/angular-public/file-selector/file-selector/file-selector.component.html:16</note>
+        <note category="description">Button label to select files for upload</note>
+      </notes>
+      <segment>
+        <source>Upload file</source>
+      </segment>
+    </unit>
+    <unit id="sbbFileSelectorRemoveFile">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/file-selector/file-selector/file-selector.component.html:59</note>
+        <note category="location">../../../../../../src/angular-public/file-selector/file-selector/file-selector.component.html:59</note>
+        <note category="description">Hidden button label to remove a file from the selection list</note>
+      </notes>
+      <segment>
+        <source>Remove file</source>
+      </segment>
+    </unit>
+    <unit id="sbbHeaderMenuBack">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/header/header-menu/header-menu.component.html:3</note>
+        <note category="description">Go back to the app chooser navigation</note>
+      </notes>
+      <segment>
+        <source>Back</source>
+      </segment>
+    </unit>
+    <unit id="sbbNavigationPreviousPage">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/pagination/navigation/navigation.component.html:6</note>
+        <note category="location">../../../../../../src/angular-public/pagination/navigation/navigation.component.html:6</note>
+        <note category="description">Button label to navigate to the previous page</note>
+      </notes>
+      <segment>
+        <source>Previous Page</source>
+      </segment>
+    </unit>
+    <unit id="sbbNavigationNextPage">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/pagination/navigation/navigation.component.html:22</note>
+        <note category="location">../../../../../../src/angular-public/pagination/navigation/navigation.component.html:22</note>
+        <note category="description">Button label to navigate to the next page</note>
+      </notes>
+      <segment>
+        <source>Next Page</source>
+      </segment>
+    </unit>
+    <unit id="sbbPaginationPreviousPage">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/pagination/pagination/pagination.component.html:6</note>
+        <note category="location">../../../../../../src/angular-business/pagination/paginator/paginator.component.html:6</note>
+        <note category="location">../../../../../../src/angular-public/pagination/pagination/pagination.component.html:6</note>
+        <note category="location">../../../../../../src/angular-public/pagination/paginator/paginator.component.html:6</note>
+        <note category="description">Button label to navigate to the previous page</note>
+      </notes>
+      <segment>
+        <source>Previous Page</source>
+      </segment>
+    </unit>
+    <unit id="sbbPaginationNextPage">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/pagination/pagination/pagination.component.html:37</note>
+        <note category="location">../../../../../../src/angular-business/pagination/paginator/paginator.component.html:42</note>
+        <note category="location">../../../../../../src/angular-public/pagination/pagination/pagination.component.html:37</note>
+        <note category="location">../../../../../../src/angular-public/pagination/paginator/paginator.component.html:42</note>
+        <note category="description">Button label to navigate to the next page</note>
+      </notes>
+      <segment>
+        <source>Next Page</source>
+      </segment>
+    </unit>
+    <unit id="sbbSidebarCollapse">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html:18</note>
+        <note category="description">Label to &apos;collapse&apos; icon sidebar</note>
+      </notes>
+      <segment>
+        <source>Collapse</source>
+      </segment>
+    </unit>
+    <unit id="sbbSidebarExpand">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html:25</note>
+        <note category="description">Label to &apos;expand&apos; icon sidebar</note>
+      </notes>
+      <segment>
+        <source>Expand</source>
+      </segment>
+    </unit>
+    <unit id="sbbTableChangeSorting">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/table/sort-header/sort-header.component.ts:93</note>
+        <note category="description">Button label to change the sorting of column</note>
+      </notes>
+      <segment>
+        <source>Change sorting for <ph id="0" equiv="PH" disp="this.id"/></source>
+      </segment>
+    </unit>
+    <unit id="sbbTabsBadgePillAmountOfEntries">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/tabs/tabs/tabs.component.html:25</note>
+        <note category="location">../../../../../../src/angular-public/tabs/tabs/tabs.component.html:27</note>
+        <note category="description">Aria label for amount of entries displayed in badge pill</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> entries</source>
+      </segment>
+    </unit>
+    <unit id="sbbTextareaCounterText">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/textarea/textarea/textarea.component.html:19,20</note>
+        <note category="location">../../../../../../src/angular-public/textarea/textarea/textarea.component.html:19,20</note>
+        <note category="description">Counter text for textarea</note>
+      </notes>
+      <segment>
+        <source> <ph id="0" equiv="INTERPOLATION" disp="  {{ _counter | async "/> characters remaining
+</source>
+      </segment>
+    </unit>
+    <unit id="sbbTextexpandShowLess">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/textexpand/textexpand/textexpand.component.html:14</note>
+        <note category="location">../../../../../../src/angular-public/textexpand/textexpand/textexpand.component.html:14</note>
+        <note category="description">Button label for showing less</note>
+      </notes>
+      <segment>
+        <source>Show less</source>
+      </segment>
+    </unit>
+    <unit id="sbbTextexpandShowMore">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/textexpand/textexpand/textexpand.component.html:20</note>
+        <note category="location">../../../../../../src/angular-public/textexpand/textexpand/textexpand.component.html:20</note>
+        <note category="description">Button label for showing more</note>
+      </notes>
+      <segment>
+        <source>Show more</source>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuLogin">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/usermenu/usermenu.html:10</note>
+        <note category="location">../../../../../../src/angular-public/usermenu/usermenu.html:10</note>
+        <note category="description">Button label for login</note>
+      </notes>
+      <segment>
+        <source>Login</source>
+      </segment>
+    </unit>
+    <unit id="sbbGhettoboxCloseGhettobox">
+      <notes>
+        <note category="location">../../../../../../src/angular-public/ghettobox/ghettobox/ghettobox.component.html:47</note>
+        <note category="description">Hidden button label to close the ghettobox</note>
+      </notes>
+      <segment>
+        <source>Close message</source>
+      </segment>
+    </unit>
+    <unit id="sbbTagBadgePillAmountOfResults">
+      <notes>
+        <note category="location">../../../../../../src/angular-public/tag/tag/tag.component.html:8</note>
+        <note category="location">../../../../../../src/angular-public/tag/tag/tag.component.html:43</note>
+        <note category="description">Aria label for amount of results displayed in badge pill</note>
+      </notes>
+      <segment>
+        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> results available</source>
+      </segment>
+    </unit>
+    <unit id="sbbTagsAll">
+      <notes>
+        <note category="location">../../../../../../src/angular-public/tag/tags/tags.component.html:4</note>
+        <note category="description">Label for the &apos;All&apos; tag</note>
+      </notes>
+      <segment>
+        <source>All</source>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuOpenPanel">
+      <notes>
+        <note category="location">../../../../../../src/angular-public/usermenu/usermenu.ts:196,198</note>
+        <note category="description">Aria label to open user menu</note>
+      </notes>
+      <segment>
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+    "/>. Click or press enter to open user menu.</source>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuClosePanel">
+      <notes>
+        <note category="location">../../../../../../src/angular-public/usermenu/usermenu.ts:203,205</note>
+        <note category="description">Aria label to close user menu</note>
+      </notes>
+      <segment>
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+    "/>. Click or press enter to close user menu.</source>
+      </segment>
+    </unit>
+  </file>
+</xliff>

--- a/src/angular-public/BUILD.bazel
+++ b/src/angular-public/BUILD.bazel
@@ -56,6 +56,7 @@ markdown_to_html(
     srcs = [
         ":README.md",
         ":getting-started.md",
+        ":i18n.md",
         ":typography.md",
     ],
 )

--- a/src/angular-public/accordion/accordion/accordion.directive.spec.ts
+++ b/src/angular-public/accordion/accordion/accordion.directive.spec.ts
@@ -13,7 +13,6 @@ import {
   SbbExpansionPanelHeader,
 } from '../public-api';
 
-// tslint:disable:i18n
 @Component({
   template: `
     <sbb-accordion [multi]="multi">

--- a/src/angular-public/accordion/expansion-panel/expansion-panel.component.spec.ts
+++ b/src/angular-public/accordion/expansion-panel/expansion-panel.component.spec.ts
@@ -15,7 +15,6 @@ import { dispatchKeyboardEvent } from '@sbb-esta/angular-core/testing';
 
 import { SbbAccordionModule, SbbExpansionPanel } from '../public-api';
 
-// tslint:disable:i18n
 @Component({
   template: `
     <sbb-expansion-panel

--- a/src/angular-public/breadcrumb/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/angular-public/breadcrumb/breadcrumbs/breadcrumbs.component.spec.ts
@@ -18,7 +18,6 @@ import { SbbBreadcrumb, SBB_BREADCRUMB_LEVEL_OFFSET } from '../breadcrumb/breadc
 
 import { SbbBreadcrumbs } from './breadcrumbs.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-breadcrumbs-test',
   template: `

--- a/src/angular-public/button/button/button.component.spec.ts
+++ b/src/angular-public/button/button/button.component.spec.ts
@@ -6,7 +6,6 @@ import { SbbIconTestingModule } from '@sbb-esta/angular-core/icon/testing';
 
 import { SbbButton } from './button.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-button-test',
   template: `

--- a/src/angular-public/checkbox-panel/checkbox-panel/checkbox-panel.component.spec.ts
+++ b/src/angular-public/checkbox-panel/checkbox-panel/checkbox-panel.component.spec.ts
@@ -10,7 +10,6 @@ import { SbbCheckboxPanelModule } from '../checkbox-panel.module';
 
 import { SbbCheckboxPanel } from './checkbox-panel.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-model-sbb-checkbox-panel-test',
   template: `

--- a/src/angular-public/checkbox/checkbox/checkbox.component.spec.ts
+++ b/src/angular-public/checkbox/checkbox/checkbox.component.spec.ts
@@ -8,7 +8,6 @@ import { SbbIconTestingModule } from '@sbb-esta/angular-core/icon/testing';
 
 import { SbbCheckbox } from './checkbox.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-model-checkbox-test',
   template: `

--- a/src/angular-public/datepicker/calendar/calendar-header.component.html
+++ b/src/angular-public/datepicker/calendar/calendar-header.component.html
@@ -8,7 +8,7 @@
         (click)="previousMonthClicked()"
         i18n-aria-label="
           Button label to switch to the previous month@@sbbDatepickerSwitchToPreviousMonth"
-        aria-label="Zum letzten Monat wechseln"
+        aria-label="Change to the previous month"
       >
         <sbb-icon svgIcon="kom:chevron-small-left-small"></sbb-icon>
       </button>
@@ -24,7 +24,7 @@
         [disabled]="!nextMonthEnabled()"
         (click)="nextMonthClicked()"
         i18n-aria-label="Button label to switch to the next month@@sbbDatepickerSwitchToNextMonth"
-        aria-label="Zum nächsten Monat wechseln"
+        aria-label="Change to the next month"
       >
         <sbb-icon svgIcon="kom:chevron-small-right-small"></sbb-icon>
       </button>
@@ -37,7 +37,7 @@
         (click)="previousYearClicked()"
         i18n-aria-label="
           Button label to switch to the previous year@@sbbDatepickerSwitchToPreviousYear"
-        aria-label="Zum letzten Jahr wechseln"
+        aria-label="Change to the previous year"
       >
         <sbb-icon svgIcon="kom:chevron-small-left-small"></sbb-icon>
       </button>
@@ -50,7 +50,7 @@
         [disabled]="!nextYearEnabled()"
         (click)="nextYearClicked()"
         i18n-aria-label="Button label to switch to the next year@@sbbDatepickerSwitchToNextYear"
-        aria-label="Zum nächsten Jahr wechseln"
+        aria-label="Change to the next year"
       >
         <sbb-icon svgIcon="kom:chevron-small-right-small"></sbb-icon>
       </button>

--- a/src/angular-public/datepicker/datepicker-toggle/datepicker-toggle.component.html
+++ b/src/angular-public/datepicker/datepicker-toggle/datepicker-toggle.component.html
@@ -1,7 +1,7 @@
 <button
   aria-haspopup="true"
   i18n-aria-label="Open calendar@@sbbDatepickerOpenCalendar"
-  aria-label="Kalender öffnen"
+  aria-label="Show calendar"
   [attr.tabindex]="disabled ? -1 : tabIndex"
   [disabled]="disabled"
   (click)="open($event)"

--- a/src/angular-public/datepicker/datepicker/datepicker.component.spec.ts
+++ b/src/angular-public/datepicker/datepicker/datepicker.component.spec.ts
@@ -20,7 +20,6 @@ import { SbbDatepickerModule } from '../datepicker.module';
 
 import { SbbDatepicker } from './datepicker.component';
 
-// tslint:disable:i18n
 @Component({
   template: `
     <sbb-datepicker #d [disabled]="disabled" [opened]="opened">

--- a/src/angular-public/dropdown/dropdown/dropdown.component.spec.ts
+++ b/src/angular-public/dropdown/dropdown/dropdown.component.spec.ts
@@ -16,7 +16,6 @@ import {
 
 import { SbbDropdown } from './dropdown.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-dropdown-test',
   template: `

--- a/src/angular-public/file-selector/file-selector/file-selector.component.html
+++ b/src/angular-public/file-selector/file-selector/file-selector.component.html
@@ -13,7 +13,7 @@
   />
   <span class="sbb-file-selector-button" [class.sbb-file-selector-disabled]="disabled">
     <span i18n="Button label to select files for upload@@sbbFileSelectorUploadFile"
-      >Datei hochladen</span
+      >Upload file</span
     >
     <span class="sbb-svgsprite-icon sbb-icon-fit"
       ><sbb-icon svgIcon="kom:upload-small"></sbb-icon
@@ -56,7 +56,7 @@
         i18n="
           Hidden button label to remove a file from the selection list@@sbbFileSelectorRemoveFile"
         class="cdk-visually-hidden"
-        >Datei entfernen</span
+        >Remove file</span
       >
       <sbb-icon svgIcon="kom:trash-small"></sbb-icon>
     </button>

--- a/src/angular-public/getting-started.md
+++ b/src/angular-public/getting-started.md
@@ -145,17 +145,7 @@ export class SbbModule {}
 
 Whichever approach you use, be sure to import the modules after Angular's BrowserModule, as the import order matters for NgModules.
 
-## Step 3: i18n
-
-This library uses [Angular i18n](https://angular.io/guide/i18n). All translatables have an id with the pattern "sbb*Component*".
-Run `ng xi18n` in your project (after using components of this library in your code) to generate the list of translatables.
-
-### Datepicker i18n:
-
-The datepicker uses the CLDR data [provided by Angular](https://angular.io/guide/i18n#setting-up-the-locale-of-your-app).
-This means it uses the locale data configured via the `i18nLocale` entry in your angular.json `build` options or configurations.
-
-## Step 4 (Optional): Use mixins and functions from the library
+## Step 3 (Optional): Use mixins and functions from the library
 
 If you need to reuse some mixins from the library, you have to configure your own Angular application in
 SCSS mode and import `_styles.scss` from the library into your `styles.scss`:

--- a/src/angular-public/ghettobox/ghettobox-container/ghettobox-container.component.spec.ts
+++ b/src/angular-public/ghettobox/ghettobox-container/ghettobox-container.component.spec.ts
@@ -14,7 +14,6 @@ import { SbbGhettoboxService } from '../ghettobox/ghettobox.service';
 
 import { SbbGhettoboxContainer } from './ghettobox-container.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-ghettobox-container-test',
   template: `

--- a/src/angular-public/ghettobox/ghettobox/ghettobox.component.html
+++ b/src/angular-public/ghettobox/ghettobox/ghettobox.component.html
@@ -44,7 +44,7 @@
           <span
             i18n="Hidden button label to close the ghettobox@@sbbGhettoboxCloseGhettobox"
             class="cdk-visually-hidden"
-            >Hinweismeldung schliessen</span
+            >Close message</span
           >
         </button>
       </div>

--- a/src/angular-public/ghettobox/ghettobox/ghettobox.component.spec.ts
+++ b/src/angular-public/ghettobox/ghettobox/ghettobox.component.spec.ts
@@ -9,7 +9,6 @@ import { SbbIconTestingModule } from '@sbb-esta/angular-core/icon/testing';
 
 import { SbbGhettobox } from './ghettobox.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-ghettobox-test',
   template: `

--- a/src/angular-public/i18n.md
+++ b/src/angular-public/i18n.md
@@ -1,0 +1,42 @@
+# i18n
+
+This library uses [Angular i18n](https://angular.io/guide/i18n). All translatables have an id with the pattern "sbb*Component*".
+Run `ng xi18n` in your project (after using components of this library in your code) to generate the list of translatables.
+
+### Provided translations
+
+Our components use english as the default. We provide german (de-CH), french (fr-CH) and italian (it-CH)
+translations in XLIFF 1.2 and 2.0 variants. These are located in
+`node_modules/@sbb-esta/angular-core/i18n/xlf/messages.*.xlf` for XLIFF 1.2 and in
+`node_modules/@sbb-esta/angular-core/i18n/xlf2/messages.*.xlf` for XLIFF 2.0.
+
+Add them to your angular.json as follows (change `xlf` to `xlf2` for XLIFF 2.0):
+
+```json
+    "your-project-name": {
+      ...
+      "i18n": {
+        ...
+        "locales": {
+          "de-CH": [
+            "your-translation.xlf",
+            "node_modules/@sbb-esta/angular-core/i18n/xlf/messages.de-CH.xlf"
+          ],
+          "fr-CH": [
+            "your-translation.xlf",
+            "node_modules/@sbb-esta/angular-core/i18n/xlf/messages.fr-CH.xlf"
+          ],
+          "it-CH": [
+            "your-translation.xlf",
+            "node_modules/@sbb-esta/angular-core/i18n/xlf/messages.it-CH.xlf"
+          ],
+        }
+      },
+      ...
+    }
+```
+
+### Datepicker
+
+The datepicker uses the CLDR data [provided by Angular](https://angular.io/guide/i18n#setting-up-the-locale-of-your-app).
+This is configured via the `i18n` entry in your angular.json.

--- a/src/angular-public/lightbox/lightbox/lightbox.spec.ts
+++ b/src/angular-public/lightbox/lightbox/lightbox.spec.ts
@@ -32,7 +32,6 @@ import { SbbLightbox, SbbLightboxModule, SbbLightboxRef, SBB_LIGHTBOX_DATA } fro
 
 import { SbbLightboxContainer } from './lightbox-container.component';
 
-// tslint:disable:i18n
 @Directive({ selector: '[sbbDirWithViewContainer]' })
 class DirectiveWithViewContainerDirective {
   constructor(public viewContainerRef: ViewContainerRef) {}

--- a/src/angular-public/pagination/navigation/navigation.component.html
+++ b/src/angular-public/pagination/navigation/navigation.component.html
@@ -2,8 +2,8 @@
   <li class="sbb-navigation-item sbb-navigation-item-left" *ngIf="previousPage">
     <button
       type="button"
-      i18n-aria-label="@@navigationPreviousPage"
-      aria-label="Vorherige Seite"
+      i18n-aria-label="Button label to navigate to the previous page@@sbbNavigationPreviousPage"
+      aria-label="Previous Page"
       (click)="pageChange.emit('previous')"
       [attr.title]="previousPage"
     >
@@ -18,8 +18,8 @@
   <li class="sbb-navigation-item sbb-navigation-item-right" *ngIf="nextPage">
     <button
       type="button"
-      i18n-aria-label="@@navigationNextPage"
-      aria-label="Nächste Seite"
+      i18n-aria-label="Button label to navigate to the next page@@sbbNavigationNextPage"
+      aria-label="Next Page"
       (click)="pageChange.emit('next')"
       [attr.title]="nextPage"
     >

--- a/src/angular-public/pagination/pagination/pagination.component.html
+++ b/src/angular-public/pagination/pagination/pagination.component.html
@@ -2,8 +2,8 @@
   <li class="sbb-pagination-item">
     <button
       type="button"
-      i18n-aria-label="@@paginationPreviousPage"
-      aria-label="Vorherige Seite"
+      i18n-aria-label="Button label to navigate to the previous page@@sbbPaginationPreviousPage"
+      aria-label="Previous Page"
       class="sbb-pagination-item-boundary"
       [disabled]="!(hasPreviousPage | async)"
       [class.sbb-pagination-item-disabled]="!(hasPreviousPage | async)"
@@ -33,8 +33,8 @@
   <li class="sbb-pagination-item">
     <button
       type="button"
-      i18n-aria-label="@@paginationNextPage"
-      aria-label="Nächste Seite"
+      i18n-aria-label="Button label to navigate to the next page@@sbbPaginationNextPage"
+      aria-label="Next Page"
       class="sbb-pagination-item-boundary"
       [disabled]="!(hasNextPage | async)"
       [class.sbb-pagination-item-disabled]="!(hasNextPage | async)"

--- a/src/angular-public/pagination/pagination/pagination.component.spec.ts
+++ b/src/angular-public/pagination/pagination/pagination.component.spec.ts
@@ -12,7 +12,6 @@ import { SbbPaginationModule } from '../pagination.module';
 
 import { SbbPagination } from './pagination.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-pagination-test',
   template: `

--- a/src/angular-public/pagination/paginator/paginator.component.html
+++ b/src/angular-public/pagination/paginator/paginator.component.html
@@ -2,8 +2,8 @@
   <li class="sbb-paginator-item">
     <button
       type="button"
-      i18n-aria-label="@@paginationPreviousPage"
-      aria-label="Vorherige Seite"
+      i18n-aria-label="Button label to navigate to the previous page@@sbbPaginationPreviousPage"
+      aria-label="Previous Page"
       class="sbb-paginator-item-boundary"
       [disabled]="_previousButtonDisabled()"
       [class.sbb-paginator-item-disabled]="_previousButtonDisabled()"
@@ -38,8 +38,8 @@
   <li class="sbb-paginator-item">
     <button
       type="button"
-      i18n-aria-label="@@paginationNextPage"
-      aria-label="Nächste Seite"
+      i18n-aria-label="Button label to navigate to the next page@@sbbPaginationNextPage"
+      aria-label="Next Page"
       class="sbb-paginator-item-boundary"
       [disabled]="_nextButtonDisabled()"
       [class.sbb-paginator-item-disabled]="_nextButtonDisabled()"

--- a/src/angular-public/processflow/processflow/processflow.component.spec.ts
+++ b/src/angular-public/processflow/processflow/processflow.component.spec.ts
@@ -8,7 +8,6 @@ import { SbbProcessflowModule } from '../processflow.module';
 
 import { SbbProcessflow } from './processflow.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-processflow-test',
   template: `

--- a/src/angular-public/radio-button-panel/radio-button-panel/radio-button-panel.component.spec.ts
+++ b/src/angular-public/radio-button-panel/radio-button-panel/radio-button-panel.component.spec.ts
@@ -9,7 +9,6 @@ import { SbbRadioButtonPanelModule } from '../radio-button-panel.module';
 
 import { SbbRadioButtonPanel } from './radio-button-panel.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-model-radio-button-panel-test',
   template: `

--- a/src/angular-public/radio-button/radio-button/radio-button.component.spec.ts
+++ b/src/angular-public/radio-button/radio-button/radio-button.component.spec.ts
@@ -7,7 +7,6 @@ import { ɵRadioButtonModule } from '@sbb-esta/angular-core/radio-button';
 
 import { SbbRadioButton } from './radio-button.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-model-radio-button-test',
   template: `

--- a/src/angular-public/select/select/select.component.spec.ts
+++ b/src/angular-public/select/select/select.component.spec.ts
@@ -60,7 +60,6 @@ import { SbbSelectModule } from '../select.module';
 
 import { SbbSelect } from './select.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-basic-select',
   template: `

--- a/src/angular-public/tabs/tabs/tabs.component.business.html
+++ b/src/angular-public/tabs/tabs/tabs.component.business.html
@@ -22,7 +22,7 @@
         {{ tab.label }}
         <sbb-badge
           i18n-aria-label="Aria label for amount of entries displayed in badge pill@@sbbTabsBadgePillAmountOfEntries"
-          aria-label="{{ tab.badgePill }} Einträge"
+          aria-label="{{ tab.badgePill }} entries"
           *ngIf="tab.badgePill"
           >{{ tab.badgePill }}</sbb-badge
         >

--- a/src/angular-public/tabs/tabs/tabs.component.html
+++ b/src/angular-public/tabs/tabs/tabs.component.html
@@ -24,7 +24,7 @@
       <sbb-badge
         i18n-aria-label="
           Aria label for amount of entries displayed in badge pill@@sbbTabsBadgePillAmountOfEntries"
-        aria-label="{{ tab.badgePill }} Einträge"
+        aria-label="{{ tab.badgePill }} entries"
         *ngIf="tab.badgePill"
         >{{ tab.badgePill }}</sbb-badge
       >

--- a/src/angular-public/tabs/tabs/tabs.component.spec.ts
+++ b/src/angular-public/tabs/tabs/tabs.component.spec.ts
@@ -11,7 +11,6 @@ import { SbbTab } from '../tab/tab.component';
 
 import { SbbTabs } from './tabs.component';
 
-// tslint:disable:i18n
 @Component({
   template: `
     <sbb-tabs #tabs>

--- a/src/angular-public/tag/tag/tag.component.html
+++ b/src/angular-public/tag/tag/tag.component.html
@@ -5,7 +5,7 @@
     <sbb-badge
       i18n-aria-label="
         Aria label for amount of results displayed in badge pill@@sbbTagBadgePillAmountOfResults"
-      aria-label="{{ amount }} Resultate verfügbar"
+      aria-label="{{ amount }} results available"
       class="sbb-badge-active"
       >{{ amount }}</sbb-badge
     >
@@ -40,7 +40,7 @@
     <sbb-badge
       i18n-aria-label="
         Aria label for amount of results displayed in badge pill@@sbbTagBadgePillAmountOfResults"
-      aria-label="{{ amount }} Resultate verfügbar"
+      aria-label="{{ amount }} results available"
       [active]="checked"
       >{{ amount }}</sbb-badge
     >

--- a/src/angular-public/tag/tags/tags.component.html
+++ b/src/angular-public/tag/tags/tags.component.html
@@ -1,7 +1,7 @@
 <sbb-tag
   #allTag
-  i18n-label="Label for 'All' tag@@sbbTagsAll"
-  label="Alle"
+  i18n-label="Label for the 'All' tag@@sbbTagsAll"
+  label="All"
   (change)="allTagClick()"
   [amount]="_totalAmount | async"
 ></sbb-tag>

--- a/src/angular-public/textarea/textarea/textarea.component.html
+++ b/src/angular-public/textarea/textarea/textarea.component.html
@@ -17,5 +17,5 @@
   *ngIf="maxlength && !disabled"
   class="sbb-textarea-remaining-chars"
 >
-  Noch {{ _counter | async }} Zeichen
+  {{ _counter | async }} characters remaining
 </div>

--- a/src/angular-public/textarea/textarea/textarea.component.spec.ts
+++ b/src/angular-public/textarea/textarea/textarea.component.spec.ts
@@ -222,7 +222,7 @@ describe('SbbTextarea digits counter', () => {
     component.writeValue(component.value + ' ');
     fixture.detectChanges();
     const counterDiv = fixture.debugElement.query(By.css('div'));
-    expect(counterDiv.nativeElement.textContent.trim()).toBe('Noch 16 Zeichen');
+    expect(counterDiv.nativeElement.textContent.trim()).toBe('16 characters remaining');
   });
 
   it('should disappear', () => {

--- a/src/angular-public/textexpand/textexpand/textexpand.component.html
+++ b/src/angular-public/textexpand/textexpand/textexpand.component.html
@@ -11,12 +11,12 @@
     class="sbb-textexpand-button-label"
     *ngIf="isExpanded"
     i18n="Button label for showing less@@sbbTextexpandShowLess"
-    >Weniger anzeigen</span
+    >Show less</span
   >
   <span
     class="sbb-textexpand-button-label"
     *ngIf="!isExpanded"
     i18n="Button label for showing more@@sbbTextexpandShowMore"
-    >Mehr anzeigen</span
+    >Show more</span
   >
 </button>

--- a/src/angular-public/textexpand/textexpand/textexpand.component.spec.ts
+++ b/src/angular-public/textexpand/textexpand/textexpand.component.spec.ts
@@ -8,7 +8,6 @@ import { SbbTextexpandModule } from '../textexpand.module';
 
 import { SbbTextexpand } from './textexpand.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-textexpand-test',
   template: `
@@ -103,7 +102,7 @@ describe('SbbTextexpand', () => {
     const buttonClicked = fixtureTest.debugElement.query(By.css('.sbb-textexpand-button'))
       .nativeElement;
 
-    expect(buttonClicked.textContent).toContain('Mehr anzeigen');
+    expect(buttonClicked.textContent).toContain('Show more');
   });
 
   it('verify button label when text is expanded', async () => {
@@ -112,6 +111,6 @@ describe('SbbTextexpand', () => {
     buttonClicked.click();
     fixtureTest.detectChanges();
 
-    expect(buttonClicked.textContent).toContain('Weniger anzeigen');
+    expect(buttonClicked.textContent).toContain('Show less');
   });
 });

--- a/src/angular-public/toggle/toggle/toggle.component.spec.ts
+++ b/src/angular-public/toggle/toggle/toggle.component.spec.ts
@@ -14,7 +14,6 @@ import { Observable, of } from 'rxjs';
 import { SbbToggleOption } from '../toggle-option/toggle-option.component';
 import { SbbToggleModule } from '../toggle.module';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-toggle-test-reactive',
   template: `

--- a/src/angular-public/tooltip/tooltip/tooltip.component.spec.ts
+++ b/src/angular-public/tooltip/tooltip/tooltip.component.spec.ts
@@ -13,7 +13,6 @@ import { SbbTooltipModule } from '../tooltip.module';
 
 import { SbbTooltipComponent } from './tooltip.component';
 
-// tslint:disable:i18n
 @Component({
   selector: 'sbb-tooltip-test',
   template: `

--- a/src/angular-public/usermenu/BUILD.bazel
+++ b/src/angular-public/usermenu/BUILD.bazel
@@ -26,6 +26,7 @@ ng_module(
         "@npm//@angular/cdk",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//@angular/localize",
         "@npm//rxjs",
     ],
 )

--- a/src/angular-public/usermenu/usermenu.html
+++ b/src/angular-public/usermenu/usermenu.html
@@ -16,10 +16,7 @@
   *ngIf="_loggedIn"
   class="sbb-usermenu-trigger sbb-usermenu-trigger-logged-in sbb-usermenu-trigger-open"
   (click)="open()"
-  i18n-aria-label="Aria label to open user menu@@sbbUsermenuOpenPanel"
-  attr.aria-label="Logged in as {{
-    displayName || userName
-  }}. Click or press enter to open user menu."
+  [attr.aria-label]="_ariaLabelOpenPanel"
   aria-haspopup="true"
   [attr.aria-controls]="panelOpen ? id + '-panel' : null"
   [attr.aria-expanded]="panelOpen"
@@ -87,10 +84,7 @@
       #triggerCloseButton
       class="sbb-usermenu-trigger sbb-usermenu-trigger-logged-in sbb-usermenu-trigger-close"
       (click)="_closeAndFocus()"
-      i18n-aria-label="Aria label to close user menu@@sbbUsermenuClosePanel"
-      attr.aria-label="Logged in as {{
-        displayName || userName
-      }}. Click or press enter to close user menu."
+      [attr.aria-label]="_ariaLabelClosePanel"
     >
       <ng-container *ngTemplateOutlet="usermenuTriggerContent"></ng-container>
     </button>

--- a/src/angular-public/usermenu/usermenu.ts
+++ b/src/angular-public/usermenu/usermenu.ts
@@ -1,3 +1,6 @@
+// Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
+/// <reference types="@angular/localize/init" />
+
 import { AnimationEvent } from '@angular/animations';
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import { DOWN_ARROW, ENTER, ESCAPE, hasModifierKey, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
@@ -186,6 +189,28 @@ export class SbbUsermenu implements OnInit, OnDestroy, AfterContentInit {
         return current[0] + next[0];
       })
       .toLocaleUpperCase();
+  }
+
+  /** @docs-private */
+  get _ariaLabelOpenPanel() {
+    return typeof $localize === 'function'
+      ? $localize`:Aria label to open user menu@@sbbUsermenuOpenPanel:Logged in as ${
+          this.displayName || this.userName
+        }. Click or press enter to open user menu.`
+      : `Logged in as ${
+          this.displayName || this.userName
+        }. Click or press enter to open user menu.`;
+  }
+
+  /** @docs-private */
+  get _ariaLabelClosePanel() {
+    return typeof $localize === 'function'
+      ? $localize`:Aria label to close user menu@@sbbUsermenuClosePanel:Logged in as ${
+          this.displayName || this.userName
+        }. Click or press enter to close user menu.`
+      : `Logged in as ${
+          this.displayName || this.userName
+        }. Click or press enter to close user menu.`;
   }
 
   /** Whether the current component is used in business package or not */

--- a/src/angular-public/usermenu/usermenu.ts
+++ b/src/angular-public/usermenu/usermenu.ts
@@ -191,7 +191,6 @@ export class SbbUsermenu implements OnInit, OnDestroy, AfterContentInit {
       .toLocaleUpperCase();
   }
 
-  /** @docs-private */
   get _ariaLabelOpenPanel() {
     return typeof $localize === 'function'
       ? $localize`:Aria label to open user menu@@sbbUsermenuOpenPanel:Logged in as ${
@@ -202,7 +201,6 @@ export class SbbUsermenu implements OnInit, OnDestroy, AfterContentInit {
         }. Click or press enter to open user menu.`;
   }
 
-  /** @docs-private */
   get _ariaLabelClosePanel() {
     return typeof $localize === 'function'
       ? $localize`:Aria label to close user menu@@sbbUsermenuClosePanel:Logged in as ${

--- a/src/bazel-tsconfig-build.json
+++ b/src/bazel-tsconfig-build.json
@@ -28,7 +28,7 @@
     "target": "es2015",
     "lib": ["es2015", "dom"],
     "skipLibCheck": true,
-    "types": ["arcgis-js-api", "grecaptcha", "tslib"]
+    "types": ["@angular/localize/init", "arcgis-js-api", "grecaptcha", "jasmine"]
   },
   "bazelOptions": {
     // Note: We can remove this once we fully switched away from Gulp. Currently we still set

--- a/src/showcase/app/business/business/business.component.html
+++ b/src/showcase/app/business/business/business.component.html
@@ -5,6 +5,7 @@
       <a sbbSidebarLink routerLink="./introduction/getting-started" routerLinkActive="sbb-active"
         >Getting started</a
       >
+      <a sbbSidebarLink routerLink="./introduction/i18n" routerLinkActive="sbb-active">i18n</a>
       <a sbbSidebarLink routerLink="./introduction/typography" routerLinkActive="sbb-active"
         >Typography</a
       >

--- a/src/showcase/app/public/public/public.component.html
+++ b/src/showcase/app/public/public/public.component.html
@@ -5,6 +5,7 @@
       <a sbbSidebarLink routerLink="./introduction/getting-started" routerLinkActive="sbb-active"
         >Getting started</a
       >
+      <a sbbSidebarLink routerLink="./introduction/i18n" routerLinkActive="sbb-active">i18n</a>
       <a sbbSidebarLink routerLink="./introduction/typography" routerLinkActive="sbb-active"
         >Typography</a
       >

--- a/t9n-xlf.json
+++ b/t9n-xlf.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/kyubisation/angular-t9n/master/t9n.schema.json",
+  "translationFile": "src/angular-core/i18n/xlf/messages.xlf",
+  "targetTranslationPath": "",
+  "includeContextInTarget": false,
+  "port": 4300
+}

--- a/t9n-xlf2.json
+++ b/t9n-xlf2.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/kyubisation/angular-t9n/master/t9n.schema.json",
+  "translationFile": "src/angular-core/i18n/xlf2/messages.xlf",
+  "targetTranslationPath": "",
+  "includeContextInTarget": false,
+  "port": 4400
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "strictBindCallApply": true,
     "target": "es2015",
     "lib": ["es5", "es2015", "dom"],
-    "types": ["arcgis-js-api", "grecaptcha", "jasmine"],
+    "types": ["@angular/localize/init", "arcgis-js-api", "grecaptcha", "jasmine"],
     "baseUrl": ".",
     "paths": {
       "@sbb-esta/angular-public": ["src/angular-public"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,6 +2289,63 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz#2173ccb92469aaf62031fa9499d21b16d07f9b57"
   integrity sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==
 
+"@nestjs/common@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/common/-/common-7.5.2.tgz#8229081c8aab8a656c5509f1060411bfb8cf03eb"
+  integrity sha512-b1rKSOCO20qFgS9qr4Blu24XyVs+PAa4GIFDZxw+4HiPPKrU9PMLC3YdJ2K+wB1xEO9D7bmS0mlEz3fimD/z0A==
+  dependencies:
+    axios "0.21.0"
+    iterare "1.2.1"
+    tslib "2.0.3"
+    uuid "8.3.1"
+
+"@nestjs/core@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-7.5.2.tgz#8c358a753825041efc5012a24f545e54ac9df59f"
+  integrity sha512-StAYVexFqEch7NLV5wcjMwM/q2JKJ8Qi46bnsXVOxEQV8qlBc9aflJ3DWpM4pERvtUFJyfgo9iLk5IMQAPnnCg==
+  dependencies:
+    "@nuxtjs/opencollective" "0.2.2"
+    fast-safe-stringify "2.0.7"
+    iterare "1.2.1"
+    object-hash "2.0.3"
+    path-to-regexp "3.2.0"
+    tslib "2.0.3"
+    uuid "8.3.1"
+
+"@nestjs/platform-express@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/platform-express/-/platform-express-7.5.2.tgz#06de8ee148ff9d668987e4f1140ae5b371554b57"
+  integrity sha512-SgcWsBMrJ8Blhi1V24C8lBor+mx9ffpyyWmSZUWhNIfAtPHnfalie9K3Ny7b4Kv782l/4f5bewHQVbhDAe8Jog==
+  dependencies:
+    body-parser "1.19.0"
+    cors "2.8.5"
+    express "4.17.1"
+    multer "1.4.2"
+    tslib "2.0.3"
+
+"@nestjs/platform-ws@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/platform-ws/-/platform-ws-7.5.2.tgz#9a488669ff227783327614e98c4c78dae21649b1"
+  integrity sha512-ejHX8PEWuLfbiM1LE3J9PP/ptkiychKddbMJKnI5n9/bqiyq4UsrlSgn17ewBLPG4bCT5w7uLAnNFG1pekXiVw==
+  dependencies:
+    tslib "2.0.3"
+    ws "7.3.1"
+
+"@nestjs/serve-static@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nestjs/serve-static/-/serve-static-2.1.3.tgz#bdcb6d3463d193153b334212facc24a9767046e9"
+  integrity sha512-9xyysggaOdfbABWqhty+hAkauDWv/Q8YKHm4OMXdQbQei5tquFuTjiSx8IFDOZeSOKlA9fjBq/2MXCJRSo23SQ==
+  dependencies:
+    path-to-regexp "0.1.7"
+
+"@nestjs/websockets@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/websockets/-/websockets-7.5.2.tgz#94e8259930ff26ff7ad028885d0f8ba8995f8b58"
+  integrity sha512-28EPcANckB9yl/BMSV/KF1rvuznmnC7If3z+39WXq2PzhVcO4HCcznR63yuCmlXCvmendDlCbvhtPeqG72It7g==
+  dependencies:
+    iterare "1.2.1"
+    tslib "2.0.3"
+
 "@ngtools/webpack@11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-11.0.0.tgz#bddc9ad4677de55d9df9418408079c2a2be4f482"
@@ -2325,6 +2382,15 @@
   integrity sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==
   dependencies:
     mkdirp "^1.0.4"
+
+"@nuxtjs/opencollective@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/opencollective/-/opencollective-0.2.2.tgz#26a761ebf588cc92a422d7cee996a66bd6e2761e"
+  integrity sha512-69gFVDs7mJfNjv9Zs5DFVD+pvBW+k1TaHSOqUWqAyTTfLcKI/EMYQgvEvziRd+zAFtUOoye6MfWh0qvinGISPw==
+  dependencies:
+    chalk "^2.4.1"
+    consola "^2.3.0"
+    node-fetch "^2.3.0"
 
 "@phenomnomnominal/tsquery@^4.0.0":
   version "4.1.0"
@@ -2731,6 +2797,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/validator@13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.0.0.tgz#365f1bf936aeaddd0856fc41aa1d6f82d88ee5b3"
+  integrity sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==
+
 "@types/vfile-message@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"
@@ -3110,6 +3181,24 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+angular-t9n@^11.1.2:
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/angular-t9n/-/angular-t9n-11.1.2.tgz#2533d9322249a16e5eb564f6473dbdd4f6ec6c19"
+  integrity sha512-lRoEREMdaMPQv7tsLMH8AoPu+MyzVWi1uuOUiA2gqKL7TrbHHl/EqYjE0/AyHRahJnvLTeY8PmTVyWjL2ejC7Q==
+  dependencies:
+    "@nestjs/common" "^7.5.2"
+    "@nestjs/core" "^7.5.2"
+    "@nestjs/platform-express" "^7.5.2"
+    "@nestjs/platform-ws" "^7.5.2"
+    "@nestjs/serve-static" "^2.1.3"
+    "@nestjs/websockets" "^7.5.2"
+    class-transformer "^0.3.1"
+    class-validator "^0.12.2"
+    js-levenshtein "^1.1.6"
+    reflect-metadata "^0.1.13"
+    rxjs "~6.5.5"
+    xmldom "^0.3.0"
+
 ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -3187,6 +3276,11 @@ app-root-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-3.0.0.tgz#210b6f43873227e18a4b810a032283311555d5ad"
   integrity sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw==
+
+append-field@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-field/-/append-field-1.0.0.tgz#1e3440e915f0b1203d23748e78edd7b9b5b43e56"
+  integrity sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=
 
 aproba@^1.1.1:
   version "1.2.0"
@@ -3404,6 +3498,13 @@ aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+
+axios@0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
+  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
+  dependencies:
+    follow-redirects "^1.10.0"
 
 axobject-query@2.0.2:
   version "2.0.2"
@@ -3795,6 +3896,14 @@ builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
+busboy@^0.2.11:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
+  integrity sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=
+  dependencies:
+    dicer "0.2.5"
+    readable-stream "1.1.x"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -4198,6 +4307,11 @@ circular-dependency-plugin@5.2.0:
   resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz#e09dbc2dd3e2928442403e2d45b41cea06bc0a93"
   integrity sha512-7p4Kn/gffhQaavNfyDFg7LS5S/UT1JAjyGd4UqR2+jzoYF02eDkj0Ec3+48TsIa4zghjLY87nQHIh/ecK9qLdw==
 
+class-transformer@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.3.1.tgz#ee681a5439ff2230fc57f5056412d3befa70d597"
+  integrity sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA==
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -4207,6 +4321,16 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+class-validator@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.12.2.tgz#2ceb72f88873e9c714cf5f9c278cbc71f6f6c8ef"
+  integrity sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==
+  dependencies:
+    "@types/validator" "13.0.0"
+    google-libphonenumber "^3.2.8"
+    tslib ">=1.9.0"
+    validator "13.0.0"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -4526,7 +4650,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0:
+concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -4560,6 +4684,11 @@ connect@^3.6.0:
     finalhandler "1.1.2"
     parseurl "~1.3.3"
     utils-merge "1.0.1"
+
+consola@^2.3.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.0.tgz#40fc4eefa4d2f8ef2e2806147f056ea207fcc0e9"
+  integrity sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ==
 
 console-browserify@^1.1.0:
   version "1.2.0"
@@ -4870,6 +4999,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cors@2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig@^5.0.0:
   version "5.2.1"
@@ -5458,6 +5595,14 @@ diagnostics@^1.1.1:
     colorspace "1.1.x"
     enabled "1.0.x"
     kuler "1.0.x"
+
+dicer@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
+  integrity sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=
+  dependencies:
+    readable-stream "1.1.x"
+    streamsearch "0.1.2"
 
 diff@^4.0.1:
   version "4.0.2"
@@ -6077,7 +6222,7 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-express@^4.14.0, express@^4.17.1:
+express@4.17.1, express@^4.14.0, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -6222,7 +6367,7 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.0.4:
+fast-safe-stringify@2.0.7, fast-safe-stringify@^2.0.4:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
@@ -6402,7 +6547,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
@@ -6814,6 +6959,11 @@ gonzales-pe@^4.3.0:
   integrity sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==
   dependencies:
     minimist "^1.2.5"
+
+google-libphonenumber@^3.2.8:
+  version "3.2.15"
+  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.15.tgz#3a01dc554dbf83c754f249c16df3605e5d154bb9"
+  integrity sha512-tbCIuzMoH34RdrbFRw5kijAZn/p6JMQvsgtr1glg2ugbwqrMPlOL8pHNK8cyGo9B6SXpcMm4hdyDqwomR+HPRg==
 
 graceful-fs@4.2.2, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.2"
@@ -7914,6 +8064,11 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -8021,6 +8176,11 @@ istanbul@^0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
+iterare@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/iterare/-/iterare-1.2.1.tgz#139c400ff7363690e33abffa33cbba8920f00042"
+  integrity sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==
+
 jasmine-core@^3.5.0, jasmine-core@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.5.0.tgz#132c23e645af96d85c8bca13c8758b18429fc1e4"
@@ -8100,6 +8260,11 @@ jju@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha1-o6vicYryQaKykE+EpiWXDzia4yo=
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -9269,6 +9434,20 @@ ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+multer@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.2.tgz#2f1f4d12dbaeeba74cb37e623f234bf4d3d2057a"
+  integrity sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==
+  dependencies:
+    append-field "^1.0.0"
+    busboy "^0.2.11"
+    concat-stream "^1.5.2"
+    mkdirp "^0.5.1"
+    object-assign "^4.1.1"
+    on-finished "^2.3.0"
+    type-is "^1.6.4"
+    xtend "^4.0.0"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -9359,6 +9538,11 @@ node-fetch-npm@^2.0.2:
     encoding "^0.1.11"
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
+
+node-fetch@^2.3.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -9607,7 +9791,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -9625,6 +9809,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.3.tgz#d12db044e03cd2ca3d77c0570d87225b02e1e6ea"
+  integrity sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg==
 
 object-inspect@^1.7.0:
   version "1.7.0"
@@ -9716,7 +9905,7 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-on-finished@~2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
@@ -10144,6 +10333,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.2.0.tgz#fa7877ecbc495c601907562222453c43cc204a5f"
+  integrity sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -11054,6 +11248,16 @@ read-pkg@^5.2.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 "readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
@@ -11117,7 +11321,7 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-reflect-metadata@^0.1.12, reflect-metadata@^0.1.2:
+reflect-metadata@^0.1.12, reflect-metadata@^0.1.13, reflect-metadata@^0.1.2:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
@@ -11634,7 +11838,7 @@ rxjs@6.6.3, rxjs@^6.6.0, rxjs@^6.6.2:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.5.3, rxjs@~6.5.4:
+rxjs@^6.5.3, rxjs@~6.5.4, rxjs@~6.5.5:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
@@ -12493,6 +12697,11 @@ streamroller@^1.0.6:
     fs-extra "^7.0.1"
     lodash "^4.17.14"
 
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
 string-argv@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
@@ -12580,6 +12789,11 @@ string_decoder@^1.0.0, string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -13239,7 +13453,7 @@ tsickle@0.38.1, tsickle@^0.38.0:
   resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.38.1.tgz#30762db759d40c435943093b6972c7f2efb384ef"
   integrity sha512-4xZfvC6+etRu6ivKCNqMOd1FqcY/m6JY3Y+yr5+Xw+i751ciwrWINi6x/3l1ekcODH9GZhlf0ny2LpzWxnjWYA==
 
-tslib@2.0.3, tslib@^2.0.3:
+tslib@2.0.3, tslib@>=1.9.0, tslib@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
@@ -13383,7 +13597,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-is@~1.6.17, type-is@~1.6.18:
+type-is@^1.6.4, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
@@ -13762,12 +13976,17 @@ validate.js@^0.12.0:
   resolved "https://registry.yarnpkg.com/validate.js/-/validate.js-0.12.0.tgz#17f989e37c192ea2f826bbf19bf4e97e6e4be68f"
   integrity sha512-/x2RJSvbqEyxKj0RPN4xaRquK+EggjeVXiDDEyrJzsJogjtiZ9ov7lj/svVb4DM5Q5braQF4cooAryQbUwOxlA==
 
+validator@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.0.0.tgz#0fb6c6bb5218ea23d368a8347e6d0f5a70e3bcab"
+  integrity sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==
+
 validator@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-8.2.0.tgz#3c1237290e37092355344fef78c231249dab77b9"
   integrity sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
@@ -14176,6 +14395,11 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
+  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+
 ws@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
@@ -14224,6 +14448,11 @@ xmldom@^0.1.22:
   version "0.1.31"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
   integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
+
+xmldom@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.3.0.tgz#e625457f4300b5df9c2e1ecb776147ece47f3e5a"
+  integrity sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"


### PR DESCRIPTION
With this PR we provide XLIFF 1.2 and XLIFF 2.0 translation files for de-CH, fr-CH and it-CH.
All default texts in our code have been changed to english and the i18n ids are now all
correctly prefixed with `sbb`.

Closes #114 