### PR TITLE
fix(angular/table): better handling of invalid data

### DIFF
--- a/src/angular/table/table.spec.ts
+++ b/src/angular/table/table.spec.ts
@@ -543,6 +543,45 @@ describe('SbbTable', () => {
         ['Footer A', 'Footer B', 'Footer C'],
       ]);
     });
+
+    it('should fall back to empty table if invalid data is passed in', () => {
+      component.underlyingDataSource.addData();
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        ['a_1', 'b_1', 'c_1'],
+        ['a_2', 'b_2', 'c_2'],
+        ['a_3', 'b_3', 'c_3'],
+        ['a_4', 'b_4', 'c_4'],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
+
+      dataSource.data = null!;
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
+
+      component.underlyingDataSource.addData();
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        ['a_1', 'b_1', 'c_1'],
+        ['a_2', 'b_2', 'c_2'],
+        ['a_3', 'b_3', 'c_3'],
+        ['a_4', 'b_4', 'c_4'],
+        ['a_5', 'b_5', 'c_5'],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
+
+      dataSource.data = {} as any;
+      fixture.detectChanges();
+      expectTableToMatchContent(tableElement, [
+        ['Column A', 'Column B', 'Column C'],
+        ['Footer A', 'Footer B', 'Footer C'],
+      ]);
+    });
   });
 
   it('should set css classes to grouped columns', () => {

--- a/src/angular/table/table/table-data-source.ts
+++ b/src/angular/table/table/table-data-source.ts
@@ -80,6 +80,7 @@ export class _SbbTableDataSource<
     return this._data.value;
   }
   set data(data: T[]) {
+    data = Array.isArray(data) ? data : [];
     this._data.next(data);
     // Normally the `filteredData` is updated by the re-render
     // subscription, but that won't happen if it's inactive.


### PR DESCRIPTION
The table data source is set up to expect an array and will throw a cryptic error
 down the line if the value is anything different. While typings should be enough to enforce this,
 if the value comes from somewhere in the view it may not get caught.
Since the effort for handling it on our end is minimal,
these changes add some logic that fall back to an empty array if the value is invalid.
https://github.com/angular/components/pull/18953