### PR TITLE
fix(tabs): prevent re-creation of existing tab instances on (redundant) activation of active tab

### DIFF
--- a/src/angular-public/tabs/tabs/tabs.component.spec.ts
+++ b/src/angular-public/tabs/tabs/tabs.component.spec.ts
@@ -130,6 +130,17 @@ describe('SbbTabs', () => {
     expect(component.numberOfTimesSubComponentHasBeenInitialized).toEqual(1);
   });
 
+  it('should not render lazy tab content again, when opening active tab', async () => {
+    component.tabsComponent.openTabByIndex(3);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    component.tabsComponent.openTabByIndex(3); // open active tab (redundantly)
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.numberOfTimesSubComponentHasBeenInitialized).toEqual(1);
+  });
+
   it('should render lazy tab content multiple times, when switching tabs', async () => {
     component.tabsComponent.openTabByIndex(3);
     fixture.detectChanges();

--- a/src/angular-public/tabs/tabs/tabs.component.ts
+++ b/src/angular-public/tabs/tabs/tabs.component.ts
@@ -96,6 +96,9 @@ export class SbbTabs implements AfterContentInit, OnDestroy {
 
   /** Method that selects the tab that matches with the tab in input */
   selectTab(tab: SbbTab, firstSelection = false) {
+    if (tab.active) {
+      return; // skip redundant update
+    }
     // TODO: Check if there is a better solution for this timing issue
     Promise.resolve().then(() => {
       this.tabs.forEach((t, index) => {


### PR DESCRIPTION
This prevents problems when tabs are opened programmatically based on external information,
such as query params.

Closes #638