### PR TITLE
fix(angular/autocomplete): don't handle enter events with modifier keys

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -460,7 +460,7 @@ export class SbbAutocompleteTrigger
       event.preventDefault();
     }
 
-    if (this.activeOption && keyCode === ENTER && this.panelOpen) {
+    if (this.activeOption && keyCode === ENTER && this.panelOpen && !hasModifierKey(event)) {
       this.activeOption._selectViaInteraction();
       this._resetActiveItem();
       event.preventDefault();

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -1516,6 +1516,28 @@ describe('SbbAutocomplete', () => {
       expect(enterEvent.defaultPrevented).toBe(false, 'Default action should not be prevented.');
     });
 
+    it('should not interfere with the ENTER key when pressing a modifier', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+
+      expect(input.value).toBeFalsy('Expected input to start off blank.');
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to start off open.');
+
+      fixture.componentInstance.trigger._handleKeydown(downArrowEvent);
+      flush();
+      fixture.detectChanges();
+
+      Object.defineProperty(enterEvent, 'altKey', { get: () => true });
+      fixture.componentInstance.trigger._handleKeydown(enterEvent);
+      fixture.detectChanges();
+
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to remain open.');
+      expect(input.value).toBeFalsy('Expected input to remain blank.');
+      expect(enterEvent.defaultPrevented).toBe(
+        false,
+        'Expected the default ENTER action not to have been prevented.'
+      );
+    }));
+
     it('should fill the text field, not select an option, when SPACE is entered', () => {
       typeInElement(input, 'New');
       fixture.detectChanges();


### PR DESCRIPTION
Doesn't handle `ENTER` key presses and doesn't prevent their default action,
if they have a modifier, in order to avoid interfering with any OS-level shortcuts.
https://github.com/angular/components/pull/14717