### PR TITLE
fix(business): prevent submit event in chips when pressing enter with content

### DIFF
--- a/src/angular-business/chip/chip-input/chip-input.component.html
+++ b/src/angular-business/chip/chip-input/chip-input.component.html
@@ -15,7 +15,7 @@
   [sbbAutocompleteConnectedTo]="_origin"
   (focus)="_onFocus()"
   (blur)="_onBlur()"
-  (keydown.enter)="_onEnter($any($event.target)?.value)"
+  (keydown)="_handleKeydown($event)"
   class="sbb-chip-input-textfield"
 />
 <ng-template #noAutocomplete>
@@ -27,7 +27,7 @@
     [disabled]="disabled"
     (focus)="_onFocus()"
     (blur)="_onBlur()"
-    (keydown.enter)="_onEnter($any($event.target)?.value)"
+    (keydown)="_handleKeydown($event)"
     class="sbb-chip-input-textfield"
   />
 </ng-template>

--- a/src/angular-business/chip/chip-input/chip-input.component.ts
+++ b/src/angular-business/chip/chip-input/chip-input.component.ts
@@ -1,5 +1,6 @@
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { SelectionModel } from '@angular/cdk/collections';
+import { ENTER } from '@angular/cdk/keycodes';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -278,14 +279,27 @@ export class SbbChipInput
     this._inputElement.nativeElement.value = '';
   }
 
-  /** Selects a given value if the action doesn't refer to an autocomplete option. */
-  _onEnter(option: string) {
+  /**
+   * Selects a given value if the action doesn't refer to an autocomplete option.
+   * @deprecated No longer used.
+   */
+  _onEnter(_option: string) {}
+
+  /** Handle the keydown event. */
+  _handleKeydown(event: KeyboardEvent) {
+    const keyCode = event.keyCode;
+    const currentValue = this._inputElement.nativeElement.value;
+    if (keyCode !== ENTER || !currentValue) {
+      return;
+    }
+
+    event.preventDefault();
     if (this.autocomplete) {
       if (!this.autocomplete.options.some((opt) => opt.active)) {
-        this._onSelect(option);
+        this._onSelect(currentValue);
       }
     } else {
-      this._onSelect(option);
+      this._onSelect(currentValue);
     }
   }
 

--- a/src/showcase/app/business/business-examples/chip-examples/autocomplete-chip-input-example/autocomplete-chip-input-example.component.html
+++ b/src/showcase/app/business/business-examples/chip-examples/autocomplete-chip-input-example/autocomplete-chip-input-example.component.html
@@ -1,4 +1,4 @@
-<ng-container [formGroup]="formGroup">
+<form [formGroup]="formGroup" (ngSubmit)="onSubmit($event)">
   <sbb-form-field label="Label" class="sbb-form-field-long">
     <sbb-chip-input formControlName="chip" [sbbAutocomplete]="auto"></sbb-chip-input>
     <sbb-autocomplete #auto="sbbAutocomplete">
@@ -6,6 +6,6 @@
     </sbb-autocomplete>
     <sbb-error *ngIf="formGroup.get('chip')?.errors?.required">This field is required.</sbb-error>
   </sbb-form-field>
-</ng-container>
+</form>
 <h4>Properties</h4>
 <pre>{{ formGroup.get('chip')?.value | json }}</pre>

--- a/src/showcase/app/business/business-examples/chip-examples/autocomplete-chip-input-example/autocomplete-chip-input-example.component.ts
+++ b/src/showcase/app/business/business-examples/chip-examples/autocomplete-chip-input-example/autocomplete-chip-input-example.component.ts
@@ -21,4 +21,8 @@ export class AutocompleteChipInputExampleComponent {
       chip: [['option-1'], Validators.required],
     });
   }
+
+  onSubmit(event: Event) {
+    console.log(event);
+  }
 }

--- a/src/showcase/app/business/business-examples/chip-examples/reactive-forms-chip-input-example/reactive-forms-chip-input-example.component.html
+++ b/src/showcase/app/business/business-examples/chip-examples/reactive-forms-chip-input-example/reactive-forms-chip-input-example.component.html
@@ -1,8 +1,8 @@
-<ng-container [formGroup]="formGroup">
+<form [formGroup]="formGroup" (ngSubmit)="onSubmit($event)">
   <sbb-form-field label="Label" class="sbb-form-field-long">
     <sbb-chip-input formControlName="chip"></sbb-chip-input>
     <sbb-error *ngIf="formGroup.get('chip')?.errors?.required">This field is required.</sbb-error>
   </sbb-form-field>
-</ng-container>
+</form>
 <h4>Properties</h4>
 <pre>{{ formGroup.get('chip')?.value | json }}</pre>

--- a/src/showcase/app/business/business-examples/chip-examples/reactive-forms-chip-input-example/reactive-forms-chip-input-example.component.ts
+++ b/src/showcase/app/business/business-examples/chip-examples/reactive-forms-chip-input-example/reactive-forms-chip-input-example.component.ts
@@ -13,4 +13,8 @@ export class ReactiveFormsChipInputExampleComponent {
       chip: [['option-1'], Validators.required],
     });
   }
+
+  onSubmit(event: Event) {
+    console.log(event);
+  }
 }


### PR DESCRIPTION
Currently if enter is pressed in the chips input, the submit event from the surrounding
form is triggered. In order to prevent this from always happening, we check if content
has been entered in the input and if yes, we prevent the form submit. If the inner
input has no value, then the enter press will trigger the form submit.