### PR TITLE
fix: add description input for sort-header

### DIFF
--- a/src/angular/table/sort/sort-header.ts
+++ b/src/angular/table/sort/sort-header.ts
@@ -342,9 +342,8 @@ export class SbbSortHeader
     // nothing to update in the DOM.
     if (this._sortButton) {
       // removeDescription will no-op if there is no existing message.
-      // TODO(jelbourn): remove optional chaining when AriaDescriber is required.
-      this._ariaDescriber?.removeDescription(this._sortButton, this._sortActionDescription);
-      this._ariaDescriber?.describe(this._sortButton, newDescription);
+      this._ariaDescriber.removeDescription(this._sortButton, this._sortActionDescription);
+      this._ariaDescriber.describe(this._sortButton, newDescription);
     }
 
     this._sortActionDescription = newDescription;

--- a/src/angular/table/sort/sort-header.ts
+++ b/src/angular/table/sort/sort-header.ts
@@ -1,4 +1,4 @@
-import { FocusMonitor } from '@angular/cdk/a11y';
+import { AriaDescriber, FocusMonitor } from '@angular/cdk/a11y';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { CdkColumnDef } from '@angular/cdk/table';
@@ -94,6 +94,12 @@ export class SbbSortHeader
   private _rerenderSubscription: Subscription;
 
   /**
+   * The element with role="button" inside this component's view. We need this
+   * in order to apply a description with AriaDescriber.
+   */
+  private _sortButton: HTMLElement;
+
+  /**
    * Flag set to true when the indicator should be displayed while the sort is not active. Used to
    * provide an affordance that the header is sortable by showing on focus and hover.
    */
@@ -124,7 +130,23 @@ export class SbbSortHeader
   /** Overrides the sort start value of the containing SbbSort for this SbbSortable. */
   @Input() start: 'asc' | 'desc';
 
-  /** Overrides the disable clear value of the containing SbbSort for this SbbSortable. */
+  /**
+   * Description applied to SbbSortHeader's button element with aria-describedby. This text should
+   * describe the action that will occur when the user clicks the sort header.
+   */
+  @Input()
+  get sortActionDescription(): string {
+    return this._sortActionDescription;
+  }
+  set sortActionDescription(value: string) {
+    this._updateSortActionDescription(value);
+  }
+  // Default the action description to "Sort" because it's better than nothing.
+  // Without a description, the button's label comes from the sort header text content,
+  // which doesn't give any indication that it performs a sorting operation.
+  private _sortActionDescription: string = 'Sort';
+
+  /** Overrides the disable clear value of the containing MatSort for this MatSortable. */
   @Input()
   get disableClear(): boolean {
     return this._disableClear;
@@ -142,7 +164,8 @@ export class SbbSortHeader
     // Also Inject MAT_SORT_HEADER_COLUMN_DEF to provide full cdkTable support
     @Inject('MAT_SORT_HEADER_COLUMN_DEF') @Optional() private _columnDefCdk: CdkColumnDef,
     private _focusMonitor: FocusMonitor,
-    private _elementRef: ElementRef<HTMLElement>
+    private _elementRef: ElementRef<HTMLElement>,
+    private _ariaDescriber: AriaDescriber
   ) {
     // Note that we use a string token for the `_columnDef`, because the value is provided both by
     // `angular/table` and `cdk/table` and we can't have the CDK depending on SBB Angular,
@@ -171,6 +194,9 @@ export class SbbSortHeader
     });
 
     this._sort.register(this);
+
+    this._sortButton = this._elementRef.nativeElement.querySelector('[role="button"]')!;
+    this._updateSortActionDescription(this._sortActionDescription);
   }
 
   ngAfterViewInit() {
@@ -305,6 +331,23 @@ export class SbbSortHeader
   /** Whether the arrow inside the sort header should be rendered. */
   _renderArrow() {
     return !this._isDisabled() || this._isSorted();
+  }
+
+  private _updateSortActionDescription(newDescription: string) {
+    // We use AriaDescriber for the sort button instead of setting an `aria-label` because some
+    // screen readers (notably VoiceOver) will read both the column header *and* the button's label
+    // for every *cell* in the table, creating a lot of unnecessary noise.
+
+    // If _sortButton is undefined, the component hasn't been initialized yet so there's
+    // nothing to update in the DOM.
+    if (this._sortButton) {
+      // removeDescription will no-op if there is no existing message.
+      // TODO(jelbourn): remove optional chaining when AriaDescriber is required.
+      this._ariaDescriber?.removeDescription(this._sortButton, this._sortActionDescription);
+      this._ariaDescriber?.describe(this._sortButton, newDescription);
+    }
+
+    this._sortActionDescription = newDescription;
   }
 
   /** Handles changes in the sorting state. */

--- a/src/angular/table/sort/sort.spec.ts
+++ b/src/angular/table/sort/sort.spec.ts
@@ -414,6 +414,30 @@ describe('SbbSort', () => {
 
       expect(sortHeaderElement.querySelector('.sbb-sort-header-arrow')).toBeTruthy();
     }));
+
+    it('should add a default aria description to sort buttons', () => {
+      const sortButton = fixture.nativeElement.querySelector('[role="button"]');
+      const descriptionId = sortButton.getAttribute('aria-describedby');
+      expect(descriptionId).toBeDefined();
+
+      const descriptionElement = document.getElementById(descriptionId);
+      expect(descriptionElement?.textContent).toBe('Sort');
+    });
+
+    it('should add a custom aria description to sort buttons', () => {
+      const sortButton = fixture.nativeElement.querySelector('#defaultB [role="button"]');
+      let descriptionId = sortButton.getAttribute('aria-describedby');
+      expect(descriptionId).toBeDefined();
+
+      let descriptionElement = document.getElementById(descriptionId);
+      expect(descriptionElement?.textContent).toBe('Sort second column');
+
+      fixture.componentInstance.secondColumnDescription = 'Sort 2nd column';
+      fixture.detectChanges();
+      descriptionId = sortButton.getAttribute('aria-describedby');
+      descriptionElement = document.getElementById(descriptionId);
+      expect(descriptionElement?.textContent).toBe('Sort 2nd column');
+    });
   });
 
   describe('with default options', () => {
@@ -508,7 +532,14 @@ type SimpleSbbSortAppColumnIds = 'defaultA' | 'defaultB' | 'overrideStart' | 'ov
       <div id="defaultA" #defaultA sbb-sort-header="defaultA" [disabled]="disabledColumnSort">
         A
       </div>
-      <div id="defaultB" #defaultB sbb-sort-header="defaultB">B</div>
+      <div
+        id="defaultB"
+        #defaultB
+        sbb-sort-header="defaultB"
+        [sortActionDescription]="secondColumnDescription"
+      >
+        B
+      </div>
       <div id="overrideStart" #overrideStart sbb-sort-header="overrideStart" start="desc">D</div>
       <div
         id="overrideDisableClear"
@@ -530,6 +561,7 @@ class SimpleSbbSortApp {
   disableClear: boolean;
   disabledColumnSort = false;
   disableAllSort = false;
+  secondColumnDescription = 'Sort second column';
 
   @ViewChild(SbbSort) sbbSort: SbbSort;
   @ViewChild('defaultA') defaultA: SbbSortHeader;

--- a/src/angular/table/table.md
+++ b/src/angular/table/table.md
@@ -282,6 +282,24 @@ export class SortableTableExampleComponent implements AfterViewInit {
 }
 ```
 
+#### Accessibility
+
+When you apply `SbbSortHeader` to a header cell element, the component wraps the content of the
+header cell inside a button. The text content of the header cell then becomes the accessible
+label for the sort button. However, the header cell text typically describes the column and does
+not indicate that interacting with the control performs a sorting action. To clearly communicate
+that the header performs sorting, always use the `sortActionDescription` input to provide a
+description for the button element, such as "Sort by last name".
+
+`SbbSortHeader` applies the `aria-sort` attribute to communicate the active sort state to
+assistive technology. However, most screen readers do not announce changes to the value of
+`aria-sort`, meaning that screen reader users do not receive feedback that sorting occurred. To
+remedy this, use the `sbbSortChange` event on the `SbbSort` directive to announce state
+updates with the `LiveAnnouncer` service from `@angular/cdk/a11y`.
+
+If your application contains many tables and sort headers, consider creating a custom
+directives to consistently apply `sortActionDescription` and announce sort state changes.
+
 #### Filtering
 
 SBB Angular does not provide a specific component to be used for filtering the `SbbTable`

--- a/src/components-examples/angular/table/filter-sort-paginator-table/filter-sort-paginator-table-example.html
+++ b/src/components-examples/angular/table/filter-sort-paginator-table/filter-sort-paginator-table-example.html
@@ -4,9 +4,15 @@
   </sbb-form-field>
 
   <sbb-table-wrapper>
-    <table sbb-table sbbSort>
+    <table sbb-table sbbSort (sbbSortChange)="announceSortChange($event)">
       <ng-container *ngFor="let column of columns" [sbbColumnDef]="column.title">
-        <th sbb-header-cell [sbb-sort-header]="column.title" *sbbHeaderCellDef style="width: 20%">
+        <th
+          sbb-header-cell
+          [sbb-sort-header]="column.title"
+          *sbbHeaderCellDef
+          [sortActionDescription]="'Sort by ' + column.title"
+          style="width: 20%"
+        >
           {{ column.title }}
           <div *ngIf="column.subtitle" class="sbb-table-header-subtitle">{{column.subtitle}}</div>
         </th>

--- a/src/components-examples/angular/table/filter-sort-paginator-table/filter-sort-paginator-table-example.ts
+++ b/src/components-examples/angular/table/filter-sort-paginator-table/filter-sort-paginator-table-example.ts
@@ -1,7 +1,14 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { AfterViewInit, Component, OnDestroy, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { SbbPaginator } from '@sbb-esta/angular/pagination';
-import { SbbSort, SbbTable, SbbTableDataSource, SbbTableFilter } from '@sbb-esta/angular/table';
+import {
+  SbbSort,
+  SbbSortState,
+  SbbTable,
+  SbbTableDataSource,
+  SbbTableFilter,
+} from '@sbb-esta/angular/table';
 import { Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
 
@@ -60,6 +67,8 @@ export class FilterSortPaginatorTableExample implements AfterViewInit, OnDestroy
 
   private _destroyed = new Subject<void>();
 
+  constructor(private _liveAnnouncer: LiveAnnouncer) {}
+
   ngAfterViewInit() {
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
@@ -78,6 +87,19 @@ export class FilterSortPaginatorTableExample implements AfterViewInit, OnDestroy
           : [...new Set(this.dataSource.filteredData.map((vehicle) => vehicle.description))].sort()
       )
     );
+  }
+
+  /** Announce the change in sort state for assistive technology. */
+  announceSortChange(sortState: SbbSortState) {
+    // This example uses English messages. If your application supports
+    // multiple language, you would internationalize these strings.
+    // Furthermore, you can customize the message to add additional
+    // details about the values being sorted.
+    if (sortState.direction) {
+      this._liveAnnouncer.announce(`Sorted ${sortState.direction}ending`);
+    } else {
+      this._liveAnnouncer.announce('Sorting cleared');
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/components-examples/angular/table/sortable-table/sortable-table-example.html
+++ b/src/components-examples/angular/table/sortable-table/sortable-table-example.html
@@ -1,19 +1,54 @@
 <sbb-table-wrapper>
-  <table sbb-table sbbSort [dataSource]="dataSource" sbbSortActive="letter" sbbSortDirection="asc">
+  <table
+    sbb-table
+    sbbSort
+    (sbbSortChange)="announceSortChange($event)"
+    [dataSource]="dataSource"
+    sbbSortActive="letter"
+    sbbSortDirection="asc"
+  >
     <ng-container sbbColumnDef="letter">
-      <th sbb-header-cell sbb-sort-header="letter" *sbbHeaderCellDef>Letter</th>
+      <th
+        sbb-header-cell
+        sbb-sort-header="letter"
+        *sbbHeaderCellDef
+        sortActionDescription="Sort by letter"
+      >
+        Letter
+      </th>
       <td sbb-cell *sbbCellDef="let element">{{ element.letter }}</td>
     </ng-container>
     <ng-container sbbColumnDef="number">
-      <th sbb-header-cell sbb-sort-header="number" *sbbHeaderCellDef>Number</th>
+      <th
+        sbb-header-cell
+        sbb-sort-header="number"
+        *sbbHeaderCellDef
+        sortActionDescription="Sort by number"
+      >
+        Number
+      </th>
       <td sbb-cell *sbbCellDef="let element">{{ element.number }}</td>
     </ng-container>
     <ng-container sbbColumnDef="word">
-      <th sbb-header-cell sbb-sort-header="word" *sbbHeaderCellDef>Word</th>
+      <th
+        sbb-header-cell
+        sbb-sort-header="word"
+        *sbbHeaderCellDef
+        sortActionDescription="Sort by word"
+      >
+        Word
+      </th>
       <td sbb-cell *sbbCellDef="let element">{{ element.word }}</td>
     </ng-container>
     <ng-container sbbColumnDef="date">
-      <th sbb-header-cell sbb-sort-header="date" *sbbHeaderCellDef>Date</th>
+      <th
+        sbb-header-cell
+        sbb-sort-header="date"
+        *sbbHeaderCellDef
+        sortActionDescription="Sort by date"
+      >
+        Date
+      </th>
       <td sbb-cell *sbbCellDef="let element">{{ element.date | date }}</td>
     </ng-container>
 

--- a/src/components-examples/angular/table/sortable-table/sortable-table-example.ts
+++ b/src/components-examples/angular/table/sortable-table/sortable-table-example.ts
@@ -1,5 +1,6 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { AfterViewInit, Component, ViewChild } from '@angular/core';
-import { SbbSort, SbbTableDataSource } from '@sbb-esta/angular/table';
+import { SbbSort, SbbSortState, SbbTableDataSource } from '@sbb-esta/angular/table';
 
 /**
  * @title Sortable Table
@@ -13,10 +14,25 @@ export class SortableTableExample implements AfterViewInit {
   displayedColumns: string[] = ['letter', 'number', 'word', 'date'];
   dataSource: SbbTableDataSource<any> = new SbbTableDataSource(TABLE_EXAMPLE_DATA);
 
+  constructor(private _liveAnnouncer: LiveAnnouncer) {}
+
   @ViewChild(SbbSort) sort: SbbSort;
 
   ngAfterViewInit(): void {
     this.dataSource.sort = this.sort;
+  }
+
+  /** Announce the change in sort state for assistive technology. */
+  announceSortChange(sortState: SbbSortState) {
+    // This example uses English messages. If your application supports
+    // multiple language, you would internationalize these strings.
+    // Furthermore, you can customize the message to add additional
+    // details about the values being sorted.
+    if (sortState.direction) {
+      this._liveAnnouncer.announce(`Sorted ${sortState.direction}ending`);
+    } else {
+      this._liveAnnouncer.announce('Sorting cleared');
+    }
   }
 }
 

--- a/src/components-examples/angular/table/sticky-table/sticky-table-example.html
+++ b/src/components-examples/angular/table/sticky-table/sticky-table-example.html
@@ -1,22 +1,43 @@
 <h4>Trains per section of line</h4>
 
 <sbb-table-wrapper class="table-wrapper" *ngIf="!loading; else: loadingIndicator">
-  <table sbb-table sbbSort [dataSource]="dataSource">
+  <table sbb-table sbbSort [dataSource]="dataSource" (sbbSortChange)="announceSortChange($event)">
     <ng-container sbbColumnDef="line" sticky>
-      <th sbb-header-cell *sbbHeaderCellDef sbb-sort-header="line">line</th>
+      <th
+        sbb-header-cell
+        *sbbHeaderCellDef
+        sbb-sort-header="line"
+        sortActionDescription="Sort by line"
+      >
+        line
+      </th>
       <td sbb-cell *sbbCellDef="let element">{{ element.line }}</td>
       <td sbb-footer-cell *sbbFooterCellDef>line</td>
     </ng-container>
 
     <!-- Iterate over all non sticky columns -->
     <ng-container *ngFor="let column of displayedColumns.slice(1, -1)" [sbbColumnDef]="column">
-      <th sbb-header-cell *sbbHeaderCellDef [sbb-sort-header]="column">{{column}}</th>
+      <th
+        sbb-header-cell
+        *sbbHeaderCellDef
+        [sbb-sort-header]="column"
+        [sortActionDescription]="'Sort by ' + column"
+      >
+        {{column}}
+      </th>
       <td sbb-cell *sbbCellDef="let element">{{ element[column] }}</td>
       <td sbb-footer-cell *sbbFooterCellDef>{{column}}</td>
     </ng-container>
 
     <ng-container sbbColumnDef="recordId" stickyEnd>
-      <th sbb-header-cell *sbbHeaderCellDef sbb-sort-header="recordId">recordId</th>
+      <th
+        sbb-header-cell
+        *sbbHeaderCellDef
+        sbb-sort-header="recordId"
+        sortActionDescription="Sort by recordId"
+      >
+        recordId
+      </th>
       <td sbb-cell *sbbCellDef="let element">{{ element.recordId }}</td>
       <td sbb-footer-cell *sbbFooterCellDef>recordId</td>
     </ng-container>

--- a/src/components-examples/angular/table/sticky-table/sticky-table-example.ts
+++ b/src/components-examples/angular/table/sticky-table/sticky-table-example.ts
@@ -1,6 +1,7 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { HttpClient } from '@angular/common/http';
 import { Component, ViewChild } from '@angular/core';
-import { SbbSort, SbbTableDataSource } from '@sbb-esta/angular/table';
+import { SbbSort, SbbSortState, SbbTableDataSource } from '@sbb-esta/angular/table';
 
 /**
  * @title Sticky Table Example
@@ -30,7 +31,7 @@ export class StickyTableExample {
     this.dataSource.sort = sort;
   }
 
-  constructor(httpClient: HttpClient) {
+  constructor(private _liveAnnouncer: LiveAnnouncer, httpClient: HttpClient) {
     httpClient
       .get(
         'https://data.sbb.ch/api/records/1.0/search/?dataset=zugzahlen&q=isb%3DSBB&rows=80&facet=isb&facet=strecke_bezeichnung&facet=strecke_art&facet=bp_von_abschnitt&facet=bp_bis_abschnitt&facet=jahr'
@@ -50,5 +51,18 @@ export class StickyTableExample {
 
         this.loading = false;
       });
+  }
+
+  /** Announce the change in sort state for assistive technology. */
+  announceSortChange(sortState: SbbSortState) {
+    // This example uses English messages. If your application supports
+    // multiple language, you would internationalize these strings.
+    // Furthermore, you can customize the message to add additional
+    // details about the values being sorted.
+    if (sortState.direction) {
+      this._liveAnnouncer.announce(`Sorted ${sortState.direction}ending`);
+    } else {
+      this._liveAnnouncer.announce('Sorting cleared');
+    }
   }
 }


### PR DESCRIPTION
Adds a description input for sbb-sort-header so that developers can provide an accessible description (using AriaDescriber under the hood). Additionally, update the accessibility section for the sort header's documentation with guidance on providing an accessible experience.
We decided to use this approach because the message developers would want to set here depends on several bits of information, including:
 * Whether the column is currently sorted
 * The sort direction
 * Whether users can clear sorting (configured on `SbbSort`)
 * The name of the column (not the ID)

Accounting for all of these factors would have made the intl formatting too complicated. This does have the negative consequence of needing to set a description for every header. However, users can add a custom directive to set the 
description in a consistent way if they have an application with many tables.