### PR TITLE
feat(business): add flexible mode and environment element for header

### DIFF
--- a/src/angular-business/header/header-breakpoint.ts
+++ b/src/angular-business/header/header-breakpoint.ts
@@ -1,6 +1,9 @@
 import { Breakpoints } from '@sbb-esta/angular-core/breakpoints';
 
-/** The breakpoints on which the header menus are displayed in the header bar. */
+/**
+ * The breakpoints on which the header menus are displayed in the header bar.
+ * @deprecated No longer in use.
+ */
 export const SBB_HEADER_BREAKPOINT = [
   Breakpoints.Desktop,
   Breakpoints.DesktopLarge,

--- a/src/angular-business/header/header-environment/header-environment.directive.ts
+++ b/src/angular-business/header/header-environment/header-environment.directive.ts
@@ -1,0 +1,51 @@
+import { ContentObserver } from '@angular/cdk/observers';
+import { Directive, ElementRef, OnDestroy } from '@angular/core';
+import { Subject } from 'rxjs';
+import { map, takeUntil } from 'rxjs/operators';
+
+@Directive({
+  selector: 'sbb-header-environment',
+  exportAs: 'sbbHeaderEnvironment',
+  host: {
+    class: 'sbb-header-environment',
+  },
+})
+export class SbbHeaderEnvironment implements OnDestroy {
+  private _destroyed = new Subject<void>();
+  private _previousClass: string | null = null;
+
+  constructor(contentObserver: ContentObserver, elementRef: ElementRef<HTMLElement>) {
+    contentObserver
+      .observe(elementRef)
+      .pipe(
+        map(() => {
+          let text = elementRef.nativeElement.textContent;
+          if (text) {
+            text = text
+              .replace(/[^a-zA-Z0-9-_]+/g, '-')
+              .replace(/(^-+|-+$)/g, '')
+              .toLowerCase();
+            return `sbb-header-environment-${text}`;
+          }
+
+          return null;
+        }),
+        takeUntil(this._destroyed)
+      )
+      .subscribe((selector) => {
+        const classes = elementRef.nativeElement.classList;
+        if (this._previousClass) {
+          classes.remove(this._previousClass);
+        }
+        if (selector) {
+          classes.add(selector);
+        }
+        this._previousClass = selector;
+      });
+  }
+
+  ngOnDestroy(): void {
+    this._destroyed.next();
+    this._destroyed.complete();
+  }
+}

--- a/src/angular-business/header/header-menu-trigger/header-menu-trigger.component.scss
+++ b/src/angular-business/header/header-menu-trigger/header-menu-trigger.component.scss
@@ -21,7 +21,7 @@
     }
   }
 
-  @include mq($from: desktop) {
+  :host-context(.sbb-header-main-menu) {
     padding: 0;
 
     > span {

--- a/src/angular-business/header/header-menu-trigger/header-menu-trigger.component.ts
+++ b/src/angular-business/header/header-menu-trigger/header-menu-trigger.component.ts
@@ -29,6 +29,8 @@ import { distinctUntilChanged, filter, map, takeUntil } from 'rxjs/operators';
 
 import { SBB_HEADER_BREAKPOINT } from '../header-breakpoint';
 import { SbbHeaderMenu } from '../header-menu/header-menu.component';
+import { SBB_HEADER } from '../header/header-token';
+import type { SbbHeader } from '../header/header.component';
 
 /** Injection token that determines the scroll handling while the menu is open. */
 export const SBB_HEADER_MENU_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrategy>(
@@ -110,6 +112,9 @@ export class SbbHeaderMenuTrigger implements AfterContentInit, OnDestroy {
     return this._menuOpen;
   }
 
+  /**
+   * @deprecated No longer used
+   */
   _isDesktop: Observable<boolean>;
 
   private _overlayRef: OverlayRef | null = null;
@@ -131,7 +136,8 @@ export class SbbHeaderMenuTrigger implements AfterContentInit, OnDestroy {
     private _focusMonitor: FocusMonitor,
     private _breakpointObserver: BreakpointObserver,
     @Optional() private _router: Router,
-    @Inject(SBB_HEADER_MENU_SCROLL_STRATEGY) scrollStrategy: any
+    @Inject(SBB_HEADER_MENU_SCROLL_STRATEGY) scrollStrategy: any,
+    @Inject(SBB_HEADER) private _header: SbbHeader
   ) {
     _element.nativeElement.addEventListener(
       'touchstart',
@@ -180,7 +186,7 @@ export class SbbHeaderMenuTrigger implements AfterContentInit, OnDestroy {
     }
 
     this._checkMenu();
-    if (!this._breakpointObserver.isMatched(SBB_HEADER_BREAKPOINT)) {
+    if (this._header._menusCollapsed) {
       this.menu._panelPortalOutlet.attachTemplatePortal(this.menu._panelPortal);
     } else {
       const overlayRef = this._createOverlay();
@@ -353,10 +359,7 @@ export class SbbHeaderMenuTrigger implements AfterContentInit, OnDestroy {
   private _menuClosingActions() {
     const backdrop = this._overlayRef ? this._overlayRef.backdropClick() : NEVER;
     const detachments = this._overlayRef ? this._overlayRef.detachments() : NEVER;
-    const dimensionChange = this._breakpointObserver.observe(SBB_HEADER_BREAKPOINT).pipe(
-      map((m) => m.matches),
-      filter((m) => !m)
-    );
+    const dimensionChange = this._header._headerMenusCollapsed;
     const routeChange = this._router
       ? this._router.events.pipe(filter((e) => e instanceof NavigationStart))
       : NEVER;

--- a/src/angular-business/header/header-menu/header-menu.component.scss
+++ b/src/angular-business/header/header-menu/header-menu.component.scss
@@ -3,7 +3,7 @@
 $sbbHeaderMenuSectionHeight: 54px;
 
 :host {
-  display: block;
+  display: none;
   position: fixed;
   top: 0;
   right: 0;
@@ -16,10 +16,10 @@ $sbbHeaderMenuSectionHeight: 54px;
     width: calc(100vw - #{$sbbHeaderMenuWidth});
     z-index: $sbbHeaderMenuTabletZIndex;
   }
+}
 
-  @include mq($from: desktop) {
-    display: none;
-  }
+:host(.sbb-header-menus-collapsed) {
+  display: block;
 }
 
 button.sbb-header-menu-back,

--- a/src/angular-business/header/header-menu/header-menu.component.ts
+++ b/src/angular-business/header/header-menu/header-menu.component.ts
@@ -2,17 +2,16 @@ import { AnimationEvent } from '@angular/animations';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { FocusKeyManager, FocusOrigin } from '@angular/cdk/a11y';
 import { DOWN_ARROW, END, ESCAPE, hasModifierKey, HOME, UP_ARROW } from '@angular/cdk/keycodes';
-import { BreakpointObserver } from '@angular/cdk/layout';
 import { CdkPortal, CdkPortalOutlet } from '@angular/cdk/portal';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ContentChildren,
   ElementRef,
   EventEmitter,
   HostListener,
+  Inject,
   Input,
   OnDestroy,
   Output,
@@ -23,8 +22,9 @@ import { TypeRef } from '@sbb-esta/angular-core/common-behaviors';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { map, startWith, takeUntil } from 'rxjs/operators';
 
-import { SBB_HEADER_BREAKPOINT } from '../header-breakpoint';
 import { SbbHeaderMenuItem } from '../header-menu-item/header-menu-item.directive';
+import { SBB_HEADER } from '../header/header-token';
+import type { SbbHeader } from '../header/header.component';
 
 let nextId = 0;
 
@@ -45,6 +45,7 @@ let nextId = 0;
     class: 'sbb-header-menu',
     '[id]': 'this.id',
     '[@open]': 'this._animationState',
+    '[class.sbb-header-menus-collapsed]': 'this._header._menusCollapsed',
   },
 })
 export class SbbHeaderMenu implements AfterContentInit, OnDestroy {
@@ -73,7 +74,7 @@ export class SbbHeaderMenu implements AfterContentInit, OnDestroy {
       this._open = value;
       if (!value) {
         this._animationState = 'closed';
-      } else if (this._breakpointObserver.isMatched(SBB_HEADER_BREAKPOINT)) {
+      } else if (!this._header._menusCollapsed) {
         this._animationState = 'open-panel';
       } else {
         this._animationState = 'open-menu';
@@ -127,8 +128,7 @@ export class SbbHeaderMenu implements AfterContentInit, OnDestroy {
 
   constructor(
     private _elementRef: ElementRef<HTMLElement>,
-    private _breakpointObserver: BreakpointObserver,
-    private _changeDetectorRef: ChangeDetectorRef
+    @Inject(SBB_HEADER) public _header: SbbHeader
   ) {}
 
   ngAfterContentInit() {
@@ -223,7 +223,7 @@ export class SbbHeaderMenu implements AfterContentInit, OnDestroy {
       default:
         if (keyCode === UP_ARROW || keyCode === DOWN_ARROW) {
           manager.setFocusOrigin('keyboard');
-        } else if (this._breakpointObserver.isMatched(SBB_HEADER_BREAKPOINT)) {
+        } else if (!this._header._menusCollapsed) {
           manager.onKeydown(event);
         }
     }

--- a/src/angular-business/header/header.md
+++ b/src/angular-business/header/header.md
@@ -4,10 +4,9 @@ It supports `<a>` and `<button>` tags for navigation. Optionally a `<sbb-usermen
 provided, as well as any element with a `[brand]` attribute or `.brand` class, for replacing
 the standard logo.
 
-**Note: The responsive design is still experimental.**
-
 ```html
-<sbb-header [label]="Title" [subtitle]="Subtitle" [environment]="dev" [environmentColor]="red">
+<sbb-header [label]="Title" [subtitle]="Subtitle">
+  <sbb-header-environment [style.background]="environmentColor">example</sbb-header-environment>
   <a routerLink="/">Home</a>
   <button type="button" [sbbHeaderMenu]="menu">Sections</button>
   <sbb-header-menu #menu="sbbHeaderMenu">
@@ -21,12 +20,61 @@ the standard logo.
 </sbb-header>
 ```
 
+### Flexible mode
+
+By adding the class `.sbb-header-flexible` to the `sbb-header` element, the default five column
+layout is disabled and elements can be placed inside the header as desired. This will become the
+default in a future release.
+
+Use the `collapseBreakpoint` input to define on which breakpoint the header menus should be
+collapsed. See the API documentation for more details.
+
+```html
+<sbb-header
+  [label]="Title"
+  [subtitle]="Subtitle"
+  class="sbb-header-flexible"
+  collapseBreakpoint="desktop"
+>
+  ...
+</sbb-header>
+```
+
+### Environment
+
+Use the `sbb-header-environment` to add a ribbon to describe the current environment (e.g. dev, test, int, ...).
+
+Note: For the production environment, the `sbb-header-environment` is expected to be hidden.
+
+```html
+<sbb-header [label]="Title" [subtitle]="Subtitle">
+  <sbb-header-environment>dev</sbb-header-environment>
+</sbb-header>
+```
+
+We provide default colors for `edu`, `dev`, `test` and `int`. In order to configure your own color,
+set the background color of `sbb-header-environment`. Note that the normalized text content of the
+element will be added as a class in the format of `.sbb-header-environment-{text}`.
+
+```html
+<sbb-header [label]="Title" [subtitle]="Subtitle">
+  <!-- Configure your own color -->
+  <sbb-header-environment [style.background]="environmentColor">example</sbb-header-environment>
+</sbb-header>
+```
+
+```scss
+.sbb-header-environment-example {
+  background-color: $sbbColorAutumn;
+}
+```
+
 ### App Chooser
 
 It is possible to provide app chooser sections for links to other apps or external addresses.
 
 ```html
-<sbb-header [label]="Title" [subtitle]="Subtitle" [environment]="dev" [environmentColor]="red">
+<sbb-header [label]="Title" [subtitle]="Subtitle">
   <a routerLink="/">Home</a>
   ...
   <sbb-app-chooser-section label="Apps">

--- a/src/angular-business/header/header.module.ts
+++ b/src/angular-business/header/header.module.ts
@@ -1,3 +1,4 @@
+import { ObserversModule } from '@angular/cdk/observers';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
@@ -5,6 +6,7 @@ import { NgModule } from '@angular/core';
 import { SbbIconModule, ɵSBB_ICON_REGISTRY_WRAPPER_PROVIDER } from '@sbb-esta/angular-core/icon';
 
 import { SbbAppChooserSection } from './app-chooser-section/app-chooser-section.component';
+import { SbbHeaderEnvironment } from './header-environment/header-environment.directive';
 import { SbbHeaderMenuItem } from './header-menu-item/header-menu-item.directive';
 import {
   SbbHeaderMenuTrigger,
@@ -14,13 +16,14 @@ import { SbbHeaderMenu } from './header-menu/header-menu.component';
 import { SbbHeader } from './header/header.component';
 
 @NgModule({
-  imports: [CommonModule, OverlayModule, PortalModule, SbbIconModule],
+  imports: [CommonModule, ObserversModule, OverlayModule, PortalModule, SbbIconModule],
   declarations: [
     SbbHeader,
     SbbAppChooserSection,
     SbbHeaderMenu,
     SbbHeaderMenuTrigger,
     SbbHeaderMenuItem,
+    SbbHeaderEnvironment,
   ],
   exports: [
     SbbHeader,
@@ -28,6 +31,7 @@ import { SbbHeader } from './header/header.component';
     SbbHeaderMenu,
     SbbHeaderMenuTrigger,
     SbbHeaderMenuItem,
+    SbbHeaderEnvironment,
   ],
   providers: [
     SBB_HEADER_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER,

--- a/src/angular-business/header/header/header.component.html
+++ b/src/angular-business/header/header/header.component.html
@@ -1,6 +1,8 @@
-<div class="sbb-header-ribbon" *ngIf="environment" [style.background]="environmentColor">
+<!-- TODO: Remove inlined sbb-header-environment with merge or v12 and add migration -->
+<sbb-header-environment *ngIf="environment" [style.background]="environmentColor">
   {{ environment }}
-</div>
+</sbb-header-environment>
+<ng-content select="sbb-header-environment"></ng-content>
 
 <button
   type="button"
@@ -19,7 +21,7 @@
   <span *ngIf="subtitle">{{ subtitle }}</span>
 </div>
 
-<nav>
+<nav class="sbb-header-main-menu">
   <ng-template cdkPortalOutlet #mainMenuOutlet="cdkPortalOutlet"></ng-template>
 </nav>
 

--- a/src/angular-business/header/header/header.component.scss
+++ b/src/angular-business/header/header/header.component.scss
@@ -1,6 +1,6 @@
 @import '../header';
 
-$sbbHeaderHeight: 54px;
+$sbbHeaderHeight: pxToRem(54);
 
 :host {
   display: flex;
@@ -14,29 +14,55 @@ $sbbHeaderHeight: 54px;
   border-bottom: solid 1px $sbbColorSilver;
 
   > nav {
-    margin-left: 50px;
     overflow-x: hidden;
     display: flex;
     flex-grow: 1;
+  }
+
+  &:not(.sbb-header-flexible) > nav {
+    margin-left: pxToRem(50);
 
     > ::ng-deep a,
     > ::ng-deep button {
       flex: 0 0 20%;
     }
   }
+
+  &.sbb-header-flexible > nav {
+    > ::ng-deep a,
+    > ::ng-deep button {
+      margin-right: 1rem;
+    }
+  }
 }
 
-.sbb-header-ribbon {
-  width: 80px;
-  position: absolute;
-  top: 12px;
-  left: -20px;
-  text-align: center;
-  line-height: 12px;
-  letter-spacing: 0px;
-  font-size: 10px;
-  color: $sbbColorWhite;
-  transform: rotate(-45deg);
+::ng-deep {
+  .sbb-header-environment {
+    width: pxToRem(80);
+    position: absolute;
+    top: pxToRem(12);
+    left: pxToRem(-20);
+    text-align: center;
+    line-height: pxToRem(12);
+    letter-spacing: 0;
+    font-size: pxToRem(10);
+    color: $sbbColorWhite;
+    transform: rotate(-45deg);
+  }
+
+  // Default colors for the environments
+  .sbb-header-environment-dev {
+    background-color: $sbbColorPeach;
+  }
+  .sbb-header-environment-test {
+    background-color: $sbbColorNight;
+  }
+  .sbb-header-environment-edu {
+    background-color: $sbbColorGreen;
+  }
+  .sbb-header-environment-int {
+    background-color: $sbbColorGranite;
+  }
 }
 
 .sbb-header-open-menu,
@@ -44,17 +70,17 @@ $sbbHeaderHeight: 54px;
   @include buttonResetFrameless();
   flex-grow: 0;
   flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  margin-left: 15px;
+  width: pxToRem(24);
+  height: pxToRem(24);
+  margin-left: pxToRem(15);
   cursor: pointer;
   position: relative;
   outline: none;
 
   > .sbb-icon {
     display: inline-block;
-    width: 24px;
-    height: 24px;
+    width: pxToRem(24);
+    height: pxToRem(24);
   }
 
   &:focus {
@@ -64,8 +90,9 @@ $sbbHeaderHeight: 54px;
   }
 }
 
-.sbb-header-open-menu:not(.sbb-header-app-chooser-available) {
-  @include mq($from: desktop) {
+.sbb-header-open-menu {
+  &:not(.sbb-header-app-chooser-available),
+  :host:not(.sbb-header-menus-collapsed) {
     visibility: hidden;
   }
 }
@@ -74,22 +101,26 @@ $sbbHeaderHeight: 54px;
   display: flex;
   flex-grow: 0;
   flex-direction: column;
-  width: 200px;
-  margin-left: 15px;
+  width: pxToRem(200);
+  margin-left: pxToRem(15);
   font-family: $fontSbbLight;
 
+  :host(.sbb-header-flexible) & {
+    width: auto;
+    margin-right: 2.5rem;
+  }
   > span {
     @include ellipsis();
   }
   > span:first-child {
-    line-height: 23px;
+    line-height: pxToRem(23);
     color: $sbbColorBlack;
     font-family: $fontSbbRoman;
   }
   > span:nth-child(2) {
-    font-size: 13px;
+    font-size: pxToRem(13);
     font-weight: 300;
-    line-height: 16px;
+    line-height: pxToRem(16);
     color: $sbbColorAnthracite;
   }
 }
@@ -97,8 +128,8 @@ $sbbHeaderHeight: 54px;
 nav {
   > ::ng-deep a,
   > ::ng-deep button {
-    line-height: 23px;
-    font-size: 15px;
+    line-height: pxToRem(23);
+    font-size: pxToRem(15);
     border: transparent solid 1px;
     outline: none;
     color: $sbbColorBlack;
@@ -113,7 +144,7 @@ nav {
   }
   > ::ng-deep a {
     text-decoration: none;
-    padding: 6px 8px;
+    padding: pxToRem(6) pxToRem(8);
   }
   > ::ng-deep button {
     cursor: pointer;
@@ -127,12 +158,12 @@ nav {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  margin-right: 35px;
+  margin-right: pxToRem(35);
 
   > .sbb-header-usermenu {
     z-index: 1;
-    margin-left: 15px;
-    margin-right: 15px;
+    margin-left: pxToRem(15);
+    margin-right: pxToRem(15);
   }
 
   > .sbb-header-logo {
@@ -140,7 +171,7 @@ nav {
     height: $sbbHeaderHeight;
 
     > svg {
-      width: 80px;
+      width: pxToRem(80);
     }
   }
 }
@@ -167,7 +198,7 @@ nav {
   top: 0;
   background-color: $sbbColorWhite;
   border-right: 1px solid $sbbColorGranite;
-  box-shadow: 4px 0 0 0 rgba(0, 0, 0, 0.15);
+  box-shadow: pxToRem(4) 0 0 0 rgba(0, 0, 0, 0.15);
   z-index: $sbbHeaderSideMenuZIndex;
   overflow-y: auto;
 
@@ -175,13 +206,13 @@ nav {
     display: flex;
     align-items: center;
     height: $sbbHeaderHeight;
-    margin-bottom: 12px;
+    margin-bottom: pxToRem(12);
     flex: 0 0 auto;
   }
 
   nav {
     flex-direction: column;
-    margin: 0 15px;
+    margin: 0 pxToRem(15);
 
     > ::ng-deep a,
     > ::ng-deep button {

--- a/src/angular-business/header/public-api.ts
+++ b/src/angular-business/header/public-api.ts
@@ -1,5 +1,6 @@
 export * from './app-chooser-section/app-chooser-section.component';
 export * from './header/header.component';
+export * from './header-environment/header-environment.directive';
 export * from './header/header-token';
 export * from './header-menu/header-menu.component';
 export * from './header-menu-item/header-menu-item.directive';

--- a/src/showcase-merge/app/app.component.html
+++ b/src/showcase-merge/app/app.component.html
@@ -1,4 +1,10 @@
-<sbb-header label="SBB Angular" [subtitle]="'Version ' + showcaseVersion">
+<sbb-header
+  class="sbb-header-flexible"
+  label="SBB Angular"
+  [subtitle]="'Version ' + showcaseVersion"
+  collapseBreakpoint="mobile"
+>
+  <sbb-header-environment>dev</sbb-header-environment>
   <sbb-app-chooser-section label="Links">
     <a target="_blank" href="https://github.com/sbb-design-systems/sbb-angular">GitHub</a>
     <a target="_blank" href="https://angular.io/">Angular {{ angularVersion }}</a>

--- a/src/showcase/app/app.component.html
+++ b/src/showcase/app/app.component.html
@@ -1,4 +1,9 @@
-<sbb-header label="SBB Angular" [subtitle]="'Version ' + showcaseVersion">
+<sbb-header
+  class="sbb-header-flexible"
+  label="SBB Angular"
+  [subtitle]="'Version ' + showcaseVersion"
+  collapseBreakpoint="mobile"
+>
   <sbb-app-chooser-section label="Links">
     <a target="_blank" href="https://github.com/sbb-design-systems/sbb-angular">GitHub</a>
     <a target="_blank" href="https://angular.io/">Angular {{ angularVersion }}</a>


### PR DESCRIPTION
Adds a flexible mode (css class .sbb-header-flexible) to the header, which
disables the five column layout. This will become the default in a future release.
Also adds the sbb-header-environment element, which replaces the environment
and environmentColor inputs (which are now deprecated).
See header documentation for details.