### PR TITLE
fix(angular/badge): correctly apply badge description

### DIFF
--- a/src/angular/badge/badge.spec.ts
+++ b/src/angular/badge/badge.spec.ts
@@ -7,8 +7,8 @@ import { SbbBadge, SbbBadgeModule, SbbBadgePosition } from './index';
 describe('SbbBadge', () => {
   let fixture: ComponentFixture<any>;
   let testComponent: BadgeTestApp;
-  let badgeNativeElement: HTMLElement;
-  let badgeDebugElement: DebugElement;
+  let badgeHostNativeElement: HTMLElement;
+  let badgeHostDebugElement: DebugElement;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -20,12 +20,12 @@ describe('SbbBadge', () => {
     testComponent = fixture.debugElement.componentInstance;
     fixture.detectChanges();
 
-    badgeDebugElement = fixture.debugElement.query(By.directive(SbbBadge))!;
-    badgeNativeElement = badgeDebugElement.nativeElement;
+    badgeHostDebugElement = fixture.debugElement.query(By.directive(SbbBadge))!;
+    badgeHostNativeElement = badgeHostDebugElement.nativeElement;
   }));
 
   it('should update the badge based on attribute', () => {
-    const badgeElement = badgeNativeElement.querySelector('.sbb-badge-content')!;
+    const badgeElement = badgeHostNativeElement.querySelector('.sbb-badge-content')!;
     expect(badgeElement.textContent).toContain('1');
 
     testComponent.badgeContent = '22';
@@ -34,7 +34,7 @@ describe('SbbBadge', () => {
   });
 
   it('should be able to pass in falsy values to the badge content', () => {
-    const badgeElement = badgeNativeElement.querySelector('.sbb-badge-content')!;
+    const badgeElement = badgeHostNativeElement.querySelector('.sbb-badge-content')!;
     expect(badgeElement.textContent).toContain('1');
 
     testComponent.badgeContent = 0;
@@ -43,7 +43,7 @@ describe('SbbBadge', () => {
   });
 
   it('should treat null and undefined as empty strings in the badge content', () => {
-    const badgeElement = badgeNativeElement.querySelector('.sbb-badge-content')!;
+    const badgeElement = badgeHostNativeElement.querySelector('.sbb-badge-content')!;
     expect(badgeElement.textContent).toContain('1');
 
     testComponent.badgeContent = null;
@@ -56,41 +56,41 @@ describe('SbbBadge', () => {
   });
 
   it('should update the badge position on direction change', () => {
-    expect(badgeNativeElement.classList.contains('sbb-badge-above')).toBe(true);
+    expect(badgeHostNativeElement.classList.contains('sbb-badge-above')).toBe(true);
 
     testComponent.badgeDirection = 'after';
     fixture.detectChanges();
 
-    expect(badgeNativeElement.classList.contains('sbb-badge-after')).toBe(true);
+    expect(badgeHostNativeElement.classList.contains('sbb-badge-after')).toBe(true);
   });
 
   it('should change visibility to hidden', () => {
-    expect(badgeNativeElement.classList.contains('sbb-badge-hidden')).toBe(false);
+    expect(badgeHostNativeElement.classList.contains('sbb-badge-hidden')).toBe(false);
 
     testComponent.badgeHidden = true;
     fixture.detectChanges();
 
-    expect(badgeNativeElement.classList.contains('sbb-badge-hidden')).toBe(true);
+    expect(badgeHostNativeElement.classList.contains('sbb-badge-hidden')).toBe(true);
   });
 
   it('should toggle `aria-describedby` depending on whether the badge has a description', () => {
-    const badgeContent = badgeNativeElement.querySelector('.sbb-badge-content')!;
-
-    expect(badgeContent.getAttribute('aria-describedby')).toBeFalsy();
+    expect(badgeHostNativeElement.hasAttribute('aria-describedby')).toBeFalse();
 
     testComponent.badgeDescription = 'Describing a badge';
     fixture.detectChanges();
 
-    expect(badgeContent.getAttribute('aria-describedby')).toBeTruthy();
+    const describedById = badgeHostNativeElement.getAttribute('aria-describedby') || '';
+    const description = document.getElementById(describedById)?.textContent;
+    expect(description).toBe('Describing a badge');
 
     testComponent.badgeDescription = '';
     fixture.detectChanges();
 
-    expect(badgeContent.getAttribute('aria-describedby')).toBeFalsy();
+    expect(badgeHostNativeElement.hasAttribute('aria-describedby')).toBeFalse();
   });
 
   it('should toggle visibility based on whether the badge has content', () => {
-    const classList = badgeNativeElement.classList;
+    const classList = badgeHostNativeElement.classList;
 
     expect(classList.contains('sbb-badge-hidden')).toBe(false);
 
@@ -116,7 +116,7 @@ describe('SbbBadge', () => {
   });
 
   it('should apply view encapsulation on create badge content', () => {
-    const badge = badgeNativeElement.querySelector('.sbb-badge-content')!;
+    const badge = badgeHostNativeElement.querySelector('.sbb-badge-content')!;
     let encapsulationAttr: Attr | undefined;
 
     for (let i = 0; i < badge.attributes.length; i++) {
@@ -130,7 +130,7 @@ describe('SbbBadge', () => {
   });
 
   it('should toggle a class depending on the badge disabled state', () => {
-    const element: HTMLElement = badgeDebugElement.nativeElement;
+    const element: HTMLElement = badgeHostDebugElement.nativeElement;
 
     expect(element.classList).not.toContain('sbb-badge-disabled');
 
@@ -138,25 +138,6 @@ describe('SbbBadge', () => {
     fixture.detectChanges();
 
     expect(element.classList).toContain('sbb-badge-disabled');
-  });
-
-  it('should update the aria-label if the description changes', () => {
-    const badgeContent = badgeNativeElement.querySelector('.sbb-badge-content')!;
-
-    fixture.componentInstance.badgeDescription = 'initial content';
-    fixture.detectChanges();
-
-    expect(badgeContent.getAttribute('aria-label')).toBe('initial content');
-
-    fixture.componentInstance.badgeDescription = 'changed content';
-    fixture.detectChanges();
-
-    expect(badgeContent.getAttribute('aria-label')).toBe('changed content');
-
-    fixture.componentInstance.badgeDescription = '';
-    fixture.detectChanges();
-
-    expect(badgeContent.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should clear any pre-existing badges', () => {
@@ -174,7 +155,7 @@ describe('SbbBadge', () => {
   });
 
   it('should expose the badge element', () => {
-    const badgeElement = badgeNativeElement.querySelector('.sbb-badge-content')!;
+    const badgeElement = badgeHostNativeElement.querySelector('.sbb-badge-content')!;
     expect(fixture.componentInstance.badgeInstance.getBadgeElement()).toBe(badgeElement);
   });
 

--- a/src/angular/badge/badge.ts
+++ b/src/angular/badge/badge.ts
@@ -6,11 +6,10 @@ import {
   Inject,
   Input,
   NgZone,
-  OnChanges,
   OnDestroy,
+  OnInit,
   Optional,
   Renderer2,
-  SimpleChanges,
 } from '@angular/core';
 import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { CanDisable, mixinDisabled } from '@sbb-esta/angular/core';
@@ -25,6 +24,8 @@ const _SbbBadgeBase = mixinDisabled(class {});
 /** Allowed position options for sbbBadgePosition */
 export type SbbBadgePosition = 'after' | 'above';
 
+const BADGE_CONTENT_CLASS = 'sbb-badge-content';
+
 /** Directive to display a text badge. */
 @Directive({
   selector: '[sbbBadge]',
@@ -33,19 +34,23 @@ export type SbbBadgePosition = 'after' | 'above';
     class: 'sbb-badge',
     '[class.sbb-badge-above]': 'position !== "after"',
     '[class.sbb-badge-after]': 'position === "after"',
-    '[class.sbb-badge-hidden]': 'hidden || !_hasContent',
+    '[class.sbb-badge-hidden]': 'hidden || !content',
     '[class.sbb-badge-disabled]': 'disabled',
   },
 })
-export class SbbBadge extends _SbbBadgeBase implements OnDestroy, OnChanges, CanDisable {
-  /** Whether the badge has any content. */
-  _hasContent: boolean = false;
-
+export class SbbBadge extends _SbbBadgeBase implements OnInit, OnDestroy, CanDisable {
   /** Position the badge should reside. */
   @Input('sbbBadgePosition') position: SbbBadgePosition = 'above';
 
   /** The content for the badge */
-  @Input('sbbBadge') content: string | number | undefined | null;
+  @Input('sbbBadge')
+  get content(): string | number | undefined | null {
+    return this._content;
+  }
+  set content(newContent: string | number | undefined | null) {
+    this._updateRenderedContent(newContent);
+  }
+  private _content: string | number | undefined | null;
 
   /** Message used to describe the decorated element via aria-describedby */
   @Input('sbbBadgeDescription')
@@ -53,17 +58,7 @@ export class SbbBadge extends _SbbBadgeBase implements OnDestroy, OnChanges, Can
     return this._description;
   }
   set description(newDescription: string) {
-    if (newDescription !== this._description) {
-      const badgeElement = this._badgeElement;
-      this._updateHostAriaDescription(newDescription, this._description);
-      this._description = newDescription;
-
-      if (badgeElement) {
-        newDescription
-          ? badgeElement.setAttribute('aria-label', newDescription)
-          : badgeElement.removeAttribute('aria-label');
-      }
-    }
+    this._updateHostAriaDescription(newDescription);
   }
   private _description: string;
 
@@ -80,7 +75,11 @@ export class SbbBadge extends _SbbBadgeBase implements OnDestroy, OnChanges, Can
   /** Unique id for the badge */
   _id: number = nextId++;
 
+  /** Visible badge element. */
   private _badgeElement: HTMLElement | undefined;
+
+  /** Whether the OnInit lifecycle hook has run yet */
+  private _isInitialized = false;
 
   constructor(
     private _ngZone: NgZone,
@@ -99,32 +98,6 @@ export class SbbBadge extends _SbbBadgeBase implements OnDestroy, OnChanges, Can
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    const contentChange = changes['content'];
-
-    if (contentChange) {
-      const value = contentChange.currentValue;
-      this._hasContent = value != null && `${value}`.trim().length > 0;
-      this._updateTextContent();
-    }
-  }
-
-  ngOnDestroy() {
-    const badgeElement = this._badgeElement;
-
-    if (badgeElement) {
-      if (this.description) {
-        this._ariaDescriber.removeDescription(badgeElement, this.description);
-      }
-
-      // When creating a badge through the Renderer, Angular will keep it in an index.
-      // We have to destroy it ourselves, otherwise it'll be retained in memory.
-      if (this._renderer.destroyNode) {
-        this._renderer.destroyNode(badgeElement);
-      }
-    }
-  }
-
   /**
    * Gets the element into which the badge's content is being rendered.
    * Undefined if the element hasn't been created (e.g. if the badge doesn't have content).
@@ -133,34 +106,44 @@ export class SbbBadge extends _SbbBadgeBase implements OnDestroy, OnChanges, Can
     return this._badgeElement;
   }
 
-  /** Injects a span element into the DOM with the content. */
-  private _updateTextContent(): HTMLSpanElement {
-    if (!this._badgeElement) {
+  ngOnInit() {
+    // We may have server-side rendered badge that we need to clear.
+    // We need to do this in ngOnInit because the full content of the component
+    // on which the badge is attached won't necessarily be in the DOM until this point.
+    this._clearExistingBadges();
+
+    if (this.content && !this._badgeElement) {
       this._badgeElement = this._createBadgeElement();
-    } else {
-      this._badgeElement.textContent = this._stringifyContent();
+      this._updateRenderedContent(this.content);
     }
-    return this._badgeElement;
+
+    this._isInitialized = true;
+  }
+
+  ngOnDestroy() {
+    // ViewEngine only: when creating a badge through the Renderer, Angular remembers its index.
+    // We have to destroy it ourselves, otherwise it'll be retained in memory.
+    if (this._renderer.destroyNode) {
+      this._renderer.destroyNode(this._badgeElement);
+    }
+
+    this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this.description);
   }
 
   /** Creates the badge element */
   private _createBadgeElement(): HTMLElement {
     const badgeElement = this._renderer.createElement('span');
     const activeClass = 'sbb-badge-active';
-    const contentClass = 'sbb-badge-content';
 
-    // Clear any existing badges which may have persisted from a server-side render.
-    this._clearExistingBadges(contentClass);
     badgeElement.setAttribute('id', `sbb-badge-content-${this._id}`);
-    badgeElement.classList.add(contentClass);
-    badgeElement.textContent = this._stringifyContent();
+
+    // The badge is aria-hidden because we don't want it to appear in the page's navigation
+    // flow. Instead, we use the badge to describe the decorated element with aria-describedby.
+    badgeElement.setAttribute('aria-hidden', 'true');
+    badgeElement.classList.add(BADGE_CONTENT_CLASS);
 
     if (this._animationMode === 'NoopAnimations') {
       badgeElement.classList.add('_sbb-animation-noopable');
-    }
-
-    if (this.description) {
-      badgeElement.setAttribute('aria-label', this.description);
     }
 
     this._elementRef.nativeElement.appendChild(badgeElement);
@@ -179,40 +162,44 @@ export class SbbBadge extends _SbbBadgeBase implements OnDestroy, OnChanges, Can
     return badgeElement;
   }
 
-  /** Sets the aria-label property on the element */
-  private _updateHostAriaDescription(newDescription: string, oldDescription: string): void {
-    // ensure content available before setting label
-    const content = this._updateTextContent();
+  /** Update the text content of the badge element in the DOM, creating the element if necessary. */
+  private _updateRenderedContent(newContent: string | number | undefined | null): void {
+    const newContentNormalized: string = `${newContent ?? ''}`.trim();
 
-    if (oldDescription) {
-      this._ariaDescriber.removeDescription(content, oldDescription);
+    // Don't create the badge element if the directive isn't initialized because we want to
+    // append the badge element to the *end* of the host element's content for backwards
+    // compatibility.
+    if (this._isInitialized && newContentNormalized && !this._badgeElement) {
+      this._badgeElement = this._createBadgeElement();
     }
 
+    if (this._badgeElement) {
+      this._badgeElement.textContent = newContentNormalized;
+    }
+
+    this._content = newContentNormalized;
+  }
+
+  /** Updates the host element's aria description via AriaDescriber. */
+  private _updateHostAriaDescription(newDescription: string): void {
+    this._ariaDescriber.removeDescription(this._elementRef.nativeElement, this.description);
     if (newDescription) {
-      this._ariaDescriber.describe(content, newDescription);
+      this._ariaDescriber.describe(this._elementRef.nativeElement, newDescription);
     }
+    this._description = newDescription;
   }
 
   /** Clears any existing badges that might be left over from server-side rendering. */
-  private _clearExistingBadges(cssClass: string) {
-    const element = this._elementRef.nativeElement;
-    let childCount = element.children.length;
-
-    // Use a reverse while, because we'll be removing elements from the list as we're iterating.
-    while (childCount--) {
-      const currentChild = element.children[childCount];
-
-      if (currentChild.classList.contains(cssClass)) {
-        element.removeChild(currentChild);
+  private _clearExistingBadges() {
+    // Only check direct children of this host element in order to avoid deleting
+    // any badges that might exist in descendant elements.
+    const badges = this._elementRef.nativeElement.querySelectorAll(
+      `:scope > .${BADGE_CONTENT_CLASS}`
+    );
+    for (const badgeElement of Array.from(badges)) {
+      if (badgeElement !== this._badgeElement) {
+        badgeElement.remove();
       }
     }
-  }
-
-  /** Gets the string representation of the badge content. */
-  private _stringifyContent(): string {
-    // Convert null and undefined to an empty string which is consistent
-    // with how Angular handles them in inside template interpolations.
-    const content = this.content;
-    return content == null ? '' : `${content}`;
   }
 }

--- a/src/angular/tag/tags.spec.ts
+++ b/src/angular/tag/tags.spec.ts
@@ -598,7 +598,7 @@ function expectTotalAmount(expectedTotalAmount: number, fixture: any) {
 
 function extractBadgeDescription(sbbTag: DebugElement) {
   const ariaDescribedById = sbbTag
-    .query(By.css('.sbb-badge-content'))
+    .query(By.css('.sbb-badge'))
     .nativeElement.getAttribute('aria-describedby');
   return document.getElementById(ariaDescribedById)!.textContent;
 }


### PR DESCRIPTION
Previously, `SbbBadge` was applying the provided description
as an `aria-label` to the badge content element, which is
a child element of the badge host. Then it was _also_ applying
an `aria-describedby` to that same content element.
The end result is that the badge was being treated
mainly as text content for a control, which isn't really
the best way to convey its complementary nature.
This behavior was causing problems in NVDA,
where the badge content was overriding the host button's label.

This change makes the badge content itself `aria-hidden` and
applies the badge description to the badge's _host_ element
via `aria-describedby` and completely removes any setting of `aria-label`.
It also makes a handful of minor cleanup refactorings.

https://github.com/angular/components/pull/23562