### PR TITLE
fix: ensure correct font-family

### DIFF
--- a/src/angular-core/styles/typography/_reset.scss
+++ b/src/angular-core/styles/typography/_reset.scss
@@ -21,7 +21,8 @@
   html {
     background: $sbbColorBg;
     color: $sbbColorText;
-    font-family: $fontSbbRoman;
+    // !important is required, as arcgis defines its own font-family and we need to overwrite it.
+    font-family: $fontSbbRoman !important;
     font-size: private-div($sizeFontBase, 16px) * 100%;
     line-height: $sizeLineHeightBase;
 

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -66,7 +66,8 @@ section {
 html {
   background: $sbbColorBg;
   color: $sbbColorText;
-  font-family: $fontSbbRoman;
+  // !important is required, as arcgis defines its own font-family and we need to overwrite it.
+  font-family: $fontSbbRoman !important;
   font-size: private-div($sizeFontBase, 16px) * 100%;
   line-height: pxToRem($sizeLineHeightDefault);
 


### PR DESCRIPTION
arcgis defines its own font-family for :root (html). In order to reliably overwrite any other definition, we have added !important to the font-family.