### PR TITLE
fix: fix ribbon color of sbb-header

### DIFF
--- a/src/angular-business/header/header/header.component.scss
+++ b/src/angular-business/header/header/header.component.scss
@@ -35,7 +35,7 @@ $sbbHeaderHeight: 54px;
   line-height: 12px;
   letter-spacing: 0px;
   font-size: 10px;
-  color: $sbbColorSilver;
+  color: $sbbColorWhite;
   transform: rotate(-45deg);
 }
 
@@ -75,7 +75,7 @@ $sbbHeaderHeight: 54px;
   flex-grow: 0;
   flex-direction: column;
   width: 200px;
-  margin-left: 15px;
+  margin-left: 45px;
   font-family: $fontSbbLight;
 
   > span {

--- a/src/angular-business/header/header/header.component.scss
+++ b/src/angular-business/header/header/header.component.scss
@@ -75,7 +75,7 @@ $sbbHeaderHeight: 54px;
   flex-grow: 0;
   flex-direction: column;
   width: 200px;
-  margin-left: 45px;
+  margin-left: 15px;
   font-family: $fontSbbLight;
 
   > span {


### PR DESCRIPTION
Correct header title according to https://digital.sbb.ch/de/webapps/modules/header
* left title offset of 54px 
* header ribbon text color white

I just noticed, that the left margin is only incorrect when there is no visible hamburger menu, which happens when there is no 'sbb-app-chooser-section' and there is enough space on the screen:

OK
![image](https://user-images.githubusercontent.com/78031737/105859703-20604500-5fed-11eb-93ce-afe61c4c2e39.png)


NOK
![image](https://user-images.githubusercontent.com/78031737/105859713-23f3cc00-5fed-11eb-85ce-cf6f4a618e25.png)

so fixing the 'margin-left' wont work.

I'll fix it for now by setting a default 'sbb-app-chooser-section', fixing the color would still be nice tough
