### PR TITLE
refactor: lower specificity of .sbb-icon-fit selector

### DIFF
--- a/src/angular-business/contextmenu/contextmenu/contextmenu.component.scss
+++ b/src/angular-business/contextmenu/contextmenu/contextmenu.component.scss
@@ -20,8 +20,7 @@ $sbbContextmenuBorderRadius: 2px;
     cursor: pointer;
     color: $sbbColorBlack;
 
-    /* Use tag and class selector to be more specific than the icon rule for width and height */
-    sbb-icon.sbb-icon {
+    .sbb-icon {
       height: $sbbContextmenuIconSize;
       width: $sbbContextmenuIconSize;
     }

--- a/src/angular-core/icon/icon.scss
+++ b/src/angular-core/icon/icon.scss
@@ -3,15 +3,6 @@
   display: inline-block;
   line-height: 0;
 
-  // If any ancestor has .sbb-icon-fit as a class, this rule will be applied.
-  .sbb-icon-fit &,
-  .sbb-icon-fit & svg,
-  &.sbb-icon-fit,
-  &.sbb-icon-fit svg {
-    width: 100%;
-    height: 100%;
-  }
-
   svg:not(.color-immutable) {
     [fill]:not([fill='none']) {
       fill: currentColor;
@@ -38,4 +29,13 @@
     line-height: inherit;
     width: inherit;
   }
+}
+
+// If any ancestor has .sbb-icon-fit as a class, this rule will be applied.
+.sbb-icon-fit sbb-icon,
+.sbb-icon-fit sbb-icon svg,
+sbb-icon.sbb-icon-fit,
+sbb-icon.sbb-icon-fit svg {
+  width: 100%;
+  height: 100%;
 }

--- a/src/angular/icon/icon.scss
+++ b/src/angular/icon/icon.scss
@@ -3,15 +3,6 @@
   display: inline-block;
   line-height: 0;
 
-  // If any ancestor has .sbb-icon-fit as a class, this rule will be applied.
-  .sbb-icon-fit &,
-  .sbb-icon-fit & svg,
-  &.sbb-icon-fit,
-  &.sbb-icon-fit svg {
-    width: 100%;
-    height: 100%;
-  }
-
   svg:not(.color-immutable) {
     [fill]:not([fill='none']) {
       fill: currentColor;
@@ -38,4 +29,13 @@
     line-height: inherit;
     width: inherit;
   }
+}
+
+// If any ancestor has .sbb-icon-fit as a class, this rule will be applied.
+.sbb-icon-fit sbb-icon,
+.sbb-icon-fit sbb-icon svg,
+sbb-icon.sbb-icon-fit,
+sbb-icon.sbb-icon-fit svg {
+  width: 100%;
+  height: 100%;
 }

--- a/src/angular/select/select/select.scss
+++ b/src/angular/select/select/select.scss
@@ -38,7 +38,7 @@
   text-overflow: ellipsis;
 }
 
-sbb-icon.sbb-icon.sbb-select-arrow-icon {
+.sbb-icon.sbb-select-arrow-icon {
   flex: 0 0 auto;
   transition: transform 120ms cubic-bezier(0, 0, 0.2, 1);
   color: $sbbColorGrey;

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -1656,8 +1656,7 @@ $menuItemPaddingTopBottom: 4;
     }
   }
 
-  /* Use tag and class selector to be more specific than the icon rule for width and height */
-  sbb-icon.sbb-icon {
+  .sbb-icon {
     line-height: 0;
     margin: pxToRem(-7) 0 pxToRem(-7) 0;
     transform: translateY(pxToRem(7));


### PR DESCRIPTION
The current selector is fairly aggressive and requires constructs
like .sbb-icon.sbb-icon {} to overwrite reliably. This change should
address that problem partially.