### PR TITLE
fix: update xlf files to fix interpolated entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@types/node": "^14.14.22",
     "@types/parse5": "^6.0.0",
     "@types/svgo": "^1.3.3",
-    "angular-t9n": "^11.1.2",
+    "angular-t9n": "^11.1.3",
     "codelyzer": "^6.0.0-next.2",
     "dgeni": "^0.4.12",
     "dgeni-packages": "^0.28.4",

--- a/src/angular-core/i18n/xlf/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.de-CH.xlf
@@ -63,13 +63,13 @@
         <target state="translated">Sortierung für <x id="PH" equiv-text="this.id"/> ändern</target>
       </trans-unit>
       <trans-unit id="sbbTabsBadgePillAmountOfEntries" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entries</source>
-        <target state="signed-off"><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> Einträge</target>
+        <source><x id="INTERPOLATION" equiv-text="{{ tab.badgePill }}"/> entries</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ tab.badgePill }}"/> Einträge</target>
       </trans-unit>
       <trans-unit id="sbbTextareaCounterText" datatype="html">
-        <source> <x id="INTERPOLATION" equiv-text="  {{ _counter | async "/> characters remaining
+        <source> <x id="INTERPOLATION" equiv-text="{{ _counter | async }}"/> characters remaining
 </source>
-        <target state="signed-off">Noch <x id="INTERPOLATION" equiv-text=" {{ _counter | async "/> Zeichen</target>
+        <target state="translated">Noch <x id="INTERPOLATION" equiv-text="{{ _counter | async }}"/> Zeichen</target>
       </trans-unit>
       <trans-unit id="sbbTextexpandShowLess" datatype="html">
         <source>Show less</source>
@@ -79,21 +79,21 @@
         <source>Show more</source>
         <target state="signed-off">Mehr anzeigen</target>
       </trans-unit>
+      <trans-unit id="sbbUsermenuLogin" datatype="html">
+        <source>Login</source>
+        <target state="signed-off">Anmelden</target>
+      </trans-unit>
       <trans-unit id="sbbUsermenuOpenPanel" datatype="html">
         <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
-    "/>. Click or press enter to open user menu.</source>
+        "/>. Click or press enter to open user menu.</source>
         <target state="translated">Angemeldet als <x id="PH" equiv-text="this.displayName || this.userName
 "/>. Klicken oder Enter drücken, um das Benutzermenü zu öffnen.</target>
       </trans-unit>
       <trans-unit id="sbbUsermenuClosePanel" datatype="html">
         <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
-    "/>. Click or press enter to close user menu.</source>
+        "/>. Click or press enter to close user menu.</source>
         <target state="translated">Angemeldet als <x id="PH" equiv-text="this.displayName || this.userName
 "/>. Klicken oder Enter drücken, um das Benutzermenü zu schliessen.</target>
-      </trans-unit>
-      <trans-unit id="sbbUsermenuLogin" datatype="html">
-        <source>Login</source>
-        <target state="signed-off">Anmelden</target>
       </trans-unit>
       <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
         <source>Close message</source>
@@ -104,8 +104,8 @@
         <target state="translated">Starte Suche</target>
       </trans-unit>
       <trans-unit id="sbbTagBadgePillAmountOfResults" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> results available</source>
-        <target state="signed-off"><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> Resultate verfügbar</target>
+        <source><x id="INTERPOLATION" equiv-text="{{ amount }}"/> results available</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ amount }}"/> Resultate verfügbar</target>
       </trans-unit>
       <trans-unit id="sbbTagsAll" datatype="html">
         <source>All</source>

--- a/src/angular-core/i18n/xlf/messages.fr-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.fr-CH.xlf
@@ -63,13 +63,13 @@
         <target state="translated">Modifier le tri pour <x id="PH" equiv-text="this.id"/></target>
       </trans-unit>
       <trans-unit id="sbbTabsBadgePillAmountOfEntries" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entries</source>
-        <target state="translated"><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entrées</target>
+        <source><x id="INTERPOLATION" equiv-text="{{ tab.badgePill }}"/> entries</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ tab.badgePill }}"/> entrées</target>
       </trans-unit>
       <trans-unit id="sbbTextareaCounterText" datatype="html">
-        <source> <x id="INTERPOLATION" equiv-text="  {{ _counter | async "/> characters remaining
+        <source> <x id="INTERPOLATION" equiv-text="{{ _counter | async }}"/> characters remaining
 </source>
-        <target state="translated"> <x id="INTERPOLATION" equiv-text="  {{ _counter | async "/> caractères restants</target>
+        <target state="translated"> <x id="INTERPOLATION" equiv-text=" {{ _counter | async }}"/> caractères restants</target>
       </trans-unit>
       <trans-unit id="sbbTextexpandShowLess" datatype="html">
         <source>Show less</source>
@@ -79,21 +79,21 @@
         <source>Show more</source>
         <target state="translated">Afficher plus</target>
       </trans-unit>
+      <trans-unit id="sbbUsermenuLogin" datatype="html">
+        <source>Login</source>
+        <target state="translated">Se connecter</target>
+      </trans-unit>
       <trans-unit id="sbbUsermenuOpenPanel" datatype="html">
         <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
-    "/>. Click or press enter to open user menu.</source>
+        "/>. Click or press enter to open user menu.</source>
         <target state="translated">Connecté en tant que <x id="PH" equiv-text="this.displayName || this.userName
 "/>. Cliquez ou appuyez sur Entrée pour ouvrir le menu utilisateur.</target>
       </trans-unit>
       <trans-unit id="sbbUsermenuClosePanel" datatype="html">
         <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
-    "/>. Click or press enter to close user menu.</source>
+        "/>. Click or press enter to close user menu.</source>
         <target state="translated">Connecté en tant que <x id="PH" equiv-text="this.displayName || this.userName
 "/>. Cliquez ou appuyez sur Entrée pour fermer le menu utilisateur.</target>
-      </trans-unit>
-      <trans-unit id="sbbUsermenuLogin" datatype="html">
-        <source>Login</source>
-        <target state="translated">Se connecter</target>
       </trans-unit>
       <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
         <source>Close message</source>
@@ -104,8 +104,8 @@
         <target state="translated">Lancer la recherche</target>
       </trans-unit>
       <trans-unit id="sbbTagBadgePillAmountOfResults" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> results available</source>
-        <target state="translated"><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> resultats disponbiles</target>
+        <source><x id="INTERPOLATION" equiv-text="{{ amount }}"/> results available</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ amount }}"/> resultats disponbiles</target>
       </trans-unit>
       <trans-unit id="sbbTagsAll" datatype="html">
         <source>All</source>

--- a/src/angular-core/i18n/xlf/messages.it-CH.xlf
+++ b/src/angular-core/i18n/xlf/messages.it-CH.xlf
@@ -63,13 +63,13 @@
         <target state="translated">Cambia l'ordinamento per <x id="PH" equiv-text="this.id"/></target>
       </trans-unit>
       <trans-unit id="sbbTabsBadgePillAmountOfEntries" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> entries</source>
-        <target state="translated"><x id="INTERPOLATION" equiv-text="aria-label=&quot;{{ tab."/> voci</target>
+        <source><x id="INTERPOLATION" equiv-text="{{ tab.badgePill }}"/> entries</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ tab.badgePill }}"/> voci</target>
       </trans-unit>
       <trans-unit id="sbbTextareaCounterText" datatype="html">
-        <source> <x id="INTERPOLATION" equiv-text="  {{ _counter | async "/> characters remaining
+        <source> <x id="INTERPOLATION" equiv-text="{{ _counter | async }}"/> characters remaining
 </source>
-        <target state="translated"><x id="INTERPOLATION" equiv-text=" {{ _counter | async "/> caratteri rimanenti</target>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ _counter | async }}"/> caratteri rimanenti</target>
       </trans-unit>
       <trans-unit id="sbbTextexpandShowLess" datatype="html">
         <source>Show less</source>
@@ -79,21 +79,21 @@
         <source>Show more</source>
         <target state="signed-off">Visualizzare di più</target>
       </trans-unit>
+      <trans-unit id="sbbUsermenuLogin" datatype="html">
+        <source>Login</source>
+        <target state="signed-off">Accedi</target>
+      </trans-unit>
       <trans-unit id="sbbUsermenuOpenPanel" datatype="html">
         <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
-    "/>. Click or press enter to open user menu.</source>
+        "/>. Click or press enter to open user menu.</source>
         <target state="translated">Accesso eseguito come <x id="PH" equiv-text="this.displayName || this.userName
 "/>. Fare clic o premere Invio per aprire il menu utente.</target>
       </trans-unit>
       <trans-unit id="sbbUsermenuClosePanel" datatype="html">
         <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
-    "/>. Click or press enter to close user menu.</source>
+        "/>. Click or press enter to close user menu.</source>
         <target state="translated">Accesso eseguito come <x id="PH" equiv-text="this.displayName || this.userName
 "/>. Fare clic o premere Invio per chiudere il menu utente.</target>
-      </trans-unit>
-      <trans-unit id="sbbUsermenuLogin" datatype="html">
-        <source>Login</source>
-        <target state="signed-off">Accedi</target>
       </trans-unit>
       <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
         <source>Close message</source>
@@ -104,8 +104,8 @@
         <target state="translated">Avviare la ricerca</target>
       </trans-unit>
       <trans-unit id="sbbTagBadgePillAmountOfResults" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> results available</source>
-        <target state="translated"><x id="INTERPOLATION" equiv-text="aria-label=&quot;"/> risultati disponibili</target>
+        <source><x id="INTERPOLATION" equiv-text="{{ amount }}"/> results available</source>
+        <target state="translated"><x id="INTERPOLATION" equiv-text="{{ amount }}"/> risultati disponibili</target>
       </trans-unit>
       <trans-unit id="sbbTagsAll" datatype="html">
         <source>All</source>

--- a/src/angular-core/i18n/xlf/messages.xlf
+++ b/src/angular-core/i18n/xlf/messages.xlf
@@ -162,7 +162,7 @@
         <source>Collapse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">19</context>
         </context-group>
         <note priority="1" from="description">Label to &apos;collapse&apos; icon sidebar</note>
       </trans-unit>
@@ -170,7 +170,7 @@
         <source>Expand</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">26</context>
         </context-group>
         <note priority="1" from="description">Label to &apos;expand&apos; icon sidebar</note>
       </trans-unit>
@@ -186,13 +186,14 @@
         <source><x id="INTERPOLATION" equiv-text="{{ tab.badgePill }}"/> entries</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular-business/tabs/tabs/tabs.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">27</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular-public/tabs/tabs/tabs.component.html</context>
           <context context-type="linenumber">27</context>
         </context-group>
-        <note priority="1" from="description">Aria label for amount of entries displayed in badge pill</note>
+        <note priority="1" from="description">Aria label for amount of entries displayed in badge
+            pill</note>
       </trans-unit>
       <trans-unit id="sbbTextareaCounterText" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ _counter | async }}"/> characters remaining
@@ -203,6 +204,10 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular-public/textarea/textarea/textarea.component.html</context>
+          <context context-type="linenumber">19,21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular/textarea/textarea/textarea.html</context>
           <context context-type="linenumber">19,21</context>
         </context-group>
         <note priority="1" from="description">Counter text for textarea</note>
@@ -217,6 +222,10 @@
           <context context-type="sourcefile">../../../../../../src/angular-public/textexpand/textexpand/textexpand.component.html</context>
           <context context-type="linenumber">14</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular/textexpand/textexpand.html</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
         <note priority="1" from="description">Button label for showing less</note>
       </trans-unit>
       <trans-unit id="sbbTextexpandShowMore" datatype="html">
@@ -229,33 +238,11 @@
           <context context-type="sourcefile">../../../../../../src/angular-public/textexpand/textexpand/textexpand.component.html</context>
           <context context-type="linenumber">20</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular/textexpand/textexpand.html</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
         <note priority="1" from="description">Button label for showing more</note>
-      </trans-unit>
-      <trans-unit id="sbbUsermenuOpenPanel" datatype="html">
-        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
-        "/>. Click or press enter to open user menu.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">../../../../../../src/angular-business/usermenu/usermenu.ts</context>
-          <context context-type="linenumber">198,200</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">../../../../../../src/angular-public/usermenu/usermenu.ts</context>
-          <context context-type="linenumber">196,198</context>
-        </context-group>
-        <note priority="1" from="description">Aria label to open user menu</note>
-      </trans-unit>
-      <trans-unit id="sbbUsermenuClosePanel" datatype="html">
-        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
-        "/>. Click or press enter to close user menu.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">../../../../../../src/angular-business/usermenu/usermenu.ts</context>
-          <context context-type="linenumber">208,210</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">../../../../../../src/angular-public/usermenu/usermenu.ts</context>
-          <context context-type="linenumber">206,208</context>
-        </context-group>
-        <note priority="1" from="description">Aria label to close user menu</note>
       </trans-unit>
       <trans-unit id="sbbUsermenuLogin" datatype="html">
         <source>Login</source>
@@ -268,6 +255,32 @@
           <context context-type="linenumber">10</context>
         </context-group>
         <note priority="1" from="description">Button label for login</note>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuOpenPanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+        "/>. Click or press enter to open user menu.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/usermenu/usermenu.ts</context>
+          <context context-type="linenumber">197,199</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/usermenu/usermenu.ts</context>
+          <context context-type="linenumber">195,197</context>
+        </context-group>
+        <note priority="1" from="description">Aria label to open user menu</note>
+      </trans-unit>
+      <trans-unit id="sbbUsermenuClosePanel" datatype="html">
+        <source>Logged in as <x id="PH" equiv-text="this.displayName || this.userName
+        "/>. Click or press enter to close user menu.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-business/usermenu/usermenu.ts</context>
+          <context context-type="linenumber">207,209</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular-public/usermenu/usermenu.ts</context>
+          <context context-type="linenumber">205,207</context>
+        </context-group>
+        <note priority="1" from="description">Aria label to close user menu</note>
       </trans-unit>
       <trans-unit id="sbbGhettoboxCloseGhettobox" datatype="html">
         <source>Close message</source>

--- a/src/angular-core/i18n/xlf2/messages.de-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.de-CH.xlf
@@ -93,15 +93,15 @@
     </unit>
     <unit id="sbbTabsBadgePillAmountOfEntries">
       <segment state="reviewed">
-        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> entries</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> Einträge</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ tab.badgePill }}"/> entries</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ tab.badgePill }}"/> Einträge</target>
       </segment>
     </unit>
     <unit id="sbbTextareaCounterText">
       <segment state="reviewed">
-        <source> <ph id="0" equiv="INTERPOLATION" disp="  {{ _counter | async "/> characters remaining
+        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ _counter | async }}"/> characters remaining
 </source>
-        <target>Noch <ph id="0" equiv="INTERPOLATION" disp=" {{ _counter | async "/> Zeichen</target>
+        <target>Noch <ph id="0" equiv="INTERPOLATION" disp="{{ _counter | async }}"/> Zeichen</target>
       </segment>
     </unit>
     <unit id="sbbTextexpandShowLess">
@@ -116,10 +116,16 @@
         <target>Mehr anzeigen</target>
       </segment>
     </unit>
+    <unit id="sbbUsermenuLogin">
+      <segment state="reviewed">
+        <source>Login</source>
+        <target>Anmelden</target>
+      </segment>
+    </unit>
     <unit id="sbbUsermenuOpenPanel">
       <segment state="translated">
         <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
-    "/>. Click or press enter to open user menu.</source>
+        "/>. Click or press enter to open user menu.</source>
         <target>Angemeldet als <ph id="0" equiv="PH" disp="this.displayName || this.userName
 "/>. Klicken oder Enter drücken, um das Benutzermenü zu öffnen.</target>
       </segment>
@@ -127,15 +133,9 @@
     <unit id="sbbUsermenuClosePanel">
       <segment state="translated">
         <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
-    "/>. Click or press enter to close user menu.</source>
+        "/>. Click or press enter to close user menu.</source>
         <target>Angemeldet als <ph id="0" equiv="PH" disp="this.displayName || this.userName
 "/>. Klicken oder Enter drücken, um das Benutzermenü zu schliessen.</target>
-      </segment>
-    </unit>
-    <unit id="sbbUsermenuLogin">
-      <segment state="reviewed">
-        <source>Login</source>
-        <target>Anmelden</target>
       </segment>
     </unit>
     <unit id="sbbGhettoboxCloseGhettobox">
@@ -152,8 +152,8 @@
     </unit>
     <unit id="sbbTagBadgePillAmountOfResults">
       <segment state="reviewed">
-        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> results available</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> Resultate verfügbar</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ amount }}"/> results available</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ amount }}"/> Resultate verfügbar</target>
       </segment>
     </unit>
     <unit id="sbbTagsAll">

--- a/src/angular-core/i18n/xlf2/messages.fr-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.fr-CH.xlf
@@ -93,15 +93,15 @@
     </unit>
     <unit id="sbbTabsBadgePillAmountOfEntries">
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> entries</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> entrées</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ tab.badgePill }}"/> entries</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ tab.badgePill }}"/> entrées</target>
       </segment>
     </unit>
     <unit id="sbbTextareaCounterText">
       <segment state="translated">
-        <source> <ph id="0" equiv="INTERPOLATION" disp="  {{ _counter | async "/> characters remaining
+        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ _counter | async }}"/> characters remaining
 </source>
-        <target><ph id="0" equiv="INTERPOLATION" disp=" {{ _counter | async "/> caractères restants</target>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ _counter | async }}"/> caractères restants</target>
       </segment>
     </unit>
     <unit id="sbbTextexpandShowLess">
@@ -116,10 +116,16 @@
         <target>Afficher plus</target>
       </segment>
     </unit>
+    <unit id="sbbUsermenuLogin">
+      <segment state="translated">
+        <source>Login</source>
+        <target>Se connecter</target>
+      </segment>
+    </unit>
     <unit id="sbbUsermenuOpenPanel">
       <segment state="translated">
         <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
-    "/>. Click or press enter to open user menu.</source>
+        "/>. Click or press enter to open user menu.</source>
         <target>Connecté en tant que <ph id="0" equiv="PH" disp="this.displayName || this.userName
 "/>. Cliquez ou appuyez sur Entrée pour ouvrir le menu utilisateur.</target>
       </segment>
@@ -127,15 +133,9 @@
     <unit id="sbbUsermenuClosePanel">
       <segment state="translated">
         <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
-    "/>. Click or press enter to close user menu.</source>
+        "/>. Click or press enter to close user menu.</source>
         <target>Connecté en tant que <ph id="0" equiv="PH" disp="this.displayName || this.userName
 "/>. Cliquez ou appuyez sur Entrée pour fermer le menu utilisateur.</target>
-      </segment>
-    </unit>
-    <unit id="sbbUsermenuLogin">
-      <segment state="translated">
-        <source>Login</source>
-        <target>Se connecter</target>
       </segment>
     </unit>
     <unit id="sbbGhettoboxCloseGhettobox">
@@ -152,8 +152,8 @@
     </unit>
     <unit id="sbbTagBadgePillAmountOfResults">
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> results available</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> resultats disponbiles</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ amount }}"/> results available</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ amount }}"/> resultats disponbiles</target>
       </segment>
     </unit>
     <unit id="sbbTagsAll">

--- a/src/angular-core/i18n/xlf2/messages.it-CH.xlf
+++ b/src/angular-core/i18n/xlf2/messages.it-CH.xlf
@@ -93,15 +93,15 @@
     </unit>
     <unit id="sbbTabsBadgePillAmountOfEntries">
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> entries</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;{{ tab."/> voci</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ tab.badgePill }}"/> entries</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ tab.badgePill }}"/> voci</target>
       </segment>
     </unit>
     <unit id="sbbTextareaCounterText">
       <segment state="translated">
-        <source> <ph id="0" equiv="INTERPOLATION" disp="  {{ _counter | async "/> characters remaining
+        <source> <ph id="0" equiv="INTERPOLATION" disp="{{ _counter | async }}"/> characters remaining
 </source>
-        <target><x id="INTERPOLATION" equiv-text=" {{ _counter | async "/> caratteri rimanenti</target>
+        <target><x id="INTERPOLATION" equiv-text="{{ _counter | async }}"/> caratteri rimanenti</target>
       </segment>
     </unit>
     <unit id="sbbTextexpandShowLess">
@@ -116,10 +116,16 @@
         <target>Visualizzare di più</target>
       </segment>
     </unit>
+    <unit id="sbbUsermenuLogin">
+      <segment state="translated">
+        <source>Login</source>
+        <target>Accedi</target>
+      </segment>
+    </unit>
     <unit id="sbbUsermenuOpenPanel">
       <segment state="translated">
         <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
-    "/>. Click or press enter to open user menu.</source>
+        "/>. Click or press enter to open user menu.</source>
         <target>Accesso eseguito come <ph id="0" equiv="PH" disp="this.displayName || this.userName
 "/>. Fare clic o premere Invio per aprire il menu utente.</target>
       </segment>
@@ -127,15 +133,9 @@
     <unit id="sbbUsermenuClosePanel">
       <segment state="translated">
         <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
-    "/>. Click or press enter to close user menu.</source>
+        "/>. Click or press enter to close user menu.</source>
         <target>Accesso eseguito come <ph id="0" equiv="PH" disp="this.displayName || this.userName
 "/>. Fare clic o premere Invio per chiudere il menu utente.</target>
-      </segment>
-    </unit>
-    <unit id="sbbUsermenuLogin">
-      <segment state="translated">
-        <source>Login</source>
-        <target>Accedi</target>
       </segment>
     </unit>
     <unit id="sbbGhettoboxCloseGhettobox">
@@ -152,8 +152,8 @@
     </unit>
     <unit id="sbbTagBadgePillAmountOfResults">
       <segment state="translated">
-        <source><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> results available</source>
-        <target><ph id="0" equiv="INTERPOLATION" disp="aria-label=&quot;"/> risultati disponibili</target>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ amount }}"/> results available</source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ amount }}"/> risultati disponibili</target>
       </segment>
     </unit>
     <unit id="sbbTagsAll">

--- a/src/angular-core/i18n/xlf2/messages.xlf
+++ b/src/angular-core/i18n/xlf2/messages.xlf
@@ -126,7 +126,7 @@
     </unit>
     <unit id="sbbSidebarCollapse">
       <notes>
-        <note category="location">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html:18</note>
+        <note category="location">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html:19</note>
         <note category="description">Label to &apos;collapse&apos; icon sidebar</note>
       </notes>
       <segment>
@@ -135,7 +135,7 @@
     </unit>
     <unit id="sbbSidebarExpand">
       <notes>
-        <note category="location">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html:25</note>
+        <note category="location">../../../../../../src/angular-business/sidebar/icon-sidebar/icon-sidebar.html:26</note>
         <note category="description">Label to &apos;expand&apos; icon sidebar</note>
       </notes>
       <segment>
@@ -153,9 +153,10 @@
     </unit>
     <unit id="sbbTabsBadgePillAmountOfEntries">
       <notes>
-        <note category="location">../../../../../../src/angular-business/tabs/tabs/tabs.component.html:25</note>
+        <note category="location">../../../../../../src/angular-business/tabs/tabs/tabs.component.html:27</note>
         <note category="location">../../../../../../src/angular-public/tabs/tabs/tabs.component.html:27</note>
-        <note category="description">Aria label for amount of entries displayed in badge pill</note>
+        <note category="description">Aria label for amount of entries displayed in badge
+            pill</note>
       </notes>
       <segment>
         <source><ph id="0" equiv="INTERPOLATION" disp="{{ tab.badgePill }}"/> entries</source>
@@ -165,6 +166,7 @@
       <notes>
         <note category="location">../../../../../../src/angular-business/textarea/textarea/textarea.component.html:19,21</note>
         <note category="location">../../../../../../src/angular-public/textarea/textarea/textarea.component.html:19,21</note>
+        <note category="location">../../../../../../src/angular/textarea/textarea/textarea.html:19,21</note>
         <note category="description">Counter text for textarea</note>
       </notes>
       <segment>
@@ -176,6 +178,7 @@
       <notes>
         <note category="location">../../../../../../src/angular-business/textexpand/textexpand/textexpand.component.html:14</note>
         <note category="location">../../../../../../src/angular-public/textexpand/textexpand/textexpand.component.html:14</note>
+        <note category="location">../../../../../../src/angular/textexpand/textexpand.html:14</note>
         <note category="description">Button label for showing less</note>
       </notes>
       <segment>
@@ -186,32 +189,11 @@
       <notes>
         <note category="location">../../../../../../src/angular-business/textexpand/textexpand/textexpand.component.html:20</note>
         <note category="location">../../../../../../src/angular-public/textexpand/textexpand/textexpand.component.html:20</note>
+        <note category="location">../../../../../../src/angular/textexpand/textexpand.html:20</note>
         <note category="description">Button label for showing more</note>
       </notes>
       <segment>
         <source>Show more</source>
-      </segment>
-    </unit>
-    <unit id="sbbUsermenuOpenPanel">
-      <notes>
-        <note category="location">../../../../../../src/angular-business/usermenu/usermenu.ts:198,200</note>
-        <note category="location">../../../../../../src/angular-public/usermenu/usermenu.ts:196,198</note>
-        <note category="description">Aria label to open user menu</note>
-      </notes>
-      <segment>
-        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
-        "/>. Click or press enter to open user menu.</source>
-      </segment>
-    </unit>
-    <unit id="sbbUsermenuClosePanel">
-      <notes>
-        <note category="location">../../../../../../src/angular-business/usermenu/usermenu.ts:208,210</note>
-        <note category="location">../../../../../../src/angular-public/usermenu/usermenu.ts:206,208</note>
-        <note category="description">Aria label to close user menu</note>
-      </notes>
-      <segment>
-        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
-        "/>. Click or press enter to close user menu.</source>
       </segment>
     </unit>
     <unit id="sbbUsermenuLogin">
@@ -222,6 +204,28 @@
       </notes>
       <segment>
         <source>Login</source>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuOpenPanel">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/usermenu/usermenu.ts:197,199</note>
+        <note category="location">../../../../../../src/angular-public/usermenu/usermenu.ts:195,197</note>
+        <note category="description">Aria label to open user menu</note>
+      </notes>
+      <segment>
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+        "/>. Click or press enter to open user menu.</source>
+      </segment>
+    </unit>
+    <unit id="sbbUsermenuClosePanel">
+      <notes>
+        <note category="location">../../../../../../src/angular-business/usermenu/usermenu.ts:207,209</note>
+        <note category="location">../../../../../../src/angular-public/usermenu/usermenu.ts:205,207</note>
+        <note category="description">Aria label to close user menu</note>
+      </notes>
+      <segment>
+        <source>Logged in as <ph id="0" equiv="PH" disp="this.displayName || this.userName
+        "/>. Click or press enter to close user menu.</source>
       </segment>
     </unit>
     <unit id="sbbGhettoboxCloseGhettobox">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,10 +3370,10 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-angular-t9n@^11.1.2:
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/angular-t9n/-/angular-t9n-11.1.2.tgz#2533d9322249a16e5eb564f6473dbdd4f6ec6c19"
-  integrity sha512-lRoEREMdaMPQv7tsLMH8AoPu+MyzVWi1uuOUiA2gqKL7TrbHHl/EqYjE0/AyHRahJnvLTeY8PmTVyWjL2ejC7Q==
+angular-t9n@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/angular-t9n/-/angular-t9n-11.1.3.tgz#f163e99e0d138044b4dcb3aaa5b3b63884dcae1c"
+  integrity sha512-umNEuDDLuitXimxsUASRVtPTZKdpbkSiJfdjGXHf+m5ZJ6DUl0tkvAwJ3bI1V/Ahr4+yBWlFRg5i9vZGzdSV8A==
   dependencies:
     "@nestjs/common" "^7.5.2"
     "@nestjs/core" "^7.5.2"


### PR DESCRIPTION
The Angular i18n extractor changed the output format for interpolation
elements, which causes consumers to break when using our xlf files.