### PR TITLE
fix(angular/sidebar): implicit content element being registered twice with scroll dispatcher

### DIFF
--- a/src/angular/sidebar/icon-sidebar/icon-sidebar-container.html
+++ b/src/angular/sidebar/icon-sidebar/icon-sidebar-container.html
@@ -1,6 +1,6 @@
 <ng-content select="sbb-icon-sidebar"></ng-content>
 
 <ng-content select="sbb-icon-sidebar-content"> </ng-content>
-<sbb-icon-sidebar-content *ngIf="!_content" cdkScrollable>
+<sbb-icon-sidebar-content *ngIf="!_content">
   <ng-content></ng-content>
 </sbb-icon-sidebar-content>

--- a/src/angular/sidebar/icon-sidebar/icon-sidebar.ts
+++ b/src/angular/sidebar/icon-sidebar/icon-sidebar.ts
@@ -3,7 +3,7 @@
 
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { ScrollDispatcher } from '@angular/cdk/scrolling';
+import { CdkScrollable, ScrollDispatcher } from '@angular/cdk/scrolling';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -39,6 +39,12 @@ import {
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
+  providers: [
+    {
+      provide: CdkScrollable,
+      useExisting: SbbIconSidebarContent,
+    },
+  ],
 })
 export class SbbIconSidebarContent extends SbbSidebarContentBase {
   constructor(

--- a/src/angular/sidebar/sidebar/sidebar-container.html
+++ b/src/angular/sidebar/sidebar/sidebar-container.html
@@ -19,6 +19,6 @@
 <ng-content select="sbb-sidebar"></ng-content>
 
 <ng-content select="sbb-sidebar-content"> </ng-content>
-<sbb-sidebar-content *ngIf="!_content" cdkScrollable>
+<sbb-sidebar-content *ngIf="!_content">
   <ng-content></ng-content>
 </sbb-sidebar-content>

--- a/src/angular/sidebar/sidebar/sidebar.ts
+++ b/src/angular/sidebar/sidebar/sidebar.ts
@@ -11,7 +11,7 @@ import {
 import { ESCAPE, hasModifierKey } from '@angular/cdk/keycodes';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { Platform } from '@angular/cdk/platform';
-import { ScrollDispatcher, ViewportRuler } from '@angular/cdk/scrolling';
+import { CdkScrollable, ScrollDispatcher, ViewportRuler } from '@angular/cdk/scrolling';
 import { DOCUMENT } from '@angular/common';
 import {
   AfterContentChecked,
@@ -73,6 +73,12 @@ export type SbbSidebarMode = 'over' | 'side';
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
+  providers: [
+    {
+      provide: CdkScrollable,
+      useExisting: SbbSidebarContent,
+    },
+  ],
 })
 export class SbbSidebarContent extends SbbSidebarContentBase implements AfterContentInit {
   constructor(


### PR DESCRIPTION
When the consumer doesn't provide a `sbb-sidebar-content`, we create one implicitly for them.
The implicit content element has a `cdkScrollable` on it, which means that it'll be
registered on the `ScrollDispatcher` as a `CdkScrollable`, however since `SbbSidebarContent`
also extends `CdkScrollable`, it'll be registered again as a `SbbSidebarContent`.
These change remove the extra `cdkScrollable` from the view in order to avoid the issue.

These changes also provide the sidenav content as a `CdkScrollable` for DI purposes.
https://github.com/angular/components/pull/13973