### PR TITLE
feat: add css class for normal error flow inside sbb-form-field

### DIFF
--- a/src/angular-public/form-field/form-field.md
+++ b/src/angular-public/form-field/form-field.md
@@ -41,16 +41,25 @@ messages can be shown at the same time if desired, but the `<sbb-form-field>` on
 space to display one error message at a time. Ensuring that enough space is available to display
 multiple errors is up to the user.
 
-#### Display error messages outside sbb-form-field
+#### Remove reserved space for error messages
 
 `<sbb-form-field>` reserves space below the input field for a potential error message.
-To remove this reserved space, apply the css class `sbb-form-field-errorless` to the `<sbb-form-field>` tag.
+To remove this reserved space, apply the css class `sbb-form-field-flexible-errors` to the
+`<sbb-form-field>` tag or any ancestor (e.g. `<body class="sbb-form-field-flexible-errors">`).
 Place the `<sbb-error>` below the `<sbb-form-field>` and conditionally add the aria-describedby attribute.
 Please note that this will lead to the content below the `<sbb-error>` to be pushed downward when
 the error is being displayed and upward when it is being hidden.
 
+#### Display error messages outside sbb-form-field
+
+`<sbb-form-field>` constrains error messages to its width. In order to display errors with a wider width
+the `<sbb-error>` element can be placed outside the `<sbb-form-field>`. Apply the css class
+`sbb-form-field-flexible-errors` to the `<sbb-form-field>` tag or any ancestor to remove the reserved
+error space. You will also manually need to assign the aria-describedby, as `<sbb-form-field>` is only
+able to detect and automatically assign `<sbb-error>` instances inside of itself.
+
 ```html
-<sbb-form-field label="Name" class="sbb-form-field-errorless">
+<sbb-form-field label="Name" class="sbb-form-field-flexible-errors">
   <input
     type="text"
     sbbInput

--- a/src/angular-public/form-field/form-field.scss
+++ b/src/angular-public/form-field/form-field.scss
@@ -43,7 +43,8 @@
 .sbb-form-field-wrapper {
   padding-bottom: if($sbbBusiness, pxToEm(16, 13), pxToEm(21, 14));
 
-  .sbb-form-field-errorless & {
+  .sbb-form-field-errorless &,
+  .sbb-form-field-flexible-errors & {
     padding-bottom: 0;
   }
 }
@@ -199,6 +200,10 @@ select.sbb-input-element {
   box-sizing: border-box;
   width: 100%;
   overflow: hidden;
+
+  .sbb-form-field-flexible-errors & {
+    position: relative;
+  }
 }
 
 // Scale down icons in the label and error to be the same size as the text.

--- a/src/angular/form-field/form-field.md
+++ b/src/angular/form-field/form-field.md
@@ -41,16 +41,25 @@ messages can be shown at the same time if desired, but the `<sbb-form-field>` on
 space to display one error message at a time. Ensuring that enough space is available to display
 multiple errors is up to the user.
 
-#### Display error messages outside sbb-form-field
+#### Remove reserved space for error messages
 
 `<sbb-form-field>` reserves space below the input field for a potential error message.
-To remove this reserved space, apply the css class `sbb-form-field-errorless` to the `<sbb-form-field>` tag.
+To remove this reserved space, apply the css class `sbb-form-field-flexible-errors` to the
+`<sbb-form-field>` tag or any ancestor (e.g. `<body class="sbb-form-field-flexible-errors">`).
 Place the `<sbb-error>` below the `<sbb-form-field>` and conditionally add the aria-describedby attribute.
 Please note that this will lead to the content below the `<sbb-error>` to be pushed downward when
 the error is being displayed and upward when it is being hidden.
 
+#### Display error messages outside sbb-form-field
+
+`<sbb-form-field>` constrains error messages to its width. In order to display errors with a wider width
+the `<sbb-error>` element can be placed outside the `<sbb-form-field>`. Apply the css class
+`sbb-form-field-flexible-errors` to the `<sbb-form-field>` tag or any ancestor to remove the reserved
+error space. You will also manually need to assign the aria-describedby, as `<sbb-form-field>` is only
+able to detect and automatically assign `<sbb-error>` instances inside of itself.
+
 ```html
-<sbb-form-field label="Name" class="sbb-form-field-errorless">
+<sbb-form-field label="Name" class="sbb-form-field-flexible-errors">
   <input
     type="text"
     sbbInput

--- a/src/angular/form-field/form-field.scss
+++ b/src/angular/form-field/form-field.scss
@@ -58,7 +58,7 @@
     padding-bottom: pxToRem(16);
   }
 
-  .sbb-form-field-errorless & {
+  .sbb-form-field-flexible-errors & {
     padding-bottom: 0;
   }
 }
@@ -109,6 +109,10 @@
   box-sizing: border-box;
   width: 100%;
   overflow: hidden;
+
+  .sbb-form-field-flexible-errors & {
+    position: relative;
+  }
 }
 
 // Scale down icons in the label and error to be the same size as the text.

--- a/src/angular/schematics/ng-add/migrations/merge-refactor-migration.ts
+++ b/src/angular/schematics/ng-add/migrations/merge-refactor-migration.ts
@@ -6,6 +6,7 @@ import { BadgeMigration } from './merge-refactor/badge-migration';
 import { ButtonMigration } from './merge-refactor/button-migration';
 import { CheckboxPanelMigration } from './merge-refactor/checkbox-panel-migration';
 import { ChipsMigration } from './merge-refactor/chips-migration';
+import { FormFieldMigration } from './merge-refactor/form-field-migration';
 import { LinkMigration } from './merge-refactor/link-migration';
 import { PaginationMigration } from './merge-refactor/pagination-migration';
 import { ProcessflowMigration } from './merge-refactor/processflow-migration';
@@ -26,6 +27,7 @@ export class MergeRefactorMigration extends Migration<null, DevkitContext> {
     new ButtonMigration(this),
     new CheckboxPanelMigration(this),
     new ChipsMigration(this),
+    new FormFieldMigration(this),
     new LinkMigration(this),
     new PaginationMigration(this),
     new ProcessflowMigration(this),

--- a/src/angular/schematics/ng-add/migrations/merge-refactor/form-field-migration.ts
+++ b/src/angular/schematics/ng-add/migrations/merge-refactor/form-field-migration.ts
@@ -1,0 +1,32 @@
+import type { Element } from 'parse5';
+
+import { MigrationElement } from '../../../utils';
+
+import { RefactorMigration } from './refactor-migration';
+
+/**
+ * Migration that replaces .sbb-form-field-errorless with .sbb-form-field-flexible-errors.
+ */
+export class FormFieldMigration extends RefactorMigration {
+  protected _migrateMessage: string =
+    'Replacing .sbb-form-field-errorless with .sbb-form-field-flexible-errors';
+
+  protected _shouldMigrate(element: Element): boolean {
+    return (
+      element.attrs &&
+      element.attrs.some(
+        (a) => a.name.toLowerCase() === 'class' && a.value.includes('sbb-form-field-errorless')
+      )
+    );
+  }
+
+  protected _migrate(element: MigrationElement) {
+    const classAttribute = element.findProperty('class');
+    classAttribute?.replaceValue(
+      classAttribute.nativeValue.replace(
+        'sbb-form-field-errorless',
+        'sbb-form-field-flexible-errors'
+      )
+    );
+  }
+}

--- a/src/angular/schematics/ng-add/test-cases/merge/form-field_expected_output.ts
+++ b/src/angular/schematics/ng-add/test-cases/merge/form-field_expected_output.ts
@@ -1,2 +1,13 @@
+import { Component } from '@angular/core';
 import { SbbFormFieldModule } from '@sbb-esta/angular/form-field';
 import { SbbFormFieldControl } from '@sbb-esta/angular/form-field';
+
+@Component({
+  selector: 'test',
+  template: `
+    <sbb-form-field label="Test" class="sbb-form-field-flexible-errors">
+      <input sbbInput>
+    </sbb-form-field>
+  `,
+})
+export class TestComponent {}

--- a/src/angular/schematics/ng-add/test-cases/merge/form-field_input.ts
+++ b/src/angular/schematics/ng-add/test-cases/merge/form-field_input.ts
@@ -1,2 +1,13 @@
+import { Component } from '@angular/core';
 import { SbbFormFieldModule } from '@sbb-esta/angular-public/form-field';
 import { SbbFormFieldControl } from '@sbb-esta/angular-core/forms';
+
+@Component({
+  selector: 'test',
+  template: `
+    <sbb-form-field label="Test" class="sbb-form-field-errorless">
+      <input sbbInput>
+    </sbb-form-field>
+  `,
+})
+export class TestComponent {}


### PR DESCRIPTION
We are adding the css class `sbb-form-field-flexible-errors`, which can be placed on `sbb-form-field` or any ancestor, which will remove the reserved space for errors and display errors in the normal context flow.
This also deprecates the css class `sbb-form-field-errorless`, which will be removed in a future version.