### PR TITLE
fix(angular/sidebar): restore focus with correct origin when closing via the backdrop

### DIFF
--- a/src/angular/sidebar/sidebar-base.ts
+++ b/src/angular/sidebar/sidebar-base.ts
@@ -136,7 +136,7 @@ export abstract class SbbSidebarContainerBase<T extends SbbSidebarBase>
     this._sidebar = null;
 
     // Ensure that we have at most one sidebar.
-    if (this._sidebars.length > 1) {
+    if (this._sidebars.length > 1 && (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throwSbbDuplicatedSidebarError();
     }
     this._sidebar = this._sidebars.first;


### PR DESCRIPTION
Currently, when a sidebar is closed, we restore the focus origin as when it was focused
because we don't know what kind of event closed it, however if it happens through
the backdrop, we can be fairly certain that it was via mouse.

These changes pass in the `mouse` origin when closing through the backdrop.

https://github.com/angular/components/pull/23492