### PR TITLE
feat(maps): updated to ESRI arcgis-core v4.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [12.4.0](https://github.com/sbb-design-systems/sbb-angular/compare/12.3.0...12.4.0) (2021-09-01)
+
+
+### Features
+
+* Maps using ESRI Map API for JavaScript v4.20
+* Maps examples portalId changed 
+* Maps configuration `originsWithCredentialsRequired` property marked as deprecated
+
+
 ## [12.3.0](https://github.com/sbb-design-systems/sbb-angular/compare/12.2.1...12.3.0) (2021-07-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [12.4.0](https://github.com/sbb-design-systems/sbb-angular/compare/12.3.0...12.4.0) (2021-09-02)
-
-
-### Features
-
-* **maps:** updated to ESRI [@arcgis/core v4.20.2](https://www.npmjs.com/package/@arcgis/core/v/4.20.2)
-* **maps:** example WebScene `portalItem` changed 
-* **maps:** `SbbEsriConfiguration.originsWithCredentialsRequired` property marked as deprecated
-
-
 ## [12.3.0](https://github.com/sbb-design-systems/sbb-angular/compare/12.2.1...12.3.0) (2021-07-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [12.4.0](https://github.com/sbb-design-systems/sbb-angular/compare/12.3.0...12.4.0) (2021-09-01)
+## [12.4.0](https://github.com/sbb-design-systems/sbb-angular/compare/12.3.0...12.4.0) (2021-09-02)
 
 
 ### Features
 
-* Maps using ESRI Map API for JavaScript v4.20
-* Maps examples portalId changed 
-* Maps configuration `originsWithCredentialsRequired` property marked as deprecated
+* **maps:** updated to ESRI [@arcgis/core v4.20.2](https://www.npmjs.com/package/@arcgis/core/v/4.20.2)
+* **maps:** example WebScene `portalItem` changed 
+* **maps:** `SbbEsriConfiguration.originsWithCredentialsRequired` property marked as deprecated
 
 
 ## [12.3.0](https://github.com/sbb-design-systems/sbb-angular/compare/12.2.1...12.3.0) (2021-07-29)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbb-angular",
-  "version": "12.3.0",
+  "version": "12.4.0",
   "private": true,
   "engines": {
     "node": ">=14.0.0 <16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbb-angular",
-  "version": "12.4.0",
+  "version": "12.3.0",
   "private": true,
   "engines": {
     "node": ">=14.0.0 <16.0.0",
@@ -66,7 +66,7 @@
     "@angular/platform-browser": "~12.2.0",
     "@angular/platform-browser-dynamic": "~12.2.0",
     "@angular/router": "~12.2.0",
-    "@arcgis/core": "^4.20.2",
+    "@arcgis/core": "~4.20.2",
     "core-js": "^2.6.11",
     "keycloak-js": "^4.8.3",
     "regenerator-runtime": "^0.13.7",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@angular/platform-browser": "~12.2.0",
     "@angular/platform-browser-dynamic": "~12.2.0",
     "@angular/router": "~12.2.0",
-    "@arcgis/core": "~4.19.1",
+    "@arcgis/core": "^4.20.2",
     "core-js": "^2.6.11",
     "keycloak-js": "^4.8.3",
     "regenerator-runtime": "^0.13.7",

--- a/src/angular-core/schematics/ng-update/data/class-names.ts
+++ b/src/angular-core/schematics/ng-update/data/class-names.ts
@@ -98,7 +98,6 @@ export const classNames: VersionChanges<ClassNameUpgradeData> = {
         { replace: 'DropdownSelectionChange', replaceWith: 'SbbDropdownSelectionChange' },
         { replace: 'DropdownTriggerDirective', replaceWith: 'SbbDropdownTrigger' },
         { replace: 'ErrorStateMatcher', replaceWith: 'SbbErrorStateMatcher' },
-        { replace: 'ESRI_CONFIG_TOKEN', replaceWith: 'SBB_ESRI_CONFIG_TOKEN' },
         { replace: 'EsriBasemapGalleryComponent', replaceWith: 'SbbEsriBasemapGallery' },
         { replace: 'EsriBasemapGalleryModule', replaceWith: 'SbbEsriBasemapGalleryModule' },
         { replace: 'EsriConfigConsts', replaceWith: 'SbbEsriConfigConsts' },

--- a/src/angular-maps/core/hit-test/hit-test.service.ts
+++ b/src/angular-maps/core/hit-test/hit-test.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import MapViewClickEvent = __esri.MapViewClickEvent;
-import SceneViewClickEvent = __esri.SceneViewClickEvent;
+import ViewClickEvent = __esri.ViewClickEvent;
 import Graphic from '@arcgis/core/Graphic';
 import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
 import MapView from '@arcgis/core/views/MapView';
@@ -8,14 +7,11 @@ import SceneView from '@arcgis/core/views/SceneView';
 import HitTestResult = __esri.HitTestResult;
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class SbbHitTestService {
   /** Calls the ESRI hitTest method for a location on a given map-/scene-view. */
-  esriHitTest(
-    mapView: MapView | SceneView,
-    mapClickEvent: MapViewClickEvent | SceneViewClickEvent
-  ): Promise<Graphic[]> {
+  esriHitTest(mapView: MapView | SceneView, mapClickEvent: ViewClickEvent): Promise<Graphic[]> {
     mapView.map.layers.forEach((l) => ((l as FeatureLayer).outFields = ['*']));
     return mapView
       .hitTest(mapClickEvent)

--- a/src/angular-maps/core/hit-test/hit-test.service.ts
+++ b/src/angular-maps/core/hit-test/hit-test.service.ts
@@ -7,7 +7,7 @@ import SceneView from '@arcgis/core/views/SceneView';
 import HitTestResult = __esri.HitTestResult;
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class SbbHitTestService {
   /** Calls the ESRI hitTest method for a location on a given map-/scene-view. */

--- a/src/angular-maps/esri-config/BUILD.bazel
+++ b/src/angular-maps/esri-config/BUILD.bazel
@@ -10,7 +10,7 @@ package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "esri-config",
-    srcs = glob(
+    srcs = [":esri-config.token.ts"] + glob(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),

--- a/src/angular-maps/esri-config/BUILD.bazel
+++ b/src/angular-maps/esri-config/BUILD.bazel
@@ -10,7 +10,7 @@ package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "esri-config",
-    srcs = [":esri-config.token.ts"] + glob(
+    srcs = glob(
         ["**/*.ts"],
         exclude = ["**/*.spec.ts"],
     ),

--- a/src/angular-maps/esri-config/esri-config.module.ts
+++ b/src/angular-maps/esri-config/esri-config.module.ts
@@ -1,17 +1,19 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
-import { SBB_ESRI_CONFIG_TOKEN } from './esri-config.token';
+import { SbbEsriConfigConsts } from '../esri-config/esri-standard-values.const';
+
 import { SbbEsriConfiguration } from './esri-configuration';
+import { SbbEsriLoaderService } from './esri-loader.service';
 
 @NgModule({})
 export class SbbEsriConfigModule {
-  static forRoot(config: SbbEsriConfiguration): ModuleWithProviders<SbbEsriConfigModule> {
+  static forRoot(config?: SbbEsriConfiguration): ModuleWithProviders<SbbEsriConfigModule> {
     return {
       ngModule: SbbEsriConfigModule,
       providers: [
         {
-          provide: SBB_ESRI_CONFIG_TOKEN,
-          useValue: config,
+          provide: SbbEsriLoaderService,
+          useValue: new SbbEsriLoaderService(config ?? SbbEsriConfigConsts),
         },
       ],
     };

--- a/src/angular-maps/esri-config/esri-config.module.ts
+++ b/src/angular-maps/esri-config/esri-config.module.ts
@@ -12,7 +12,7 @@ export class SbbEsriConfigModule {
       providers: [
         {
           provide: SbbEsriLoaderService,
-          useValue: new SbbEsriLoaderService(config ?? SbbEsriConfigConsts),
+          useValue: SbbEsriLoaderService.configure(config ?? SbbEsriConfigConsts),
         },
       ],
     };

--- a/src/angular-maps/esri-config/esri-config.module.ts
+++ b/src/angular-maps/esri-config/esri-config.module.ts
@@ -1,9 +1,8 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
-import { SbbEsriConfigConsts } from '../esri-config/esri-standard-values.const';
-
 import { SbbEsriConfiguration } from './esri-configuration';
 import { SbbEsriLoaderService } from './esri-loader.service';
+import { SbbEsriConfigConsts } from './esri-standard-values.const';
 
 @NgModule({})
 export class SbbEsriConfigModule {

--- a/src/angular-maps/esri-config/esri-config.token.ts
+++ b/src/angular-maps/esri-config/esri-config.token.ts
@@ -1,5 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-import { SbbEsriConfiguration } from './esri-configuration';
-
-export const SBB_ESRI_CONFIG_TOKEN = new InjectionToken<SbbEsriConfiguration>('esri.config');

--- a/src/angular-maps/esri-config/esri-configuration.ts
+++ b/src/angular-maps/esri-config/esri-configuration.ts
@@ -9,5 +9,8 @@ export interface SbbEsriConfiguration {
   arcgisJsUrl?: string;
   trustedServers?: string[];
   portalUrl?: string;
+  /**
+   * @deprecated not used. Esri is using only the new FetchAPI instead of XMLHttpRequest (since API V4.10).
+   */
   originsWithCredentialsRequired?: string[];
 }

--- a/src/angular-maps/esri-config/esri-loader.service.spec.ts
+++ b/src/angular-maps/esri-config/esri-loader.service.spec.ts
@@ -12,7 +12,6 @@ describe('EsriLoaderService', () => {
   const esriCustomConf: SbbEsriConfiguration = {
     trustedServers: ['t1', 't2'],
     portalUrl: 'urlToPortalInstance',
-    originsWithCredentialsRequired: ['o1', 'o2'],
   };
 
   let loaderService: SbbEsriLoaderService;
@@ -36,7 +35,6 @@ describe('EsriLoaderService', () => {
     SbbEsriConfigConsts.trustedServers.forEach((srv) => {
       expect(esriConfig.request.trustedServers).toContain(srv);
     });
-    expect(esriConfig.request.interceptors!.length).toBeGreaterThan(0);
   });
 
   it('should load modules with custom config', async () => {
@@ -47,6 +45,5 @@ describe('EsriLoaderService', () => {
     SbbEsriConfigConsts.trustedServers.concat(esriCustomConf.trustedServers!).forEach((srv) => {
       expect(esriConfig.request.trustedServers).toContain(srv);
     });
-    expect(esriConfig.request.interceptors!.length).toBeGreaterThan(0);
   });
 });

--- a/src/angular-maps/esri-config/esri-loader.service.spec.ts
+++ b/src/angular-maps/esri-config/esri-loader.service.spec.ts
@@ -11,7 +11,7 @@ describe('EsriLoaderService', () => {
 
   const configureTestingModule = (customConfig?: SbbEsriConfiguration) => {
     TestBed.configureTestingModule({
-      imports: [...(customConfig ? [SbbEsriConfigModule.forRoot(customConfig!)] : [])],
+      imports: [...[SbbEsriConfigModule.forRoot(customConfig)]],
     });
   };
 

--- a/src/angular-maps/esri-config/esri-loader.service.spec.ts
+++ b/src/angular-maps/esri-config/esri-loader.service.spec.ts
@@ -1,12 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import config from '@arcgis/core/config';
 
-import {
-  SbbEsriConfigConsts,
-  SbbEsriConfigModule,
-  SbbEsriConfiguration,
-  SbbEsriLoaderService,
-} from './index';
+import { SbbEsriConfigConsts, SbbEsriConfigModule, SbbEsriConfiguration } from './index';
 
 describe('EsriLoaderService', () => {
   const esriCustomConf: SbbEsriConfiguration = {
@@ -14,19 +9,11 @@ describe('EsriLoaderService', () => {
     portalUrl: 'urlToPortalInstance',
   };
 
-  let loaderService: SbbEsriLoaderService;
   const configureTestingModule = (customConfig?: SbbEsriConfiguration) => {
     TestBed.configureTestingModule({
       imports: [...(customConfig ? [SbbEsriConfigModule.forRoot(customConfig!)] : [])],
-      providers: [SbbEsriLoaderService],
     });
-    loaderService = TestBed.inject(SbbEsriLoaderService);
   };
-
-  it('should be created', () => {
-    configureTestingModule();
-    expect(loaderService).toBeTruthy();
-  });
 
   it('should configure esri with standard config', async () => {
     configureTestingModule();

--- a/src/angular-maps/esri-config/esri-loader.service.spec.ts
+++ b/src/angular-maps/esri-config/esri-loader.service.spec.ts
@@ -11,7 +11,7 @@ describe('EsriLoaderService', () => {
 
   const configureTestingModule = (customConfig?: SbbEsriConfiguration) => {
     TestBed.configureTestingModule({
-      imports: [...[SbbEsriConfigModule.forRoot(customConfig)]],
+      imports: [SbbEsriConfigModule.forRoot(customConfig)],
     });
   };
 

--- a/src/angular-maps/esri-config/esri-loader.service.ts
+++ b/src/angular-maps/esri-config/esri-loader.service.ts
@@ -1,7 +1,6 @@
-import { Inject, Injectable, Optional } from '@angular/core';
+import { Injectable } from '@angular/core';
 import esriConfig from '@arcgis/core/config';
 
-import { SBB_ESRI_CONFIG_TOKEN } from './esri-config.token';
 import { SbbEsriConfiguration } from './esri-configuration';
 import { SbbEsriConfigConsts } from './esri-standard-values.const';
 
@@ -9,10 +8,7 @@ import { SbbEsriConfigConsts } from './esri-standard-values.const';
   providedIn: 'root',
 })
 export class SbbEsriLoaderService {
-  constructor(
-    /** Inject an optional configuration to configure arcgis-js-api settings. */
-    @Optional() @Inject(SBB_ESRI_CONFIG_TOKEN) private _config: SbbEsriConfiguration
-  ) {
+  constructor(private _config: SbbEsriConfiguration) {
     this._configure();
   }
 

--- a/src/angular-maps/esri-config/esri-loader.service.ts
+++ b/src/angular-maps/esri-config/esri-loader.service.ts
@@ -8,20 +8,17 @@ import { SbbEsriConfigConsts } from './esri-standard-values.const';
   providedIn: 'root',
 })
 export class SbbEsriLoaderService {
-  constructor(private _config: SbbEsriConfiguration) {
-    this._configure();
-  }
-
   /** @docs-private */
-  private _configure() {
-    esriConfig.portalUrl = this._config?.portalUrl ?? SbbEsriConfigConsts.arcgisPortalUrl;
+  public static configure(config: SbbEsriConfiguration): SbbEsriLoaderService {
+    esriConfig.portalUrl = config?.portalUrl ?? SbbEsriConfigConsts.arcgisPortalUrl;
 
-    const trustedServers = this._config?.trustedServers ?? [];
+    const trustedServers = config?.trustedServers ?? [];
     const esriConfigTrustedServers = esriConfig.request.trustedServers!;
     SbbEsriConfigConsts.trustedServers.concat(trustedServers).forEach((srv) => {
       if (esriConfigTrustedServers.indexOf(srv) === -1) {
         esriConfigTrustedServers.push(srv);
       }
     });
+    return this;
   }
 }

--- a/src/angular-maps/esri-config/esri-loader.service.ts
+++ b/src/angular-maps/esri-config/esri-loader.service.ts
@@ -8,7 +8,7 @@ import { SbbEsriConfigConsts } from './esri-standard-values.const';
   providedIn: 'root',
 })
 export class SbbEsriLoaderService {
-  /** @docs-private */
+  /** Configures portalUrl and trustedServers. */
   public static configure(config: SbbEsriConfiguration): SbbEsriLoaderService {
     esriConfig.portalUrl = config?.portalUrl ?? SbbEsriConfigConsts.arcgisPortalUrl;
 

--- a/src/angular-maps/esri-config/esri-loader.service.ts
+++ b/src/angular-maps/esri-config/esri-loader.service.ts
@@ -27,19 +27,5 @@ export class SbbEsriLoaderService {
         esriConfigTrustedServers.push(srv);
       }
     });
-
-    const originsWithCredentials = SbbEsriConfigConsts.originsWithCredentialsReuqired;
-    const originsWithCredentialsRequired = this._config?.originsWithCredentialsRequired
-      ? originsWithCredentials.concat(this._config.originsWithCredentialsRequired)
-      : originsWithCredentials;
-
-    esriConfig.request.interceptors!.push({
-      before: (params: any) => {
-        if (originsWithCredentialsRequired.some((o) => params.url.includes(o))) {
-          params.requestOptions.withCredentials = true;
-        }
-      },
-      error: () => {},
-    });
   }
 }

--- a/src/angular-maps/esri-config/esri-standard-values.const.ts
+++ b/src/angular-maps/esri-config/esri-standard-values.const.ts
@@ -6,11 +6,5 @@ export class SbbEsriConfigConsts {
     'wms.geo.admin.ch',
   ];
 
-  public static originsWithCredentialsReuqired: string[] = [
-    'geo-dev.sbb.ch',
-    'geo-int.sbb.ch',
-    'geo.sbb.ch',
-  ];
-
   public static arcgisPortalUrl: string = 'https://www.arcgis.com';
 }

--- a/src/angular-maps/esri-config/public-api.ts
+++ b/src/angular-maps/esri-config/public-api.ts
@@ -1,5 +1,4 @@
 export * from './esri-config.module';
-export * from './esri-config.token';
 export * from './esri-configuration';
 export * from './esri-loader.service';
 export * from './esri-standard-values.const';

--- a/src/angular-maps/esri-web-map/esri-web-map/esri-web-map.component.ts
+++ b/src/angular-maps/esri-web-map/esri-web-map/esri-web-map.component.ts
@@ -14,7 +14,7 @@ import Graphic from '@arcgis/core/Graphic';
 import MapView from '@arcgis/core/views/MapView';
 import WebMap from '@arcgis/core/WebMap';
 import { SbbGraphicService, SbbHitTestService } from '@sbb-esta/angular-maps/core';
-import MapViewClickEvent = __esri.MapViewClickEvent;
+import ViewClickEvent = __esri.ViewClickEvent;
 import { ReplaySubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -129,7 +129,7 @@ export class SbbEsriWebMap implements OnInit, OnDestroy {
     this.mapView.watch('extent', (extent) => this._emitExtentChange(extent));
   }
 
-  private _emitMouseClick(e: MapViewClickEvent) {
+  private _emitMouseClick(e: ViewClickEvent) {
     this._hitTestService
       .esriHitTest(this.mapView, e)
       .then((hitTestGraphics) =>

--- a/src/angular-maps/esri-web-scene/esri-web-scene/esri-web-scene.component.ts
+++ b/src/angular-maps/esri-web-scene/esri-web-scene/esri-web-scene.component.ts
@@ -15,7 +15,7 @@ import SceneView from '@arcgis/core/views/SceneView';
 import WebScene from '@arcgis/core/WebScene';
 import { SbbGraphicService, SbbHitTestService } from '@sbb-esta/angular-maps/core';
 import SceneViewProperties = __esri.SceneViewProperties;
-import SceneViewClickEvent = __esri.SceneViewClickEvent;
+import ViewClickEvent = __esri.ViewClickEvent;
 import { ReplaySubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -142,7 +142,7 @@ export class SbbEsriWebScene implements OnInit, OnDestroy {
     this.sceneView.watch('camera', (camera) => this._handleCameraChange(camera));
   }
 
-  private _handleMouseClick(e: SceneViewClickEvent) {
+  private _handleMouseClick(e: ViewClickEvent) {
     this._hitTestService
       .esriHitTest(this.sceneView, e)
       .then((hitTestGraphics) =>

--- a/src/angular-maps/getting-started.md
+++ b/src/angular-maps/getting-started.md
@@ -123,7 +123,7 @@ Choose an angular-map [theme](https://developers.arcgis.com/javascript/latest/st
 _styles.(s)css_
 
 ```
-@import "https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css";
+@import url("https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css");
 ```
 
 Or, if you are working with local assets, see the [Managing assets locally](https://developers.arcgis.com/javascript/latest/es-modules/#managing-assets-locally) section.

--- a/src/angular-maps/getting-started.md
+++ b/src/angular-maps/getting-started.md
@@ -40,7 +40,7 @@ yarn add @arcgis/core@4.20.2 @sbb-esta/angular-maps
 
 ### Step 2: Configure the library
 
-Once the `@sbb-esta/angular-maps` package is installed, you are able to configure your application, in order to use a specific portal (by default the ArcGIS online portal is used), a different version of [ArcGIS API for Javascript](https://developers.arcgis.com/javascript/latest/guide/get-api/) or some other settings.
+Once the `@sbb-esta/angular-maps` package is installed, you are able to configure your application, in order to use a specific portal (by default the ArcGIS online portal is used), a different version of [ArcGIS API for Javascript](https://developers.arcgis.com/javascript/latest/guide/get-api/) or some other settings:
 
 ```ts
 import { SbbEsriConfigModule } from '@sbb-esta/angular-maps';
@@ -53,56 +53,26 @@ import { SbbEsriConfigModule } from '@sbb-esta/angular-maps';
 export class TrainChooChooAppModule {}
 ```
 
-If you do not have specific configurations, you can use the standard configurations as well using:
 The ArcGIS API for Javascript allows for cross origin requests made to associated servers to include credentials such as cookies and authorization headers. This is indicated by a list of named so called _trustedServers_ (see [documentation](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#request)).
 
 [Read more on how the ArcGIS API for Javascript handles CORS](https://developers.arcgis.com/javascript/latest/guide/cors/index.html).
 
-Allowing a quick start in the SBB environment, the following hosts are preconfigured as _trustedServers_ in `@sbb-esta/angular-maps` by default: _geo-dev.sbb.ch_, _geo-int.sbb.ch_ and _geo.sbb.ch_. Additionally _wms.geo.admin.ch_ is preconfigured in _trustedServers_, too.
+Allowing a quick start in the SBB environment, the following hosts are preconfigured as _trustedServers_ in `@sbb-esta/angular-maps` by default: _geo-dev.sbb.ch_, _geo-int.sbb.ch_ and _geo.sbb.ch_. Additionally _wms.geo.admin.ch_ is preconfigured in _trustedServers_, too. In order to use the standard configurations, call `forRoot()` without parameters:
 
 ```ts
 import { SbbEsriConfigModule } from '@sbb-esta/angular-maps';
 
 @NgModule({
   ...
-  imports: [SbbEsriConfigModule.forRoot({
-      portalUrl: 'https://geo-dev.sbb.ch/portal',
-      trustedServers: ['geo-dev.sbb.ch'],
-    })],
-  ...
-})
-export class TrainChooChooAppModule { }
-```
-
-If you do not have specific configurations, you can use the standard configurations as well by using:
-
-```ts
-import { SbbEsriConfigModule } from '@sbb-esta/angular-maps';
-
-@NgModule({
-  ...
-  imports: [SbbEsriConfigModule],
+  imports: [SbbEsriConfigModule.forRoot()],
   ...
 })
 export class TrainChooChooAppModule {}
 ```
 
-### Step 3: Initialize the library configuration
+If you do not call `SbbEsriConfigModule.forRoot` at all, the default Esri ArcGIS API configuration will be used, without SBB environment specific `trustedServers`.
 
-In your app.component.ts file (or any startup service), import the `SbbEsriLoaderService` and add as constructor parameter. Otherwise the configuration (the standard or your specific) won't initialize:
-
-```ts
-import { SbbEsriLoaderService } from "@sbb-esta/angular-maps";
-...
-export class AppComponent {
-  constructor(
-    private esriLoaderService: SbbEsriLoaderService,
-    ...
-  ) { }
-}
-```
-
-### Step 4: Import the component modules
+### Step 3: Import the component modules
 
 Import the NgModule for each component you want to use:
 
@@ -117,7 +87,7 @@ import { EsriWebMapModule, EsriWebSceneModule } from '@sbb-esta/angular-maps';
 export class TrainChooChooAppModule {}
 ```
 
-### Step 5: Configure CSS
+### Step 4: Configure CSS
 
 Choose an angular-map [theme](https://developers.arcgis.com/javascript/latest/styling/#themes) and then configure your App to use the Esri ArcGIS CDN, for example:
 

--- a/src/angular-maps/getting-started.md
+++ b/src/angular-maps/getting-started.md
@@ -54,7 +54,7 @@ export class TrainChooChooAppModule {}
 ```
 
 If you do not have specific configurations, you can use the standard configurations as well using:
-The ArcGIS API for Javascript allows for cross origin requests made to associated servers to include credentials such as cookies and authorization headers. This is indicated by a list of named so called _trustedServers_ (see [documentation](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#request)). 
+The ArcGIS API for Javascript allows for cross origin requests made to associated servers to include credentials such as cookies and authorization headers. This is indicated by a list of named so called _trustedServers_ (see [documentation](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#request)).
 
 [Read more on how the ArcGIS API for Javascript handles CORS](https://developers.arcgis.com/javascript/latest/guide/cors/index.html).
 
@@ -86,6 +86,7 @@ import { SbbEsriConfigModule } from '@sbb-esta/angular-maps';
 })
 export class TrainChooChooAppModule {}
 ```
+
 ### Step 3: Initialize the library configuration
 
 In your app.component.ts file (or any startup service), import the `SbbEsriLoaderService` and add as constructor parameter. Otherwise the configuration (the standard or your specific) won't initialize:

--- a/src/angular-maps/getting-started.md
+++ b/src/angular-maps/getting-started.md
@@ -29,13 +29,13 @@ You can create now your project as described in the official [Angular CLI docume
 Just after you created your own Angular project, in order to include the library, you have to install the `@sbb-esta/angular-maps` and [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) dependencies:
 
 ```sh
-npm install @arcgis/core@4.19.1 @sbb-esta/angular-maps
+npm install @arcgis/core@4.20.2 @sbb-esta/angular-maps
 ```
 
 or, if using yarn:
 
 ```sh
-yarn add @arcgis/core@4.19.1 @sbb-esta/angular-maps
+yarn add @arcgis/core@4.20.2 @sbb-esta/angular-maps
 ```
 
 ### Step 2: Configure the library
@@ -43,30 +43,31 @@ yarn add @arcgis/core@4.19.1 @sbb-esta/angular-maps
 Once the `@sbb-esta/angular-maps` package is installed, you are able to configure your application, in order to use a specific portal (by default the ArcGIS online portal is used), a different version of [ArcGIS API for Javascript](https://developers.arcgis.com/javascript/latest/guide/get-api/) or some other settings.
 
 ```ts
-import { EsriConfigModule } from '@sbb-esta/angular-maps';
+import { SbbEsriConfigModule } from '@sbb-esta/angular-maps';
 
 @NgModule({
   ...
-  imports: [EsriConfigModule.forRoot({ portalUrl: 'https://www.arcgis.com' })],
+  imports: [SbbEsriConfigModule.forRoot({ portalUrl: 'https://www.arcgis.com' })],
   ...
 })
 export class TrainChooChooAppModule {}
 ```
 
 If you do not have specific configurations, you can use the standard configurations as well using:
-The ArcGIS API for Javascript allows for cross origin requests made to associated servers to include credentials such as cookies and authorization headers. This is indicated by a list of named so called _trustedServers_ (see [documentation](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#request)). When using the SBB Geoportal, it's currently also required to add the same host names to the list of _originsWithCredentialsRequired_. Whenever a request is made to a server listed in _originsWithCredentialsRequired_ it is being intercepted (using _interceptors_ as [described](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#request)) and the [_withCredentials_ header](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) is set. [Read more on how the ArcGIS API for Javascript handles CORS](https://developers.arcgis.com/javascript/latest/guide/cors/index.html).
+The ArcGIS API for Javascript allows for cross origin requests made to associated servers to include credentials such as cookies and authorization headers. This is indicated by a list of named so called _trustedServers_ (see [documentation](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#request)). 
 
-Allowing a quick start in the SBB environment, the following hosts are preconfigured as _trustedServers_ and _originsWithCredentialsRequired_ in `@sbb-esta/angular-maps` by default: _geo-dev.sbb.ch_, _geo-int.sbb.ch_ and _geo.sbb.ch_. Additionally _wms.geo.admin.ch_ is preconfigured in _trustedServers_, too.
+[Read more on how the ArcGIS API for Javascript handles CORS](https://developers.arcgis.com/javascript/latest/guide/cors/index.html).
+
+Allowing a quick start in the SBB environment, the following hosts are preconfigured as _trustedServers_ in `@sbb-esta/angular-maps` by default: _geo-dev.sbb.ch_, _geo-int.sbb.ch_ and _geo.sbb.ch_. Additionally _wms.geo.admin.ch_ is preconfigured in _trustedServers_, too.
 
 ```ts
-import { EsriConfigModule } from '@sbb-esta/angular-maps';
+import { SbbEsriConfigModule } from '@sbb-esta/angular-maps';
 
 @NgModule({
   ...
-  imports: [EsriConfigModule.forRoot({
+  imports: [SbbEsriConfigModule.forRoot({
       portalUrl: 'https://geo-dev.sbb.ch/portal',
       trustedServers: ['geo-dev.sbb.ch'],
-      originsWithCredentialsRequired: ['geo-dev.sbb.ch']
     })],
   ...
 })
@@ -76,17 +77,31 @@ export class TrainChooChooAppModule { }
 If you do not have specific configurations, you can use the standard configurations as well by using:
 
 ```ts
-import { EsriConfigModule } from '@sbb-esta/angular-maps';
+import { SbbEsriConfigModule } from '@sbb-esta/angular-maps';
 
 @NgModule({
   ...
-  imports: [EsriConfigModule],
+  imports: [SbbEsriConfigModule],
   ...
 })
 export class TrainChooChooAppModule {}
 ```
+### Step 3: Initialize the library configuration
 
-### Step 3: Import the component modules
+In your app.component.ts file (or any startup service), import the `SbbEsriLoaderService` and add as constructor parameter. Otherwise the configuration (the standard or your specific) won't initialize:
+
+```ts
+import { SbbEsriLoaderService } from "@sbb-esta/angular-maps";
+...
+export class AppComponent {
+  constructor(
+    private esriLoaderService: SbbEsriLoaderService,
+    ...
+  ) { }
+}
+```
+
+### Step 4: Import the component modules
 
 Import the NgModule for each component you want to use:
 
@@ -101,14 +116,14 @@ import { EsriWebMapModule, EsriWebSceneModule } from '@sbb-esta/angular-maps';
 export class TrainChooChooAppModule {}
 ```
 
-### Step 4: Configure CSS
+### Step 5: Configure CSS
 
 Choose an angular-map [theme](https://developers.arcgis.com/javascript/latest/styling/#themes) and then configure your App to use the Esri ArcGIS CDN, for example:
 
 _styles.(s)css_
 
 ```
-@import "https://js.arcgis.com/4.19/@arcgis/core/assets/esri/themes/light/main.css";
+@import "https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css";
 ```
 
 Or, if you are working with local assets, see the [Managing assets locally](https://developers.arcgis.com/javascript/latest/es-modules/#managing-assets-locally) section.

--- a/src/angular-maps/overview-and-usage.md
+++ b/src/angular-maps/overview-and-usage.md
@@ -16,7 +16,7 @@ This currently comes with the requirement to use _web maps_ provided by Portal f
 
 The current implementation of `@sbb-esta/angular-maps` bases on the [ArcGIS API for Javascript](https://developers.arcgis.com/javascript/) by [Esri](https://www.esri.com). The components provided in `@sbb-esta/angular-maps` are basically wrappers around the core functionality of the _ArcGIS API for Javascript_ with the intention to hide things like the [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) configuration and ease the integration in Angular applications (also see our introduction to [Using ArcGIS API Types](/maps/advanced/using-arcgis-types)).
 
-Currently, `@sbb-esta/angular-maps` bases on the [ArcGIS API for Javascript version 4.19](https://developers.arcgis.com/javascript/latest/4.19/).
+Currently, `@sbb-esta/angular-maps` bases on the [ArcGIS API for Javascript version 4.20](https://developers.arcgis.com/javascript/latest/4.20/).
 
 ### Maps and layers
 

--- a/src/angular-maps/package.json
+++ b/src/angular-maps/package.json
@@ -4,7 +4,7 @@
   "peerDependencies": {
     "@angular/common": "0.0.0-NG",
     "@angular/core": "0.0.0-NG",
-    "@arcgis/core": "~4.19.1"
+    "@arcgis/core": "~4.20.2"
   },
   "ng-update": {
     "packageGroup": [

--- a/src/angular/schematics/ng-add/migrations/sbb-angular-symbols.json
+++ b/src/angular/schematics/ng-add/migrations/sbb-angular-symbols.json
@@ -208,7 +208,6 @@
   "throwSbbDialogContentAlreadyAttachedError": "dialog",
   "SbbEsriBasemapGallery": "esri-basemap-gallery",
   "SbbEsriBasemapGalleryModule": "esri-basemap-gallery",
-  "SBB_ESRI_CONFIG_TOKEN": "esri-config",
   "SbbEsriConfigConsts": "esri-config",
   "SbbEsriConfigModule": "esri-config",
   "SbbEsriConfiguration": "esri-config",

--- a/src/components-examples/angular-maps/esri-basemap-gallery/esri-basemap-gallery/esri-basemap-gallery-example.html
+++ b/src/components-examples/angular-maps/esri-basemap-gallery/esri-basemap-gallery/esri-basemap-gallery-example.html
@@ -7,7 +7,7 @@
 <div class="map-container">
   <sbb-esri-web-scene
     #webScene
-    [portalItemId]="'1c7a06421a314ac9b7d0fae22aa367fb'"
+    [portalItemId]="'a3bd04ebe7fe49fbae145ae6b9c66da7'"
     (mapReady)="mapIsReady = true"
     class="web-map"
   >

--- a/src/components-examples/angular-maps/esri-layer-list/esri-layer-list/esri-layer-list-example.html
+++ b/src/components-examples/angular-maps/esri-layer-list/esri-layer-list/esri-layer-list-example.html
@@ -4,7 +4,7 @@
 <div class="map-container">
   <sbb-esri-web-scene
     #webScene
-    [portalItemId]="'1c7a06421a314ac9b7d0fae22aa367fb'"
+    [portalItemId]="'a3bd04ebe7fe49fbae145ae6b9c66da7'"
     (mapReady)="mapIsReady = true"
     class="web-map"
   >

--- a/src/components-examples/angular-maps/esri-legend/esri-legend/esri-legend-example.html
+++ b/src/components-examples/angular-maps/esri-legend/esri-legend/esri-legend-example.html
@@ -4,7 +4,7 @@
 <div class="map-container">
   <sbb-esri-web-scene
     #webScene
-    [portalItemId]="'1c7a06421a314ac9b7d0fae22aa367fb'"
+    [portalItemId]="'a3bd04ebe7fe49fbae145ae6b9c66da7'"
     (mapReady)="mapIsReady = true"
     class="web-map"
   >

--- a/src/components-examples/angular-maps/esri-web-scene/esri-web-scene/esri-web-scene-example.html
+++ b/src/components-examples/angular-maps/esri-web-scene/esri-web-scene/esri-web-scene-example.html
@@ -1,5 +1,5 @@
 <sbb-esri-web-scene
-  [portalItemId]="'1c7a06421a314ac9b7d0fae22aa367fb'"
+  [portalItemId]="'a3bd04ebe7fe49fbae145ae6b9c66da7'"
   (cameraChanged)="centerPoint = $event.position"
   (mapClick)="clickedPoint = $event.clickedPoint"
   (mapReady)="mapIsReady = true"

--- a/src/showcase-merge/app/maps/maps.module.ts
+++ b/src/showcase-merge/app/maps/maps.module.ts
@@ -10,7 +10,7 @@ import { MapsRoutingModule } from './maps-routing.module';
 
 @NgModule({
   imports: [
-    SbbEsriConfigModule.forRoot({ portalUrl: 'https://www.arcgis.com' }),
+    SbbEsriConfigModule.forRoot(),
     CommonModule,
     PortalModule,
     SharedModule,

--- a/src/showcase-merge/index.dev.html
+++ b/src/showcase-merge/index.dev.html
@@ -84,7 +84,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://js.arcgis.com/4.19/@arcgis/core/assets/esri/themes/light/main.css"
+      href="https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css"
     />
     <link rel="shortcut icon" href="https://cdn.app.sbb.ch/favicons/v1/favicon.ico" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/showcase-merge/index.prod.html
+++ b/src/showcase-merge/index.prod.html
@@ -84,7 +84,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://js.arcgis.com/4.19/@arcgis/core/assets/esri/themes/light/main.css"
+      href="https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css"
     />
     <link rel="shortcut icon" href="https://cdn.app.sbb.ch/favicons/v1/favicon.ico" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/showcase/app/maps/maps-examples/esri-basemap-gallery-examples/esri-basemap-gallery-example/esri-basemap-gallery-example.component.html
+++ b/src/showcase/app/maps/maps-examples/esri-basemap-gallery-examples/esri-basemap-gallery-example/esri-basemap-gallery-example.component.html
@@ -9,7 +9,7 @@
     </div>
     <div class="map-container">
       <sbb-esri-web-scene
-        [portalItemId]="'1c7a06421a314ac9b7d0fae22aa367fb'"
+        [portalItemId]="'a3bd04ebe7fe49fbae145ae6b9c66da7'"
         #webScene
         (mapReady)="mapIsReady = true"
         class="web-map"

--- a/src/showcase/app/maps/maps-examples/esri-layer-list-examples/esri-layer-list-example/esri-layer-list-example.component.html
+++ b/src/showcase/app/maps/maps-examples/esri-layer-list-examples/esri-layer-list-example/esri-layer-list-example.component.html
@@ -6,7 +6,7 @@
     </div>
     <div class="map-container">
       <sbb-esri-web-scene
-        [portalItemId]="'1c7a06421a314ac9b7d0fae22aa367fb'"
+        [portalItemId]="'a3bd04ebe7fe49fbae145ae6b9c66da7'"
         #webScene
         (mapReady)="mapIsReady = true"
         class="web-map"

--- a/src/showcase/app/maps/maps-examples/esri-legend-examples/esri-legend-example/esri-legend-example.component.html
+++ b/src/showcase/app/maps/maps-examples/esri-legend-examples/esri-legend-example/esri-legend-example.component.html
@@ -6,7 +6,7 @@
     </div>
     <div class="map-container">
       <sbb-esri-web-scene
-        [portalItemId]="'1c7a06421a314ac9b7d0fae22aa367fb'"
+        [portalItemId]="'a3bd04ebe7fe49fbae145ae6b9c66da7'"
         #webScene
         (mapReady)="mapIsReady = true"
         class="web-map"

--- a/src/showcase/app/maps/maps-examples/esri-web-scene-examples/esri-web-scene-example/esri-web-scene-example.component.html
+++ b/src/showcase/app/maps/maps-examples/esri-web-scene-examples/esri-web-scene-example/esri-web-scene-example.component.html
@@ -3,7 +3,7 @@
     <div>
       <h4>SceneView with eventhandlers & custom properties</h4>
       <sbb-esri-web-scene
-        [portalItemId]="'1c7a06421a314ac9b7d0fae22aa367fb'"
+        [portalItemId]="'a3bd04ebe7fe49fbae145ae6b9c66da7'"
         (cameraChanged)="centerPoint = $event.position"
         (mapClick)="clickedPoint = $event.clickedPoint"
         (mapReady)="mapIsReady = true"

--- a/src/showcase/app/maps/maps.module.ts
+++ b/src/showcase/app/maps/maps.module.ts
@@ -15,7 +15,7 @@ import { MapsComponent } from './maps/maps.component';
 @NgModule({
   declarations: [MapsComponent],
   imports: [
-    SbbEsriConfigModule.forRoot({ portalUrl: 'https://www.arcgis.com' }),
+    SbbEsriConfigModule.forRoot(),
     CommonModule,
     PortalModule,
     SharedModule,

--- a/src/showcase/index.dev.html
+++ b/src/showcase/index.dev.html
@@ -84,7 +84,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://js.arcgis.com/4.19/@arcgis/core/assets/esri/themes/light/main.css"
+      href="https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css"
     />
     <link rel="shortcut icon" href="https://cdn.app.sbb.ch/favicons/v1/favicon.ico" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/showcase/index.prod.html
+++ b/src/showcase/index.prod.html
@@ -84,7 +84,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://js.arcgis.com/4.19/@arcgis/core/assets/esri/themes/light/main.css"
+      href="https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css"
     />
     <link rel="shortcut icon" href="https://cdn.app.sbb.ch/favicons/v1/favicon.ico" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,7 +342,7 @@
   dependencies:
     tslib "^2.2.0"
 
-"@arcgis/core@^4.20.2":
+"@arcgis/core@~4.20.2":
   version "4.20.2"
   resolved "https://registry.yarnpkg.com/@arcgis/core/-/core-4.20.2.tgz#baba4066b90cb9f6b6b7c0a43ff6e6eee14af919"
   integrity sha512-LmHNLhJRBri5UpLfmfSFhQ7B3O/lq0B0Qtwkdy3gJUJ1DOZBfo0c5ezpSfqsHjTTDxTxSyMF5fl8Y1H4+UagZQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@a11y/focus-trap@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@a11y/focus-trap/-/focus-trap-1.0.5.tgz#0748189c37ca21255c702aa5de3ee00ed4821d22"
+  integrity sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw==
+
 "@ampproject/remapping@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-1.0.1.tgz#1398e73e567c2a7992df6554c15bb94a89b68ba2"
@@ -337,15 +342,16 @@
   dependencies:
     tslib "^2.2.0"
 
-"@arcgis/core@~4.19.1":
-  version "4.19.1"
-  resolved "https://registry.yarnpkg.com/@arcgis/core/-/core-4.19.1.tgz#67a5578aad4275d475b5a22162523a8095dc71d8"
-  integrity sha512-H7OWfmwbq/xzfVaaL25bX4gCggMrmoatK3MgEwyJQJ97IDbxpouTfM73idpBV3wN6CUe/gHqfi73qkfIdAOaTA==
+"@arcgis/core@^4.20.2":
+  version "4.20.2"
+  resolved "https://registry.yarnpkg.com/@arcgis/core/-/core-4.20.2.tgz#baba4066b90cb9f6b6b7c0a43ff6e6eee14af919"
+  integrity sha512-LmHNLhJRBri5UpLfmfSFhQ7B3O/lq0B0Qtwkdy3gJUJ1DOZBfo0c5ezpSfqsHjTTDxTxSyMF5fl8Y1H4+UagZQ==
   dependencies:
-    "@esri/arcgis-html-sanitizer" "~2.5.0"
-    "@esri/calcite-colors" "~5.0.0"
-    "@popperjs/core" "~2.6.0"
-    focus-trap "~6.3.0"
+    "@esri/arcgis-html-sanitizer" "~2.6.1"
+    "@esri/calcite-colors" "~6.0.0"
+    "@esri/calcite-components" "1.0.0-beta.56"
+    "@popperjs/core" "~2.9.2"
+    focus-trap "~6.5.1"
     moment "~2.29.1"
     sortablejs "~1.13.0"
 
@@ -622,6 +628,14 @@
     "@babel/helper-annotate-as-pure" "^7.8.3"
     "@babel/helper-regex" "^7.8.3"
     regexpu-core "^4.7.0"
+
+"@babel/helper-define-map@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.14.5.tgz#c1579b056a70a7da2f4a27ee492ec58f5ba3c439"
+  integrity sha512-spfQRnoChdYWwyFetQDBSDBgH42VskaquRI52kbLei5MjV7s3NPq30/sh2S3YdT20Ku/ZpaNnTVgmDo20NWylg==
+  dependencies:
+    "@babel/helper-function-name" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-define-polyfill-provider@^0.2.2":
   version "0.2.3"
@@ -2196,18 +2210,31 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
   integrity sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==
 
-"@esri/arcgis-html-sanitizer@~2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.5.0.tgz#45fb2a22ca98adf6890b294ba064211b1cb76c81"
-  integrity sha512-axq4dGwm3bjY/iR1DoPxrnJOt2SKXD0Cy1QYihK4yZx25CEDpfdSUBE71oz77BSYFz+KQZvh6A3xxOgLnVEoWA==
+"@esri/arcgis-html-sanitizer@~2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.6.1.tgz#49d327e1ee0b1c4e038a56baca4ec248663dc31e"
+  integrity sha512-dB0kFaRxIh4YSR6P5+jhkRm1UD4HxnexSOz3D1sgDiTq41YgWezMSIrifO/M83JwpTKd0U28qEf8hKepmldvZg==
   dependencies:
     lodash.isplainobject "^4.0.6"
-    xss "^1.0.8"
+    xss "^1.0.9"
 
-"@esri/calcite-colors@~5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@esri/calcite-colors/-/calcite-colors-5.0.0.tgz#41e96c65bad19441b93d2fae26b1e10edc02c35d"
-  integrity sha512-8+coTzRjHQkk/T7UTvX4bTpseyiL41lKzAfVC11b4C3ORKrIOI+uhJFssBb0rGl7N40Epuzxto/2HY8xs4pLsA==
+"@esri/calcite-colors@~6.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@esri/calcite-colors/-/calcite-colors-6.0.1.tgz#770ec4d77bbbd4da32a66450eb93f4c780c0ff28"
+  integrity sha512-iGUIIpeMCJSTDGw4ZsxLwwxkml0QzOUJTtysjRryGbhSt183NEtwWKS+yQO19utXQz5LbQWjoav6x6CsawElkw==
+
+"@esri/calcite-components@1.0.0-beta.56":
+  version "1.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@esri/calcite-components/-/calcite-components-1.0.0-beta.56.tgz#94ffd478c73894318841b82a05ec1bf53b39552b"
+  integrity sha512-p3p796uJ85IqlFmkEVKmDPZGEdHWFxRilLmz6aS2nVDWx3sAD4oct9FYuV+jT6JWQBDBG/Y4YRgTS+F9SwWlLg==
+  dependencies:
+    "@a11y/focus-trap" "1.0.5"
+    "@popperjs/core" "2.9.2"
+    "@stencil/core" "2.6.0"
+    "@types/color" "3.0.1"
+    color "3.1.3"
+    lodash-es "4.17.21"
+    sortablejs "1.13.0"
 
 "@fimbul/bifrost@^0.21.0":
   version "0.21.0"
@@ -2567,10 +2594,15 @@
   dependencies:
     esquery "^1.0.1"
 
-"@popperjs/core@~2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.6.0.tgz#f022195afdfc942e088ee2101285a1d31c7d727f"
-  integrity sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==
+"@popperjs/core@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+
+"@popperjs/core@~2.9.2":
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.3.tgz#8b68da1ebd7fc603999cf6ebee34a4899a14b88e"
+  integrity sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -2684,6 +2716,11 @@
     "@angular-devkit/schematics" "12.2.0"
     jsonc-parser "3.0.0"
 
+"@stencil/core@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.6.0.tgz#29da96d8b6fc83e689b9f297ef3e8b59b90a676a"
+  integrity sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==
+
 "@stylelint/postcss-css-in-js@^0.37.2":
   version "0.37.2"
   resolved "https://registry.yarnpkg.com/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz#7e5a84ad181f4234a2480803422a47b8749af3d2"
@@ -2739,10 +2776,24 @@
   resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
   integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
 
-"@types/color-name@^1.1.1":
+"@types/color-convert@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
+  integrity sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==
+  dependencies:
+    "@types/color-name" "*"
+
+"@types/color-name@*", "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/color@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.1.tgz#2900490ed04da8116c5058cd5dba3572d5a25071"
+  integrity sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==
+  dependencies:
+    "@types/color-convert" "*"
 
 "@types/debug@^4.1.5":
   version "4.1.5"
@@ -4566,7 +4617,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -4585,10 +4636,26 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.4:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.6.0.tgz#c3915f61fe267672cb7e1e064c9d692219f6c312"
+  integrity sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
+  integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.4"
 
 colord@^2.0.1:
   version "2.0.1"
@@ -6547,12 +6614,12 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-focus-trap@~6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.3.0.tgz#31c08f0b6099705f71f6e0a16d88fbcc4c012586"
-  integrity sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==
+focus-trap@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.5.1.tgz#2d2bb91198f17e8bc52070f1fb48ac36be4230b5"
+  integrity sha512-q57JebeQXVThn9DWvWLP2rUwuArvk8w3PyqZLSddto0thmVmklFzYJQO97Aq3pUcWkTXjflUa88fT0CrASsaHQ==
   dependencies:
-    tabbable "^5.1.5"
+    tabbable "^5.2.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.0"
@@ -7667,6 +7734,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -8704,6 +8776,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -12368,6 +12445,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
+
 sisteransi@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -12522,7 +12606,7 @@ socks@^2.3.3:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-sortablejs@~1.13.0:
+sortablejs@1.13.0, sortablejs@~1.13.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.13.0.tgz#3ab2473f8c69ca63569e80b1cd1b5669b51269e9"
   integrity sha512-RBJirPY0spWCrU5yCmWM1eFs/XgX2J5c6b275/YyxFRgnzPhKl/TDeU2hNR8Dt7ITq66NRPM4UlOt+e5O4CFHg==
@@ -13283,10 +13367,10 @@ systemjs@^6.3.3:
   resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.3.3.tgz#c0f2bec5cc72d0b36a8b971b1fa32bfc828b50d4"
   integrity sha512-djQ6mZ4/cWKnVnhAWvr/4+5r7QHnC7WiA8sS9VuYRdEv3wYZYTIIQv8zPT79PdDSUwfX3bgvu5mZ8eTyLm2YQA==
 
-tabbable@^5.1.5:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
-  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
+tabbable@^5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
+  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
 
 table@^6.6.0:
   version "6.7.1"
@@ -14487,10 +14571,10 @@ xmlhttprequest-ssl@~1.5.4:
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
-xss@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.8.tgz#32feb87feb74b3dcd3d404b7a68ababf10700535"
-  integrity sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==
+xss@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.9.tgz#3ffd565571ff60d2e40db7f3b80b4677bec770d2"
+  integrity sha512-2t7FahYnGJys6DpHLhajusId7R0Pm2yTmuL0GV9+mV0ZlaLSnb2toBmppATfg5sWIhZQGlsTLoecSzya+l4EAQ==
   dependencies:
     commander "^2.20.3"
     cssfilter "0.0.10"


### PR DESCRIPTION
[12.4.0]:
* **maps:** updated to ESRI [@arcgis/core v4.20.2](https://www.npmjs.com/package/@arcgis/core/v/4.20.2)
* **maps:** example WebScene `portalItem` changed 
* **maps:** `SbbEsriConfiguration.originsWithCredentialsRequired` property marked as deprecated
