### PR TITLE
fix: avoid closing tooltip on clipping parent container

### DIFF
--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -483,11 +483,10 @@ export abstract class _SbbTooltipBase<T extends _TooltipComponentBase>
 
       if (
         this._tooltipInstance &&
-        change.scrollableViewProperties.isOverlayClipped &&
+        change.scrollableViewProperties.isOriginOutsideView &&
         this._tooltipInstance.isVisible()
       ) {
-        // After position changes occur and the overlay is clipped by
-        // a parent scrollable then close the tooltip.
+        // After position changes occur and the origin is outside the view then close the tooltip.
         this._ngZone.run(() => this.hide(0));
       }
     });


### PR DESCRIPTION
Previously the tooltip would close when it clipped the scrollable
context/parent. This would lead to the tooltip immediately closing on
scrolling when above such a border. This PR changes this behavior to
only close the tooltip when the origin of the tooltip is scrolled outside
the view.