### PR TITLE
refactor(angular): remove coercion members

### DIFF
--- a/src/angular/accordion/accordion.ts
+++ b/src/angular/accordion/accordion.ts
@@ -42,7 +42,7 @@ export class SbbAccordion extends CdkAccordion implements AfterContentInit, OnDe
   get hideToggle(): boolean {
     return this._hideToggle;
   }
-  set hideToggle(show: boolean) {
+  set hideToggle(show: BooleanInput) {
     this._hideToggle = coerceBooleanProperty(show);
   }
   private _hideToggle: boolean = false;
@@ -71,6 +71,4 @@ export class SbbAccordion extends CdkAccordion implements AfterContentInit, OnDe
     super.ngOnDestroy();
     this._ownHeaders.destroy();
   }
-
-  static ngAcceptInputType_hideToggle: BooleanInput;
 }

--- a/src/angular/accordion/expansion-panel-header.ts
+++ b/src/angular/accordion/expansion-panel-header.ts
@@ -1,5 +1,4 @@
 import { FocusableOption, FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { NumberInput } from '@angular/cdk/coercion';
 import { ENTER, hasModifierKey, SPACE } from '@angular/cdk/keycodes';
 import { DOCUMENT } from '@angular/common';
 import {
@@ -174,6 +173,4 @@ export class SbbExpansionPanelHeader
   private _isFocused() {
     return this._document?.activeElement === this._element.nativeElement;
   }
-
-  static ngAcceptInputType_tabIndex: NumberInput;
 }

--- a/src/angular/accordion/expansion-panel.ts
+++ b/src/angular/accordion/expansion-panel.ts
@@ -81,7 +81,7 @@ export class SbbExpansionPanel
   get hideToggle(): boolean {
     return this._hideToggle || (this.accordion && this.accordion.hideToggle);
   }
-  set hideToggle(value: boolean) {
+  set hideToggle(value: BooleanInput) {
     this._hideToggle = coerceBooleanProperty(value);
   }
   private _hideToggle = false;
@@ -198,6 +198,4 @@ export class SbbExpansionPanel
 
     return false;
   }
-
-  static ngAcceptInputType_hideToggle: BooleanInput;
 }

--- a/src/angular/autocomplete/autocomplete.ts
+++ b/src/angular/autocomplete/autocomplete.ts
@@ -158,7 +158,7 @@ export class SbbAutocomplete implements AfterContentInit, OnDestroy {
   get autoActiveFirstOption(): boolean {
     return this._autoActiveFirstOption;
   }
-  set autoActiveFirstOption(value: boolean) {
+  set autoActiveFirstOption(value: BooleanInput) {
     this._autoActiveFirstOption = coerceBooleanProperty(value);
   }
   private _autoActiveFirstOption: boolean;
@@ -208,7 +208,7 @@ export class SbbAutocomplete implements AfterContentInit, OnDestroy {
   get showHintIfNoOptions(): boolean {
     return this._showHintIfNoOptions;
   }
-  set showHintIfNoOptions(value: boolean) {
+  set showHintIfNoOptions(value: BooleanInput) {
     this._showHintIfNoOptions = coerceBooleanProperty(value);
   }
   private _showHintIfNoOptions: boolean = false;
@@ -299,7 +299,4 @@ export class SbbAutocomplete implements AfterContentInit, OnDestroy {
     classList[this._visibleClass] = this.showPanel;
     classList[this._hiddenClass] = !this.showPanel;
   }
-
-  static ngAcceptInputType_autoActiveFirstOption: BooleanInput;
-  static ngAcceptInputType_showHintIfNoOptions: BooleanInput;
 }

--- a/src/angular/badge/badge.ts
+++ b/src/angular/badge/badge.ts
@@ -72,7 +72,7 @@ export class SbbBadge extends _SbbBadgeBase implements OnDestroy, OnChanges, Can
   get hidden(): boolean {
     return this._hidden;
   }
-  set hidden(val: boolean) {
+  set hidden(val: BooleanInput) {
     this._hidden = coerceBooleanProperty(val);
   }
   private _hidden: boolean;
@@ -215,7 +215,4 @@ export class SbbBadge extends _SbbBadgeBase implements OnDestroy, OnChanges, Can
     const content = this.content;
     return content == null ? '' : `${content}`;
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_hidden: BooleanInput;
 }

--- a/src/angular/button/button.ts
+++ b/src/angular/button/button.ts
@@ -1,5 +1,4 @@
 import { FocusableOption, FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { BooleanInput } from '@angular/cdk/coercion';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -154,8 +153,6 @@ export class SbbButton
   private _hasHostAttributes(...attributes: string[]) {
     return attributes.some((attribute) => this._getHostElement().hasAttribute(attribute));
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }
 
 /**

--- a/src/angular/checkbox/checkbox.ts
+++ b/src/angular/checkbox/checkbox.ts
@@ -1,5 +1,5 @@
 import { FocusableOption, FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { BooleanInput, coerceBooleanProperty, NumberInput } from '@angular/cdk/coercion';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
   AfterViewInit,
   Attribute,
@@ -98,7 +98,7 @@ export class _SbbCheckboxBase
   get required(): boolean {
     return this._required;
   }
-  set required(value: boolean) {
+  set required(value: BooleanInput) {
     this._required = coerceBooleanProperty(value);
   }
   private _required: boolean;
@@ -186,10 +186,10 @@ export class _SbbCheckboxBase
    * mixinDisabled, but the mixin is still required because mixinTabIndex requires it.
    */
   @Input()
-  override get disabled() {
+  override get disabled(): boolean {
     return this._disabled;
   }
-  override set disabled(value: any) {
+  override set disabled(value: BooleanInput) {
     const newValue = coerceBooleanProperty(value);
 
     if (newValue !== this.disabled) {
@@ -209,7 +209,7 @@ export class _SbbCheckboxBase
   get indeterminate(): boolean {
     return this._indeterminate;
   }
-  set indeterminate(value: boolean) {
+  set indeterminate(value: BooleanInput) {
     const changed = value !== this._indeterminate;
     this._indeterminate = coerceBooleanProperty(value);
 
@@ -346,11 +346,6 @@ export class _SbbCheckboxBase
       nativeCheckbox.nativeElement.indeterminate = value;
     }
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_required: BooleanInput;
-  static ngAcceptInputType_indeterminate: BooleanInput;
-  static ngAcceptInputType_tabIndex: NumberInput;
 }
 
 /**

--- a/src/angular/chips/chip-input.ts
+++ b/src/angular/chips/chip-input.ts
@@ -88,7 +88,7 @@ export class SbbChipInput implements SbbChipTextControl, OnChanges, OnDestroy, A
   get addOnBlur(): boolean {
     return this._addOnBlur;
   }
-  set addOnBlur(value: boolean) {
+  set addOnBlur(value: BooleanInput) {
     this._addOnBlur = coerceBooleanProperty(value);
   }
   _addOnBlur: boolean = false;
@@ -122,7 +122,7 @@ export class SbbChipInput implements SbbChipTextControl, OnChanges, OnDestroy, A
   get disabled(): boolean {
     return this._disabled || (this._chipList && this._chipList.disabled);
   }
-  set disabled(value: boolean) {
+  set disabled(value: BooleanInput) {
     this._disabled = coerceBooleanProperty(value);
   }
   private _disabled: boolean = false;
@@ -300,7 +300,4 @@ export class SbbChipInput implements SbbChipTextControl, OnChanges, OnDestroy, A
   private _isSeparatorKey(event: KeyboardEvent) {
     return !hasModifierKey(event) && new Set(this.separatorKeyCodes).has(event.keyCode);
   }
-
-  static ngAcceptInputType_addOnBlur: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/chips/chip-list.ts
+++ b/src/angular/chips/chip-list.ts
@@ -182,7 +182,7 @@ export class SbbChipList
   get required(): boolean {
     return this._required;
   }
-  set required(value: boolean) {
+  set required(value: BooleanInput) {
     this._required = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
@@ -223,7 +223,7 @@ export class SbbChipList
   get disabled(): boolean {
     return this.ngControl ? !!this.ngControl.disabled : this._disabled;
   }
-  set disabled(value: boolean) {
+  set disabled(value: BooleanInput) {
     this._disabled = coerceBooleanProperty(value);
     this._syncChipsState();
   }
@@ -600,7 +600,4 @@ export class SbbChipList
       });
     }
   }
-
-  static ngAcceptInputType_required: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/chips/chip.ts
+++ b/src/angular/chips/chip.ts
@@ -1,5 +1,5 @@
 import { FocusableOption } from '@angular/cdk/a11y';
-import { BooleanInput, coerceBooleanProperty, NumberInput } from '@angular/cdk/coercion';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { BACKSPACE, DELETE } from '@angular/cdk/keycodes';
 import {
   Attribute,
@@ -132,7 +132,7 @@ export class SbbChip
   get disabled(): boolean {
     return this._chipListDisabled || this._disabled;
   }
-  set disabled(value: boolean) {
+  set disabled(value: BooleanInput) {
     this._disabled = coerceBooleanProperty(value);
   }
   protected _disabled: boolean = false;
@@ -144,7 +144,7 @@ export class SbbChip
   get removable(): boolean {
     return this._removable;
   }
-  set removable(value: boolean) {
+  set removable(value: BooleanInput) {
     this._removable = coerceBooleanProperty(value);
   }
   protected _removable: boolean = true;
@@ -282,10 +282,6 @@ export class SbbChip
       });
     });
   }
-
-  static ngAcceptInputType_removable: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_tabIndex: NumberInput;
 }
 
 /**

--- a/src/angular/core/common-behaviors/disabled.ts
+++ b/src/angular/core/common-behaviors/disabled.ts
@@ -1,4 +1,4 @@
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 
 import { AbstractConstructor, Constructor } from './constructor';
 
@@ -16,10 +16,10 @@ export function mixinDisabled<T extends Constructor<{}>>(base: T): Constructor<C
   return class extends base {
     private _disabled: boolean = false;
 
-    get disabled() {
+    get disabled(): boolean {
       return this._disabled;
     }
-    set disabled(value: any) {
+    set disabled(value: BooleanInput) {
       this._disabled = coerceBooleanProperty(value);
     }
 

--- a/src/angular/core/common-behaviors/tabindex.ts
+++ b/src/angular/core/common-behaviors/tabindex.ts
@@ -1,4 +1,4 @@
-import { coerceNumberProperty } from '@angular/cdk/coercion';
+import { coerceNumberProperty, NumberInput } from '@angular/cdk/coercion';
 
 import { AbstractConstructor, Constructor } from './constructor';
 import { CanDisable } from './disabled';
@@ -28,7 +28,7 @@ export function mixinTabIndex<T extends Constructor<CanDisable>>(
     get tabIndex(): number {
       return this.disabled ? -1 : this._tabIndex;
     }
-    set tabIndex(value: number) {
+    set tabIndex(value: NumberInput) {
       // If the specified tabIndex value is null or undefined, fall back to the default value.
       this._tabIndex = value != null ? coerceNumberProperty(value) : this.defaultTabIndex;
     }

--- a/src/angular/core/option/optgroup.ts
+++ b/src/angular/core/option/optgroup.ts
@@ -1,4 +1,3 @@
-import { BooleanInput } from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -77,6 +76,4 @@ export class SbbOptgroup extends _SbbOptgroupMixinBase implements CanDisable {
     super();
     this._inert = parent?.inertGroups ?? false;
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/core/option/option.ts
+++ b/src/angular/core/option/option.ts
@@ -88,10 +88,10 @@ export class SbbOption implements AfterViewChecked, OnDestroy, FocusableOption, 
 
   /** Whether the option is disabled. */
   @Input()
-  get disabled() {
+  get disabled(): boolean {
     return (this.group && this.group.disabled) || this._disabled;
   }
-  set disabled(value: any) {
+  set disabled(value: BooleanInput) {
     this._disabled = coerceBooleanProperty(value);
     this._changeDetectorRef.markForCheck();
   }
@@ -343,8 +343,6 @@ export class SbbOption implements AfterViewChecked, OnDestroy, FocusableOption, 
   private _emitSelectionChangeEvent(isUserInput = false): void {
     this.onSelectionChange.emit(new SbbOptionSelectionChange(this, isUserInput));
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }
 
 /**

--- a/src/angular/datepicker/calendar-body/calendar-body.ts
+++ b/src/angular/datepicker/calendar-body/calendar-body.ts
@@ -1,4 +1,3 @@
-import { BooleanInput } from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -110,6 +109,4 @@ export class SbbCalendarBody {
         });
     });
   }
-
-  static ngAcceptInputType_allowDisabledSelection: BooleanInput;
 }

--- a/src/angular/datepicker/date-input/date-input.directive.ts
+++ b/src/angular/datepicker/date-input/date-input.directive.ts
@@ -144,7 +144,7 @@ export class SbbDateInput<D> implements ControlValueAccessor, Validator, OnInit,
   get disabled(): boolean {
     return this._disabled;
   }
-  set disabled(value: boolean) {
+  set disabled(value: BooleanInput) {
     const newValue = coerceBooleanProperty(value);
     const element = this._elementRef.nativeElement;
 
@@ -379,6 +379,4 @@ export class SbbDateInput<D> implements ControlValueAccessor, Validator, OnInit,
   private _getValidDateOrNull(obj: any): D | null {
     return this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj) ? obj : null;
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/angular/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -47,7 +47,7 @@ export class SbbDatepickerToggle<D> implements OnDestroy, OnChanges, AfterConten
   get disabled(): boolean {
     return this._disabled === undefined ? this._datepicker.disabled : this._disabled;
   }
-  set disabled(value: boolean) {
+  set disabled(value: BooleanInput) {
     this._disabled = coerceBooleanProperty(value);
   }
   private _disabled?: boolean;
@@ -100,6 +100,4 @@ export class SbbDatepickerToggle<D> implements OnDestroy, OnChanges, AfterConten
       datepickerToggled
     ).subscribe(() => this._changeDetectorRef.markForCheck());
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/datepicker/datepicker/datepicker.ts
+++ b/src/angular/datepicker/datepicker/datepicker.ts
@@ -93,7 +93,7 @@ export class SbbDatepicker<D> implements OnDestroy {
       ? this.datepickerInput.disabled
       : !!this._disabled;
   }
-  set disabled(value: boolean) {
+  set disabled(value: BooleanInput) {
     const newValue = coerceBooleanProperty(value);
 
     if (newValue !== this._disabled) {
@@ -130,11 +130,11 @@ export class SbbDatepicker<D> implements OnDestroy {
    * Defaults to false.
    */
   @Input()
-  set arrows(value: boolean) {
-    this._arrows = coerceBooleanProperty(value);
-  }
-  get arrows() {
+  get arrows(): boolean {
     return this._arrows;
+  }
+  set arrows(value: BooleanInput) {
+    this._arrows = coerceBooleanProperty(value);
   }
   private _arrows = false;
 
@@ -145,11 +145,11 @@ export class SbbDatepicker<D> implements OnDestroy {
 
   /** Whether the datepicker toggle is enabled. Defaults to true. */
   @Input()
-  set toggle(value: boolean) {
-    this._toggle = coerceBooleanProperty(value);
-  }
-  get toggle() {
+  get toggle(): boolean {
     return this._toggle;
+  }
+  set toggle(value: BooleanInput) {
+    this._toggle = coerceBooleanProperty(value);
   }
   private _toggle = true;
 
@@ -542,8 +542,4 @@ export class SbbDatepicker<D> implements OnDestroy {
   private _getValidDateOrNull(obj: any): D | null {
     return this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj) ? obj : null;
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_arrows: BooleanInput;
-  static ngAcceptInputType_toggle: BooleanInput;
 }

--- a/src/angular/file-selector/file-selector.ts
+++ b/src/angular/file-selector/file-selector.ts
@@ -91,7 +91,7 @@ export class SbbFileSelector
   get multiple(): boolean {
     return this._multiple;
   }
-  set multiple(value: boolean) {
+  set multiple(value: BooleanInput) {
     this._multiple = coerceBooleanProperty(value);
   }
   private _multiple = false;
@@ -232,9 +232,4 @@ export class SbbFileSelector
       file1.lastModified === file2.lastModified
     );
   }
-
-  static ngAcceptInputType_capture: 'user' | 'environment' | string | null | undefined;
-  static ngAcceptInputType_multipleMode: 'default' | 'persistent' | string | null | undefined;
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_multiple: BooleanInput;
 }

--- a/src/angular/header-lean/header-menu-item.ts
+++ b/src/angular/header-lean/header-menu-item.ts
@@ -1,5 +1,4 @@
 import { FocusableOption, FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { BooleanInput } from '@angular/cdk/coercion';
 import { DOCUMENT } from '@angular/common';
 import {
   Directive,
@@ -111,6 +110,4 @@ export class SbbHeaderMenuItem extends _HeaderMenuItemBase implements FocusableO
 
     return output.trim();
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/header-lean/header.ts
+++ b/src/angular/header-lean/header.ts
@@ -142,7 +142,7 @@ export class SbbHeaderLean implements OnChanges, AfterViewInit, OnDestroy {
   get opened(): boolean {
     return this._opened;
   }
-  set opened(value: boolean) {
+  set opened(value: BooleanInput) {
     this.toggleMenu(coerceBooleanProperty(value));
   }
   private _opened = false;
@@ -457,6 +457,4 @@ export class SbbHeaderLean implements OnChanges, AfterViewInit, OnDestroy {
       this._focusTrap.enabled = this.opened;
     }
   }
-
-  static ngAcceptInputType_opened: BooleanInput;
 }

--- a/src/angular/icon/icon.ts
+++ b/src/angular/icon/icon.ts
@@ -123,7 +123,7 @@ export class SbbIcon implements OnChanges, OnInit, AfterViewChecked, OnDestroy {
   get inline(): boolean {
     return this._inline;
   }
-  set inline(inline: boolean) {
+  set inline(inline: BooleanInput) {
     this._inline = coerceBooleanProperty(inline);
   }
   private _inline: boolean = false;
@@ -401,6 +401,4 @@ export class SbbIcon implements OnChanges, OnInit, AfterViewChecked, OnDestroy {
       });
     }
   }
-
-  static ngAcceptInputType_inline: BooleanInput;
 }

--- a/src/angular/input/input.ts
+++ b/src/angular/input/input.ts
@@ -119,7 +119,7 @@ export class SbbInput
     }
     return this._disabled;
   }
-  set disabled(value: boolean) {
+  set disabled(value: BooleanInput) {
     this._disabled = coerceBooleanProperty(value);
 
     // Browsers may not fire the blur event if the input is disabled too quickly.
@@ -151,7 +151,7 @@ export class SbbInput
   get required(): boolean {
     return this._required;
   }
-  set required(value: boolean) {
+  set required(value: BooleanInput) {
     this._required = coerceBooleanProperty(value);
   }
   private _required = false;
@@ -191,7 +191,9 @@ export class SbbInput
   get value(): string {
     return this._inputValueAccessor.value;
   }
-  set value(value: string) {
+  // Accept `any` to avoid conflicts with other directives on `<input>` that may
+  // accept different types.
+  set value(value: any) {
     if (value !== this.value) {
       this._inputValueAccessor.value = value;
       this.stateChanges.next();
@@ -397,11 +399,4 @@ export class SbbInput
       this.focus();
     }
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_required: BooleanInput;
-
-  // Accept `any` to avoid conflicts with other directives on `<input>` that may
-  // accept different types.
-  static ngAcceptInputType_value: any;
 }

--- a/src/angular/menu/menu-item.ts
+++ b/src/angular/menu/menu-item.ts
@@ -1,5 +1,4 @@
 import { FocusableOption, FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { BooleanInput } from '@angular/cdk/coercion';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -143,6 +142,4 @@ export class SbbMenuItem
 
     return clone.textContent?.trim() || '';
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/menu/menu.ts
+++ b/src/angular/menu/menu.ts
@@ -195,7 +195,7 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
   get overlapTrigger(): boolean {
     return this._overlapTrigger;
   }
-  set overlapTrigger(value: boolean) {
+  set overlapTrigger(value: BooleanInput) {
     this._overlapTrigger = coerceBooleanProperty(value);
   }
   private _overlapTrigger: boolean = this._defaultOptions.overlapTrigger;
@@ -205,7 +205,7 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
   get hasBackdrop(): boolean | undefined {
     return this._hasBackdrop;
   }
-  set hasBackdrop(value: boolean | undefined) {
+  set hasBackdrop(value: BooleanInput) {
     this._hasBackdrop = coerceBooleanProperty(value);
   }
   private _hasBackdrop: boolean | undefined = this._defaultOptions.hasBackdrop;
@@ -489,7 +489,4 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
         this._directDescendantItems.notifyOnChanges();
       });
   }
-
-  static ngAcceptInputType_overlapTrigger: BooleanInput;
-  static ngAcceptInputType_hasBackdrop: BooleanInput;
 }

--- a/src/angular/pagination/paginator/paginator.ts
+++ b/src/angular/pagination/paginator/paginator.ts
@@ -1,7 +1,7 @@
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
 /// <reference types="@angular/localize/init" />
 
-import { BooleanInput, coerceNumberProperty, NumberInput } from '@angular/cdk/coercion';
+import { coerceNumberProperty, NumberInput } from '@angular/cdk/coercion';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -101,7 +101,7 @@ export class SbbPaginator extends _SbbPaginatorBase implements OnInit, CanDisabl
   get pageIndex(): number {
     return this._pageIndex;
   }
-  set pageIndex(value: number) {
+  set pageIndex(value: NumberInput) {
     const previousPageIndex = this._pageIndex;
     this._pageIndex = this._correctDownPageIndexIfNecessary(coerceNumberProperty(value));
     this._emitPageEvent(previousPageIndex);
@@ -114,7 +114,7 @@ export class SbbPaginator extends _SbbPaginatorBase implements OnInit, CanDisabl
   get length(): number {
     return this._length;
   }
-  set length(value: number) {
+  set length(value: NumberInput) {
     this._length = Math.max(coerceNumberProperty(value), 0);
     this.pageIndex = this.pageIndex; // ensure index recalculating
   }
@@ -125,7 +125,7 @@ export class SbbPaginator extends _SbbPaginatorBase implements OnInit, CanDisabl
   get pageSize(): number {
     return this._pageSize;
   }
-  set pageSize(value: number) {
+  set pageSize(value: NumberInput) {
     this._changePageSize(coerceNumberProperty(value));
   }
   private _pageSize: number = DEFAULT_PAGE_SIZE;
@@ -177,12 +177,12 @@ export class SbbPaginator extends _SbbPaginatorBase implements OnInit, CanDisabl
 
   /** Advances to the next page if it exists. */
   nextPage(): void {
-    this.pageIndex++;
+    this.pageIndex = this.pageIndex + 1;
   }
 
   /** Move back to the previous page if it exists. */
   previousPage(): void {
-    this.pageIndex--;
+    this.pageIndex = this.pageIndex - 1;
   }
 
   /** Move to the first page if not already there. */
@@ -269,9 +269,4 @@ export class SbbPaginator extends _SbbPaginatorBase implements OnInit, CanDisabl
   private _correctDownPageIndexIfNecessary(value: number): number {
     return Math.max(Math.min(Math.max(value, 0), this.numberOfPages() - 1), 0);
   }
-
-  static ngAcceptInputType_pageIndex: NumberInput;
-  static ngAcceptInputType_length: NumberInput;
-  static ngAcceptInputType_pageSize: NumberInput;
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/radio-button/radio-button.ts
+++ b/src/angular/radio-button/radio-button.ts
@@ -1,10 +1,5 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import {
-  BooleanInput,
-  coerceBooleanProperty,
-  coerceNumberProperty,
-  NumberInput,
-} from '@angular/cdk/coercion';
+import { BooleanInput, coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 import { UniqueSelectionDispatcher } from '@angular/cdk/collections';
 import {
   AfterContentInit,
@@ -136,7 +131,7 @@ export abstract class _SbbRadioGroupBase<TRadio extends _SbbRadioButtonBase>
   get required(): boolean {
     return this._required;
   }
-  set required(value: boolean) {
+  set required(value: BooleanInput) {
     this._required = coerceBooleanProperty(value);
     this._markRadiosForCheck();
   }
@@ -276,9 +271,6 @@ export abstract class _SbbRadioGroupBase<TRadio extends _SbbRadioButtonBase>
       });
     }
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_required: BooleanInput;
 }
 
 @Directive({
@@ -341,7 +333,7 @@ export class _SbbRadioButtonBase
   get checked(): boolean {
     return this._checked;
   }
-  set checked(value: boolean) {
+  set checked(value: BooleanInput) {
     const newCheckedState = coerceBooleanProperty(value);
     if (this._checked !== newCheckedState) {
       this._checked = newCheckedState;
@@ -386,7 +378,7 @@ export class _SbbRadioButtonBase
   get disabled(): boolean {
     return this._disabled || (this.radioGroup !== null && this.radioGroup.disabled);
   }
-  set disabled(value: boolean) {
+  set disabled(value: BooleanInput) {
     this._setDisabled(coerceBooleanProperty(value));
   }
 
@@ -552,11 +544,6 @@ export class _SbbRadioButtonBase
       this._changeDetector.markForCheck();
     }
   }
-
-  static ngAcceptInputType_checked: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_required: BooleanInput;
-  static ngAcceptInputType_tabIndex: NumberInput;
 }
 
 @Component({

--- a/src/angular/select/select/select.ts
+++ b/src/angular/select/select/select.ts
@@ -345,7 +345,7 @@ export class SbbSelect
   get required(): boolean {
     return this._required ?? this.ngControl?.control?.hasValidator(Validators.required) ?? false;
   }
-  set required(value: boolean) {
+  set required(value: BooleanInput) {
     this._required = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
@@ -356,7 +356,7 @@ export class SbbSelect
   get multiple(): boolean {
     return this._multiple;
   }
-  set multiple(value: boolean) {
+  set multiple(value: BooleanInput) {
     if (this._selectionModel && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throw getSbbSelectDynamicMultipleError();
     }
@@ -427,7 +427,7 @@ export class SbbSelect
   get typeaheadDebounceInterval(): number {
     return this._typeaheadDebounceInterval;
   }
-  set typeaheadDebounceInterval(value: number) {
+  set typeaheadDebounceInterval(value: NumberInput) {
     this._typeaheadDebounceInterval = coerceNumberProperty(value);
   }
   private _typeaheadDebounceInterval: number;
@@ -1216,10 +1216,4 @@ export class SbbSelect
     const scrollBuffer = panelHeight / 2;
     this._scrollTop = this._calculateOverlayScroll(firstSelectedOption, scrollBuffer, maxScroll);
   }
-
-  static ngAcceptInputType_required: BooleanInput;
-  static ngAcceptInputType_multiple: BooleanInput;
-  static ngAcceptInputType_typeaheadDebounceInterval: NumberInput;
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_tabIndex: NumberInput;
 }

--- a/src/angular/sidebar/icon-sidebar/icon-sidebar.ts
+++ b/src/angular/sidebar/icon-sidebar/icon-sidebar.ts
@@ -79,11 +79,11 @@ export class SbbIconSidebar extends SbbSidebarBase {
 
   /** Whether the sidebar is expanded. */
   @Input()
-  set expanded(value: boolean) {
-    this.toggleExpanded(coerceBooleanProperty(value));
-  }
   get expanded(): boolean {
     return this._expanded;
+  }
+  set expanded(value: BooleanInput) {
+    this.toggleExpanded(coerceBooleanProperty(value));
   }
   private _expanded = false;
 
@@ -112,8 +112,6 @@ export class SbbIconSidebar extends SbbSidebarBase {
 
     this._changeDetectorRef.markForCheck();
   }
-
-  static ngAcceptInputType_expanded: BooleanInput;
 }
 
 @Component({

--- a/src/angular/table/sort/sort-header.ts
+++ b/src/angular/table/sort/sort-header.ts
@@ -151,7 +151,7 @@ export class SbbSortHeader
   get disableClear(): boolean {
     return this._disableClear;
   }
-  set disableClear(v) {
+  set disableClear(v: BooleanInput) {
     this._disableClear = coerceBooleanProperty(v);
   }
   private _disableClear: boolean;
@@ -375,7 +375,4 @@ export class SbbSortHeader
       }
     );
   }
-
-  static ngAcceptInputType_disableClear: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/table/sort/sort.ts
+++ b/src/angular/table/sort/sort.ts
@@ -115,7 +115,7 @@ export class SbbSort
   get disableClear(): boolean {
     return this._disableClear;
   }
-  set disableClear(v: boolean) {
+  set disableClear(v: BooleanInput) {
     this._disableClear = coerceBooleanProperty(v);
   }
   private _disableClear: boolean;
@@ -200,9 +200,6 @@ export class SbbSort
   ngOnDestroy() {
     this._stateChanges.complete();
   }
-
-  static ngAcceptInputType_disableClear: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
 }
 
 /** Returns the sort direction cycle to use given the provided parameters of order and clear. */

--- a/src/angular/table/table/cell.ts
+++ b/src/angular/table/table/cell.ts
@@ -67,10 +67,10 @@ export class SbbColumnDef extends CdkColumnDef {
    * If set to true, the border to the next cell is hidden.
    */
   @Input()
-  get groupWithNext() {
+  get groupWithNext(): boolean {
     return this._groupWithNext;
   }
-  set groupWithNext(value) {
+  set groupWithNext(value: BooleanInput) {
     this._groupWithNext = coerceBooleanProperty(value);
   }
   private _groupWithNext: boolean = false;
@@ -85,8 +85,6 @@ export class SbbColumnDef extends CdkColumnDef {
     super._updateColumnCssClassName();
     this._columnCssClassName!.push(`sbb-column-${this.cssClassFriendlyName}`);
   }
-
-  static ngAcceptInputType_groupWithNext: BooleanInput;
 }
 
 /** Header cell template container that adds the right classes and role. */

--- a/src/angular/table/table/text-column.ts
+++ b/src/angular/table/table/text-column.ts
@@ -1,4 +1,4 @@
-import { BooleanInput } from '@angular/cdk/coercion';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { CdkTextColumn } from '@angular/cdk/table';
 import {
   ChangeDetectionStrategy,
@@ -49,8 +49,8 @@ export class SbbTextColumn<T> extends CdkTextColumn<T> implements OnInit {
   get groupWithNext(): boolean {
     return this._groupWithNext;
   }
-  set groupWithNext(value: boolean) {
-    this._groupWithNext = value;
+  set groupWithNext(value: BooleanInput) {
+    this._groupWithNext = coerceBooleanProperty(value);
 
     // With Ivy, inputs can be initialized before static query results are
     // available. In that case, we defer the synchronization until "ngOnInit" fires.
@@ -69,6 +69,4 @@ export class SbbTextColumn<T> extends CdkTextColumn<T> implements OnInit {
       (this.columnDef as SbbColumnDef).groupWithNext = this._groupWithNext;
     }
   }
-
-  static ngAcceptInputType_groupWithNext: BooleanInput;
 }

--- a/src/angular/tabs/paginated-tab-header.ts
+++ b/src/angular/tabs/paginated-tab-header.ts
@@ -83,7 +83,7 @@ export abstract class SbbPaginatedTabHeader
   get selectedIndex(): number {
     return this._selectedIndex;
   }
-  set selectedIndex(value: number) {
+  set selectedIndex(value: NumberInput) {
     value = coerceNumberProperty(value);
 
     if (this._selectedIndex !== value) {
@@ -343,6 +343,4 @@ export abstract class SbbPaginatedTabHeader
       element.classList.add('sbb-tab-header-right-shadow');
     }
   }
-
-  static ngAcceptInputType_selectedIndex: NumberInput;
 }

--- a/src/angular/tabs/tab-group.ts
+++ b/src/angular/tabs/tab-group.ts
@@ -80,7 +80,7 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
   get dynamicHeight(): boolean {
     return this._dynamicHeight;
   }
-  set dynamicHeight(value: boolean) {
+  set dynamicHeight(value: BooleanInput) {
     this._dynamicHeight = coerceBooleanProperty(value);
   }
   private _dynamicHeight: boolean;
@@ -90,7 +90,7 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
   get selectedIndex(): number | null {
     return this._selectedIndex;
   }
-  set selectedIndex(value: number | null) {
+  set selectedIndex(value: NumberInput) {
     this._indexToSelect = coerceNumberProperty(value, null);
   }
   private _selectedIndex: number | null = null;
@@ -325,9 +325,6 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
       this._tabHeader.focusIndex = index;
     }
   }
-
-  static ngAcceptInputType_dynamicHeight: BooleanInput;
-  static ngAcceptInputType_selectedIndex: NumberInput;
 }
 
 /**

--- a/src/angular/tabs/tab-label-wrapper.ts
+++ b/src/angular/tabs/tab-label-wrapper.ts
@@ -1,4 +1,3 @@
-import { BooleanInput } from '@angular/cdk/coercion';
 import { Directive, ElementRef } from '@angular/core';
 import { CanDisable, mixinDisabled } from '@sbb-esta/angular/core';
 
@@ -35,6 +34,4 @@ export class SbbTabLabelWrapper extends _SbbTabLabelWrapperMixinBase implements 
   getOffsetWidth(): number {
     return this.elementRef.nativeElement.offsetWidth;
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/tabs/tab-nav-bar.ts
+++ b/src/angular/tabs/tab-nav-bar.ts
@@ -1,5 +1,5 @@
 import { FocusableOption, FocusMonitor } from '@angular/cdk/a11y';
-import { BooleanInput, coerceBooleanProperty, NumberInput } from '@angular/cdk/coercion';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { ViewportRuler } from '@angular/cdk/scrolling';
 import {
   AfterContentChecked,
@@ -137,11 +137,11 @@ export class _SbbTabLinkBase
   get active(): boolean {
     return this._isActive;
   }
-  set active(value: boolean) {
+  set active(value: BooleanInput) {
     const newValue = coerceBooleanProperty(value);
 
     if (newValue !== this._isActive) {
-      this._isActive = value;
+      this._isActive = newValue;
       this._tabNavBar.updateActiveLink();
     }
   }
@@ -169,10 +169,6 @@ export class _SbbTabLinkBase
   ngOnDestroy() {
     this._focusMonitor.stopMonitoring(this.elementRef);
   }
-
-  static ngAcceptInputType_active: BooleanInput;
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_tabIndex: NumberInput;
 }
 
 /**

--- a/src/angular/tabs/tab.ts
+++ b/src/angular/tabs/tab.ts
@@ -1,4 +1,3 @@
-import { BooleanInput } from '@angular/cdk/coercion';
 import { TemplatePortal } from '@angular/cdk/portal';
 import {
   ChangeDetectionStrategy,
@@ -140,6 +139,4 @@ export class SbbTab extends _SbbTabMixinBase implements OnInit, CanDisable, OnCh
       this._templateLabel = value;
     }
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/tag/tag-link.ts
+++ b/src/angular/tag/tag-link.ts
@@ -21,7 +21,7 @@ export class SbbTagLink {
   get amount(): number {
     return this._amount;
   }
-  set amount(value: number) {
+  set amount(value: NumberInput) {
     this._amount = coerceNumberProperty(value);
     this._badgeDescriptionFallback =
       typeof $localize === 'function'
@@ -34,6 +34,4 @@ export class SbbTagLink {
   @Input('sbbBadgeDescription')
   badgeDescription: string;
   _badgeDescriptionFallback: string;
-
-  static ngAcceptInputType_amount: NumberInput;
 }

--- a/src/angular/tag/tag.ts
+++ b/src/angular/tag/tag.ts
@@ -47,7 +47,7 @@ export class SbbTag extends _SbbCheckboxBase implements OnDestroy {
   get amount(): number {
     return this._amount;
   }
-  set amount(value: number) {
+  set amount(value: NumberInput) {
     this._amount = coerceNumberProperty(value);
     this._badgeDescriptionFallback =
       typeof $localize === 'function'
@@ -112,6 +112,4 @@ export class SbbTag extends _SbbCheckboxBase implements OnDestroy {
     this._amountChange.complete();
     this._valueChange.complete();
   }
-
-  static ngAcceptInputType_amount: NumberInput;
 }

--- a/src/angular/tag/tags.ts
+++ b/src/angular/tag/tags.ts
@@ -44,12 +44,12 @@ export class SbbTags implements AfterContentInit, OnDestroy {
    * If not provided, the total amount is calculated by the sum of all amounts of all tags.
    */
   @Input()
-  set totalAmount(totalAmount: number) {
-    this._totalAmountSetAsInput = true;
-    this._totalAmount.next(coerceNumberProperty(totalAmount));
-  }
   get totalAmount(): number {
     return this._totalAmount.value;
+  }
+  set totalAmount(totalAmount: NumberInput) {
+    this._totalAmountSetAsInput = true;
+    this._totalAmount.next(coerceNumberProperty(totalAmount));
   }
   _totalAmount: BehaviorSubject<number> = new BehaviorSubject<number>(0);
 
@@ -117,6 +117,4 @@ export class SbbTags implements AfterContentInit, OnDestroy {
     this._destroyed.complete();
     this._totalAmount.complete();
   }
-
-  static ngAcceptInputType_totalAmount: NumberInput;
 }

--- a/src/angular/textarea/textarea/textarea.ts
+++ b/src/angular/textarea/textarea/textarea.ts
@@ -117,7 +117,7 @@ export class SbbTextarea
   get disabled(): boolean {
     return this._disabled;
   }
-  set disabled(value: boolean) {
+  set disabled(value: BooleanInput) {
     this._disabled = coerceBooleanProperty(value);
     this._changeDetectorRef.markForCheck();
     this.stateChanges.next();
@@ -140,7 +140,7 @@ export class SbbTextarea
   get maxlength(): number {
     return this._maxlength;
   }
-  set maxlength(value: number) {
+  set maxlength(value: NumberInput) {
     this._maxlength = coerceNumberProperty(value);
     this._updateDigitsCounter(this.value);
     this.stateChanges.next();
@@ -152,7 +152,7 @@ export class SbbTextarea
   get minlength(): number {
     return this._minlength;
   }
-  set minlength(value: number) {
+  set minlength(value: NumberInput) {
     this._minlength = coerceNumberProperty(value);
     this.stateChanges.next();
   }
@@ -330,8 +330,4 @@ export class SbbTextarea
       this._counter.next(this.maxlength - newValue.length);
     }
   }
-
-  static ngAcceptInputType_maxlength: NumberInput;
-  static ngAcceptInputType_minlength: NumberInput;
-  static ngAcceptInputType_disabled: BooleanInput;
 }

--- a/src/angular/tooltip/tooltip-wrapper.ts
+++ b/src/angular/tooltip/tooltip-wrapper.ts
@@ -47,7 +47,7 @@ export class SbbTooltipWrapper extends _SbbTooltipWrapperMixinBase implements On
   get hoverShowDelay(): number {
     return this._hoverShowDelay;
   }
-  set hoverShowDelay(value: number) {
+  set hoverShowDelay(value: NumberInput) {
     this._hoverShowDelay = coerceNumberProperty(value, 0);
   }
   private _hoverShowDelay: number;
@@ -57,7 +57,7 @@ export class SbbTooltipWrapper extends _SbbTooltipWrapperMixinBase implements On
   get hoverHideDelay(): number {
     return this._hoverHideDelay;
   }
-  set hoverHideDelay(value: number) {
+  set hoverHideDelay(value: NumberInput) {
     this._hoverHideDelay = coerceNumberProperty(value, 0);
   }
   private _hoverHideDelay: number;
@@ -96,7 +96,4 @@ export class SbbTooltipWrapper extends _SbbTooltipWrapperMixinBase implements On
   hide() {
     this._tooltip.hide(0);
   }
-
-  static ngAcceptInputType_hoverShowDelay: NumberInput;
-  static ngAcceptInputType_hoverHideDelay: NumberInput;
 }

--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -6,7 +6,7 @@ import {
   FocusOrigin,
   FocusTrap,
 } from '@angular/cdk/a11y';
-import { BooleanInput, coerceBooleanProperty, NumberInput } from '@angular/cdk/coercion';
+import { coerceBooleanProperty, coerceNumberProperty, NumberInput } from '@angular/cdk/coercion';
 import { ESCAPE, hasModifierKey } from '@angular/cdk/keycodes';
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { ConnectionPositionPair, Overlay, OverlayRef, ScrollStrategy } from '@angular/cdk/overlay';
@@ -179,10 +179,24 @@ export abstract class _SbbTooltipBase<T extends _TooltipComponentBase>
   }
 
   /** The default delay in ms before showing the tooltip after show is called */
-  @Input('sbbTooltipShowDelay') showDelay: number = this._defaultOptions.showDelay;
+  @Input('sbbTooltipShowDelay')
+  get showDelay(): number {
+    return this._showDelay;
+  }
+  set showDelay(value: NumberInput) {
+    this._showDelay = coerceNumberProperty(value);
+  }
+  private _showDelay = this._defaultOptions.showDelay;
 
   /** The default delay in ms before hiding the tooltip after hide is called */
-  @Input('sbbTooltipHideDelay') hideDelay: number = this._defaultOptions.hideDelay;
+  @Input('sbbTooltipHideDelay')
+  get hideDelay(): number {
+    return this._hideDelay;
+  }
+  set hideDelay(value: NumberInput) {
+    this._hideDelay = coerceNumberProperty(value);
+  }
+  private _hideDelay = this._defaultOptions.hideDelay;
 
   /**
    * How touch gestures should be handled by the tooltip. On touch devices the tooltip directive
@@ -724,10 +738,6 @@ export abstract class _SbbTooltipBase<T extends _TooltipComponentBase>
       (style as any).webkitTapHighlightColor = 'transparent';
     }
   }
-
-  static ngAcceptInputType_disabled: BooleanInput;
-  static ngAcceptInputType_hideDelay: NumberInput;
-  static ngAcceptInputType_showDelay: NumberInput;
 }
 
 /**


### PR DESCRIPTION
Replaces all usages of the `ngAcceptInputType` members with type declarations directly on the setters.