### PR TITLE
fix(business): avoid metadata inlining for the header

### DIFF
--- a/src/angular-business/header/header-menu/header-menu.component.ts
+++ b/src/angular-business/header/header-menu/header-menu.component.ts
@@ -128,7 +128,7 @@ export class SbbHeaderMenu implements AfterContentInit, OnDestroy {
 
   constructor(
     private _elementRef: ElementRef<HTMLElement>,
-    @Inject(SBB_HEADER) public _header: SbbHeader
+    @Inject(SBB_HEADER) public _header: TypeRef<SbbHeader>
   ) {}
 
   ngAfterContentInit() {


### PR DESCRIPTION
Due to SbbHeader being imported as type and directly used as a parameter
type in SbbHeaderMenu, the decorater metadata contained a reference to
SbbHeader, which was not actually available.

Closes #798