### PR TITLE
fix(business): fix link stretch mode and adapt css classes

### DIFF
--- a/src/angular-business/links/link.component.scss
+++ b/src/angular-business/links/link.component.scss
@@ -3,7 +3,7 @@
 .sbb-link-business {
   display: inline-block;
   hyphens: auto;
-  padding-right: pxToRem(70);
+  padding-right: pxToRem(32);
   position: relative;
   text-decoration: none;
   word-break: break-word;
@@ -20,10 +20,11 @@
   height: toPx(24);
   margin-left: toPx(8);
   pointer-events: none;
+  right: 0;
   top: 50%;
   transform: translate(0px, -50%);
+}
 
-  .sbb-link & {
-    right: 0;
-  }
+.sbb-link-business-stretch {
+  display: block;
 }

--- a/src/angular-business/links/link.component.ts
+++ b/src/angular-business/links/link.component.ts
@@ -6,8 +6,8 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
   styleUrls: ['./link.component.css'],
   host: {
     class: 'sbb-link-business sbb-icon-fit',
-    '[class.sbb-link-normal]': 'this.mode === "normal"',
-    '[class.sbb-link-stretch]': 'this.mode === "stretch"',
+    '[class.sbb-link-business-normal]': 'this.mode === "normal"',
+    '[class.sbb-link-business-stretch]': 'this.mode === "stretch"',
   },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
To follow our css naming guide lines we had to rename the following css class of sbb-link-business.

BREAKING CHANGE: css class `.sbb-link-normal` was renamed to `.sbb-link-business-normal`.
css class `.sbb-link-stretch` was renamed to `.sbb-link-business-stretch`.