### PR TITLE
fix: apply error styles based on the error state of the form field

### DIFF
--- a/src/angular-core/styles/includes/_form.scss
+++ b/src/angular-core/styles/includes/_form.scss
@@ -73,6 +73,9 @@ $labelColor: if($sbbBusiness, $sbbColorGranite, $sbbColorGrey);
     }
   }
 
+  // We want to provide the error styles both for invalid state
+  // in a sbb-form-field and also for Angular Form Validation.
+  .sbb-form-field-invalid &:not([aria-expanded='true']),
   &.ng-touched.ng-invalid:not([aria-expanded='true']) {
     color: $sbbColorError;
     border-color: $sbbColorError;

--- a/src/angular-public/select/select/select.component.scss
+++ b/src/angular-public/select/select/select.component.scss
@@ -129,6 +129,9 @@ sbb-select.sbb-select {
     }
   }
 
+  // We want to provide the error styles both for invalid state
+  // in a sbb-form-field and also for Angular Form Validation.
+  .sbb-form-field-invalid &:not([aria-expanded='true']),
   &.ng-touched.ng-invalid:not([aria-expanded='true']) {
     color: $sbbColorError;
     border-color: $sbbColorError;

--- a/src/angular-public/textarea/textarea/textarea.component.scss
+++ b/src/angular-public/textarea/textarea/textarea.component.scss
@@ -55,6 +55,9 @@
     opacity: 1;
   }
 
+  // We want to provide the error styles both for invalid state
+  // in a sbb-form-field and also for Angular Form Validation.
+  .sbb-form-field-invalid &,
   &.ng-touched.ng-invalid {
     border-color: $sbbColorCallToAction;
 

--- a/src/angular/form-field/form-field.md
+++ b/src/angular/form-field/form-field.md
@@ -87,6 +87,50 @@ if the messages are contained in one sbb-error element.
 </sbb-form-field>
 ```
 
+#### Touched vs dirty error state checking
+
+The default error state matcher checks for errors and whether the form control has been touched,
+which is usually triggered by leaving the form (blur event). An alternative is the
+`SbbShowOnDirtyErrorStateMatcher` (which needs to be added as a global provider), which
+checks for errors and whether the form control is dirty instead of touched, which is triggered as
+soon as the form control value changes, either by typing in the input field or selecting a value.
+
+You can either configure the `SbbShowOnDirtyErrorStateMatcher` globally by overriding the default
+`SbbErrorStateMatcher` or locally by proving it via input.
+
+**Global**
+
+```ts
+providers: [...{ provide: SbbErrorStateMatcher, useClass: SbbShowOnDirtyErrorStateMatcher }];
+```
+
+**Local**
+
+```ts
+providers: [...SbbShowOnDirtyErrorStateMatcher];
+```
+
+```ts
+  constructor(readonly errorStateMatcher: SbbShowOnDirtyErrorStateMatcher) {}
+```
+
+```html
+<sbb-form-field>
+  <sbb-label>Name</sbb-label>
+  <input
+    type="text"
+    sbbInput
+    formControlName="name"
+    placeholder="Name"
+    [errorStateMatcher]="errorStateMatcher"
+  />
+  <sbb-error *ngIf="form.get('name').errors?.required">This field is required.</sbb-error>
+  <sbb-error *ngIf="form.get('name').errors?.minlength"
+    >Min length is {{ name.errors?.minlength?.requiredLength }}!</sbb-error
+  >
+</sbb-form-field>
+```
+
 ### Accessibility
 
 Any errors added to the form field are automatically added to the form field control's

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -622,6 +622,9 @@ ul li ol > li::before,
     border-color: $sbbColorAluminum;
   }
 
+  // We want to provide the error styles both for invalid state
+  // in a sbb-form-field and also for Angular Form Validation.
+  .sbb-form-field-invalid &:not([aria-expanded='true']),
   &.ng-touched.ng-invalid:not([aria-expanded='true']) {
     color: $sbbColorError;
     border-color: $sbbColorError;
@@ -1504,7 +1507,13 @@ html.sbb-lean .sbb-pseudo-checkbox.sbb-selection-disabled .sbb-selection-contain
     color: $sbbColorBlack;
   }
 
-  &.ng-invalid {
+  // We need to provide error styling for both on the element
+  // or on a wrapper (e.g. sbb-radio-group) with both manual
+  // classes and Angular Form Validation classes.
+  &.sbb-selection-error,
+  .sbb-selection-error &,
+  &.ng-touched.ng-invalid,
+  .ng-touched.ng-invalid & {
     border-color: $sbbColorRed;
     color: $sbbColorRed;
   }

--- a/src/angular/textarea/textarea/textarea.scss
+++ b/src/angular/textarea/textarea/textarea.scss
@@ -22,6 +22,9 @@
     }
   }
 
+  // We want to provide the error styles both for invalid state
+  // in a sbb-form-field and also for Angular Form Validation.
+  .sbb-form-field-invalid & textarea,
   &.ng-touched.ng-invalid textarea {
     color: $sbbColorError;
   }

--- a/src/components-examples/angular/form-field/form-field-dirty-error-state/form-field-dirty-error-state-example.html
+++ b/src/components-examples/angular/form-field/form-field-dirty-error-state/form-field-dirty-error-state-example.html
@@ -1,0 +1,24 @@
+<p>
+  The default error state matcher checks for errors and whether the form control has been touched,
+  which is usually triggered by leaving the form (blur event). An alternative is the
+  <code>SbbShowOnDirtyErrorStateMatcher</code> (which needs to be added as a global provider), which
+  checks for errors and whether the form control is dirty instead of touched, which is triggered as
+  soon as the form control value changes, either by typing in the input field or selecting a value.
+</p>
+
+<sbb-form-field>
+  <sbb-label>Name</sbb-label>
+  <input
+    type="text"
+    sbbInput
+    [formControl]="name"
+    [errorStateMatcher]="errorStateMatcher"
+    autocomplete="off"
+    placeholder="Name"
+    spellcheck="false"
+  />
+  <sbb-error *ngIf="name.errors?.required">Name is required!</sbb-error>
+  <sbb-error *ngIf="name.errors?.minlength"
+    >Min length is {{ name.errors?.minlength?.requiredLength }}!</sbb-error
+  >
+</sbb-form-field>

--- a/src/components-examples/angular/form-field/form-field-dirty-error-state/form-field-dirty-error-state-example.html
+++ b/src/components-examples/angular/form-field/form-field-dirty-error-state/form-field-dirty-error-state-example.html
@@ -1,10 +1,4 @@
-<p>
-  The default error state matcher checks for errors and whether the form control has been touched,
-  which is usually triggered by leaving the form (blur event). An alternative is the
-  <code>SbbShowOnDirtyErrorStateMatcher</code> (which needs to be added as a global provider), which
-  checks for errors and whether the form control is dirty instead of touched, which is triggered as
-  soon as the form control value changes, either by typing in the input field or selecting a value.
-</p>
+<p>Local usage of <code>SbbShowOnDirtyErrorStateMatcher</code>.</p>
 
 <sbb-form-field>
   <sbb-label>Name</sbb-label>
@@ -13,9 +7,7 @@
     sbbInput
     [formControl]="name"
     [errorStateMatcher]="errorStateMatcher"
-    autocomplete="off"
     placeholder="Name"
-    spellcheck="false"
   />
   <sbb-error *ngIf="name.errors?.required">Name is required!</sbb-error>
   <sbb-error *ngIf="name.errors?.minlength"

--- a/src/components-examples/angular/form-field/form-field-dirty-error-state/form-field-dirty-error-state-example.ts
+++ b/src/components-examples/angular/form-field/form-field-dirty-error-state/form-field-dirty-error-state-example.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
+import { SbbShowOnDirtyErrorStateMatcher } from '@sbb-esta/angular/core';
+
+/**
+ * @title Form Field Dirty Error State Matcher
+ * @order 80
+ */
+@Component({
+  selector: 'sbb-form-field-dirty-error-state-example',
+  templateUrl: './form-field-dirty-error-state-example.html',
+})
+export class FormFieldDirtyErrorStateExample {
+  name: FormControl = new FormControl('', [Validators.required, Validators.minLength(5)]);
+
+  constructor(readonly errorStateMatcher: SbbShowOnDirtyErrorStateMatcher) {}
+}

--- a/src/components-examples/angular/form-field/form-field-text-input-attribute-label/form-field-text-input-attribute-label-example.html
+++ b/src/components-examples/angular/form-field/form-field-text-input-attribute-label/form-field-text-input-attribute-label-example.html
@@ -12,4 +12,6 @@
     <option value="long">Long</option>
   </select>
 </sbb-form-field>
-<sbb-checkbox (change)="toggleDisabled($event)"> Disabled </sbb-checkbox>
+<div>
+  <sbb-checkbox (change)="toggleDisabled($event)">Disabled</sbb-checkbox>
+</div>

--- a/src/components-examples/angular/form-field/form-field-text-input-sbb-label/form-field-text-input-sbb-label-example.html
+++ b/src/components-examples/angular/form-field/form-field-text-input-sbb-label/form-field-text-input-sbb-label-example.html
@@ -9,8 +9,11 @@
     spellcheck="false"
   />
   <sbb-error *ngIf="name.errors?.required">Name is required!</sbb-error>
+  <sbb-error *ngIf="name.errors?.minlength"
+    >Min length is {{ name.errors?.minlength?.requiredLength }}!</sbb-error
+  >
 </sbb-form-field>
-<p>*Name must be at least 3 characters long</p>
+<p>Name must be at least 3 characters long</p>
 
 <h4>Properties</h4>
 <sbb-checkbox (change)="toggleDisabled($event)">Disabled</sbb-checkbox>

--- a/src/components-examples/angular/form-field/index.ts
+++ b/src/components-examples/angular/form-field/index.ts
@@ -5,11 +5,13 @@ import { SbbDatepickerModule } from '@sbb-esta/angular-public/datepicker';
 import { SbbTooltipModule } from '@sbb-esta/angular-public/tooltip';
 import { SbbButtonModule } from '@sbb-esta/angular/button';
 import { SbbCheckboxModule } from '@sbb-esta/angular/checkbox';
+import { SbbShowOnDirtyErrorStateMatcher } from '@sbb-esta/angular/core';
 import { SbbFormFieldModule } from '@sbb-esta/angular/form-field';
 import { SbbSelectModule } from '@sbb-esta/angular/select';
 import { SbbTimeInputModule } from '@sbb-esta/angular/time-input';
 
 import { FormFieldDatepickerExample } from './form-field-datepicker/form-field-datepicker-example';
+import { FormFieldDirtyErrorStateExample } from './form-field-dirty-error-state/form-field-dirty-error-state-example';
 import { FormFieldSbbSelectExample } from './form-field-sbb-select/form-field-sbb-select-example';
 import { FormFieldSelectExample } from './form-field-select/form-field-select-example';
 import { FormFieldTextInputAttributeLabelExample } from './form-field-text-input-attribute-label/form-field-text-input-attribute-label-example';
@@ -25,6 +27,7 @@ export {
   FormFieldSbbSelectExample,
   FormFieldTimeInputExample,
   FormFieldDatepickerExample,
+  FormFieldDirtyErrorStateExample,
 };
 
 const EXAMPLES = [
@@ -35,6 +38,7 @@ const EXAMPLES = [
   FormFieldSbbSelectExample,
   FormFieldTimeInputExample,
   FormFieldDatepickerExample,
+  FormFieldDirtyErrorStateExample,
 ];
 
 @NgModule({
@@ -52,5 +56,6 @@ const EXAMPLES = [
   ],
   declarations: EXAMPLES,
   exports: EXAMPLES,
+  providers: [SbbShowOnDirtyErrorStateMatcher],
 })
 export class FormFieldExamplesModule {}


### PR DESCRIPTION
Currently when using the `SbbShowOnDirtyErrorStateMatcher`, errors in the form field
will be shown, but the form field itself will not (yet) be shown in an error state.
This PR fixes this by applying the error styles based on the error class from the form field.