### PR TITLE
fix(angular/autocomplete): optionSelections not emitting when the list of options changes

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -378,12 +378,16 @@ export class SbbAutocompleteTrigger
     );
   }
 
-  /** Stream of autocomplete option selections. */
+  /** Stream of changes to the selection state of the autocomplete options. */
   readonly optionSelections: Observable<SbbOptionSelectionChange> = defer(() => {
-    if (this.autocomplete && this.autocomplete.options) {
-      return merge(...this.autocomplete.options.map((option) => option.onSelectionChange));
-    }
+    const options = this.autocomplete ? this.autocomplete.options : null;
 
+    if (options) {
+      return options.changes.pipe(
+        startWith(options),
+        switchMap(() => merge(...options.map((option) => option.onSelectionChange)))
+      );
+    }
     // If there are any subscribers before `ngAfterViewInit`, the `autocomplete` will be undefined.
     // Return a stream that we'll replace with the real one once everything is in place.
     return this._zone.onStable.pipe(
@@ -429,7 +433,7 @@ export class SbbAutocompleteTrigger
 
   // Implemented as part of ControlValueAccessor.
   writeValue(value: any): void {
-    Promise.resolve(null).then(() => this._setTriggerValue(value));
+    Promise.resolve().then(() => this._setTriggerValue(value));
   }
 
   // Implemented as part of ControlValueAccessor.

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -2770,6 +2770,34 @@ describe('SbbAutocomplete', () => {
       subscription!.unsubscribe();
     }));
 
+    it('should emit to `optionSelections` if the list of options changes', fakeAsync(() => {
+      const spy = jasmine.createSpy('option selection spy');
+      const subscription = fixture.componentInstance.trigger.optionSelections.subscribe(spy);
+      const openAndSelectFirstOption = () => {
+        fixture.detectChanges();
+        fixture.componentInstance.trigger.openPanel();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+        (overlayContainerElement.querySelector('sbb-option') as HTMLElement).click();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+      };
+
+      fixture.componentInstance.numbers = [{ code: 'OR', name: 'Oregon' }];
+      fixture.detectChanges();
+
+      openAndSelectFirstOption();
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      fixture.componentInstance.numbers = [{ code: 'WV', name: 'West Virginia' }];
+      fixture.detectChanges();
+
+      openAndSelectFirstOption();
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      subscription!.unsubscribe();
+    }));
+
     it('should reposition the panel when the amount of options changes', fakeAsync(() => {
       const formField = fixture.debugElement.query(By.css('.sbb-form-field'))!.nativeElement;
       const input = formField.querySelector('input');


### PR DESCRIPTION
Fixes the `SbbAutocompleteTrigger.optionSelections` stopping to emit when
the list options has been swapped out.
https://github.com/angular/components/issues/14777