### PR TITLE
refactor(angular/input): inconsistently reading name from input with ngModel

### DIFF
--- a/src/angular/input/input.ts
+++ b/src/angular/input/input.ts
@@ -61,6 +61,7 @@ const _SbbInputBase = mixinErrorState(
     '[attr.id]': 'id',
     '[disabled]': 'disabled',
     '[required]': 'required',
+    '[attr.name]': 'name || null',
     '[attr.readonly]': 'readonly && !_isNativeSelect || null',
     // Only mark the input as invalid for assistive technology if it has a value since the
     // state usually overlaps with `aria-required` when the input is empty and can be redundant.
@@ -142,6 +143,12 @@ export class SbbInput
    * @docs-private
    */
   @Input() placeholder: string;
+
+  /**
+   * Name of the input.
+   * @docs-private
+   */
+  @Input() name: string;
 
   /**
    * Implemented as part of SbbFormFieldControl.


### PR DESCRIPTION
If an input has a `name` binding and an `ngModel`, the input harness won't be able to
read the name from the DOM, because `ngModel` doesn't proxy it. These changes add
the proxy behavior to the `SbbInput` directive, similarly to what we we're doing for
`required`, `placeholder`, `readonly` etc.
https://github.com/angular/components/pull/19233