### PR TITLE
fix: remove positioning fix for tick

### DIFF
--- a/src/angular-core/styles/includes/_checkbox.scss
+++ b/src/angular-core/styles/includes/_checkbox.scss
@@ -63,20 +63,6 @@ $checkboxRadioButtonHorizontalSpace: if($sbbBusiness, 15, 32);
     border-radius: toPx(2);
     transform: scale(1.3);
     transition: opacity 0.3s cubic-bezier(0.785, 0.135, 0.15, 0.86);
-
-    & > svg {
-      transform: translateY(toPx(-1.5));
-
-      @include publicOnly() {
-        @include mq($from: desktop4k) {
-          transform: translateY(toPx(-1.5 * $scalingFactor4k));
-        }
-
-        @include mq($from: desktop5k) {
-          transform: translateY(toPx(-1.5 * $scalingFactor5k));
-        }
-      }
-    }
   }
 }
 

--- a/src/angular-public/option/option/option.component.scss
+++ b/src/angular-public/option/option/option.component.scss
@@ -40,17 +40,6 @@ sbb-option {
       margin-right: 4px;
       overflow: hidden;
 
-      .sbb-checkbox-checked > svg {
-        @if $sbbBusiness {
-          transform: translateY(toPx(-2));
-        } @else {
-          transform: translateY(toPx(-2));
-          @include mq($from: desktop5k) {
-            transform: translateY(toPx(-4));
-          }
-        }
-      }
-
       @include publicOnly() {
         @include mq($from: desktop4k) {
           margin-right: toPx(4 * $scalingFactor4k);

--- a/src/angular/checkbox/checkbox.html
+++ b/src/angular/checkbox/checkbox.html
@@ -27,7 +27,13 @@
         viewBox="0 0 24 24"
         focusable="false"
       >
-        <polyline fill="none" stroke="#000" points="6 15 10 19 19 10.01" />
+        <polyline
+          fill="none"
+          fill-rule="evenodd"
+          stroke="#000"
+          stroke-width="1"
+          points="6 12 10 16 19 7.01"
+        />
       </svg>
     </span>
   </div>

--- a/src/angular/core/option/pseudo-checkbox.html
+++ b/src/angular/core/option/pseudo-checkbox.html
@@ -7,7 +7,13 @@
       viewBox="0 0 24 24"
       focusable="false"
     >
-      <polyline fill="none" stroke="#000" points="6 15 10 19 19 10.01" />
+      <polyline
+        fill="none"
+        fill-rule="evenodd"
+        stroke="#000"
+        stroke-width="1"
+        points="6 12 10 16 19 7.01"
+      />
     </svg>
   </span>
 </div>

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -972,16 +972,6 @@ fieldset,
       line-height: 0;
       width: 100%;
       height: 100%;
-      transform: translateY(pxToRem(-1.5));
-
-      html:not(.sbb-lean) & {
-        @include mq($from: desktop4k) {
-          transform: translateY(pxToRem(-1.5 * $scalingFactor4k));
-        }
-        @include mq($from: desktop5k) {
-          transform: translateY(pxToRem(-1.5 * $scalingFactor5k));
-        }
-      }
 
       & > polyline {
         stroke: currentColor;


### PR DESCRIPTION
Previously the checkbox tick was positioned slightly below specification.
This has been fixed in the icon CDN, which caused the tick to be placed
above the intended position. This change fixes the positioning.