### PR TITLE
fix(business): hide sidebar scrollbar on iOS devices

### DIFF
--- a/src/angular-core/styles/typography/_scrollbar.scss
+++ b/src/angular-core/styles/typography/_scrollbar.scss
@@ -27,7 +27,7 @@ $trackColor: $sbbColorMilk;
     }
 
     @supports (-webkit-touch-callout: none) {
-      // Only visible on iOS devices.
+      // Only applied on iOS devices.
       // Sets scrollbar on iOS devices invisible which solves a bug where a scrollbar
       // is wrongly visible for a short time (until clicking or scrolling) inside the sidebar.
       &::-webkit-scrollbar {

--- a/src/angular-core/styles/typography/_scrollbar.scss
+++ b/src/angular-core/styles/typography/_scrollbar.scss
@@ -26,6 +26,16 @@ $trackColor: $sbbColorMilk;
       height: 0.5rem;
     }
 
+    @supports (-webkit-touch-callout: none) {
+      // Only visible on iOS devices.
+      // Sets scrollbar on iOS devices invisible which solves a bug where a scrollbar
+      // is wrongly visible for a short time (until clicking or scrolling) inside the sidebar.
+      &::-webkit-scrollbar {
+        width: 0;
+        height: 0;
+      }
+    }
+
     &:hover::-webkit-scrollbar-thumb:hover {
       background-color: $sbbColorStorm;
     }

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -1936,6 +1936,16 @@ $trackColor: $sbbColorMilk;
     height: 0.5rem;
   }
 
+  @supports (-webkit-touch-callout: none) {
+    // Only visible on iOS devices.
+    // Sets scrollbar on iOS devices invisible which solves a bug where a scrollbar
+    // is wrongly visible for a short time (until clicking or scrolling) inside the sidebar.
+    &::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+    }
+  }
+
   &:hover::-webkit-scrollbar-thumb:hover {
     background-color: $sbbColorStorm;
   }

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -1937,7 +1937,7 @@ $trackColor: $sbbColorMilk;
   }
 
   @supports (-webkit-touch-callout: none) {
-    // Only visible on iOS devices.
+    // Only applied on iOS devices.
     // Sets scrollbar on iOS devices invisible which solves a bug where a scrollbar
     // is wrongly visible for a short time (until clicking or scrolling) inside the sidebar.
     &::-webkit-scrollbar {


### PR DESCRIPTION
Sets scrollbar on iOS devices invisible which solves a bug where a scrollbar
is wrongly visible for a short time (until clicking or scrolling) inside the sidebar.