### PR TITLE
fix(angular/tooltip): not closing if escape is pressed while trigger isn't focused

### DIFF
--- a/src/angular/tooltip/tooltip.spec.ts
+++ b/src/angular/tooltip/tooltip.spec.ts
@@ -540,9 +540,28 @@ describe('SbbTooltip', () => {
       expect(overlayContainerElement.textContent).toContain(initialTooltipMessage);
     }));
 
+    it('should hide when pressing escape', fakeAsync(() => {
+      tooltipDirective.show();
+      tick(0);
+      fixture.detectChanges();
+      tick(500);
+
+      expect(tooltipDirective._isTooltipVisible()).toBe(true);
+      expect(overlayContainerElement.textContent).toContain(initialTooltipMessage);
+
+      dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+      tick(0);
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+
+      expect(tooltipDirective._isTooltipVisible()).toBe(false);
+      expect(overlayContainerElement.textContent).toBe('');
+    }));
+
     it('should not throw when pressing ESCAPE', fakeAsync(() => {
       expect(() => {
-        dispatchKeyboardEvent(buttonElement, 'keydown', ESCAPE);
+        dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
         fixture.detectChanges();
       }).not.toThrow();
 
@@ -555,7 +574,7 @@ describe('SbbTooltip', () => {
       tick(0);
       fixture.detectChanges();
 
-      const event = dispatchKeyboardEvent(buttonElement, 'keydown', ESCAPE);
+      const event = dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
       fixture.detectChanges();
       flush();
 
@@ -568,7 +587,7 @@ describe('SbbTooltip', () => {
       fixture.detectChanges();
 
       const event = createKeyboardEvent('keydown', ESCAPE, undefined, { alt: true });
-      dispatchEvent(buttonElement, event);
+      dispatchEvent(document.body, event);
       fixture.detectChanges();
       flush();
 

--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -292,10 +292,6 @@ export abstract class _SbbTooltipBase<T extends _TooltipComponentBase>
     if (_defaultOptions?.touchGestures) {
       this.touchGestures = _defaultOptions.touchGestures;
     }
-
-    _ngZone.runOutsideAngular(() => {
-      _elementRef.nativeElement.addEventListener('keydown', this._handleKeydown);
-    });
   }
 
   ngAfterViewInit() {
@@ -333,7 +329,6 @@ export abstract class _SbbTooltipBase<T extends _TooltipComponentBase>
     }
 
     // Clean up the event listeners set in the constructor
-    nativeElement.removeEventListener('keydown', this._handleKeydown);
     this._passiveListeners.forEach(([event, listener]) => {
       nativeElement.removeEventListener(event, listener, passiveListenerOptions);
     });
@@ -408,18 +403,6 @@ export abstract class _SbbTooltipBase<T extends _TooltipComponentBase>
   _isTooltipVisible(): boolean {
     return !!this._tooltipInstance && this._tooltipInstance.isVisible();
   }
-
-  /**
-   * Handles the keydown events on the host element.
-   * Needs to be an arrow function so that we can use it in addEventListener.
-   */
-  private _handleKeydown = (event: KeyboardEvent) => {
-    if (this._isTooltipVisible() && event.keyCode === ESCAPE && !hasModifierKey(event)) {
-      event.preventDefault();
-      event.stopPropagation();
-      this._ngZone.run(() => this.hide(0));
-    }
-  };
 
   /** Create the overlay config and position strategy */
   private _createOverlay(): OverlayRef {
@@ -519,11 +502,14 @@ export abstract class _SbbTooltipBase<T extends _TooltipComponentBase>
 
     this._overlayRef
       .keydownEvents()
-      .pipe(
-        filter((e) => e.keyCode === ESCAPE),
-        takeUntil(this._destroyed)
-      )
-      .subscribe(() => this._tooltipInstance?._handleBodyInteraction());
+      .pipe(takeUntil(this._destroyed))
+      .subscribe((event) => {
+        if (this._isTooltipVisible() && event.keyCode === ESCAPE && !hasModifierKey(event)) {
+          event.preventDefault();
+          event.stopPropagation();
+          this._ngZone.run(() => this.hide(0));
+        }
+      });
 
     this._overlayRef
       .outsidePointerEvents()


### PR DESCRIPTION
Currently, the tooltip's `keydown` handler is on the trigger, which means that it won't fire
if the trigger doesn't have focus. This could happen when a tooltip was opened by
hovering over the trigger. These changes use the `OverlayKeyboardDispatcher` to
handle the events instead.
https://github.com/angular/components/pull/14434