### PR TITLE
fix(angular/chips): declare that SbbChipInput.inputElement is always defined

### DIFF
--- a/src/angular/chips/chip-input.ts
+++ b/src/angular/chips/chip-input.ts
@@ -133,7 +133,7 @@ export class SbbChipInput implements SbbChipTextControl, OnChanges, OnDestroy, A
   }
 
   /** The native input element to which this directive is attached. */
-  readonly inputElement: HTMLInputElement;
+  readonly inputElement!: HTMLInputElement;
 
   constructor(
     protected _elementRef: ElementRef<HTMLInputElement>,


### PR DESCRIPTION
It is initialized in the constructor, so there is no chance of it being
undefined.
https://github.com/angular/components/pull/23868