### PR TITLE
fix(angular/autocomplete): don't emit optionActivated event when option is reset

### DIFF
--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -3423,6 +3423,28 @@ describe('SbbAutocomplete', () => {
     expect(spy.calls.mostRecent().args[0]).toEqual({ source: autocomplete, option: options[2] });
   }));
 
+  it('should not emit the optionActivated event when the active option is reset', fakeAsync(() => {
+    const fixture = createComponent(AutocompleteWithActivatedEvent);
+
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openPanel();
+    zone.simulateZoneExit();
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input');
+    const spy = fixture.componentInstance.optionActivated;
+
+    expect(spy).not.toHaveBeenCalled();
+
+    dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+    fixture.detectChanges();
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    dispatchKeyboardEvent(input, 'keydown', ESCAPE);
+    fixture.detectChanges();
+    expect(spy).toHaveBeenCalledTimes(1);
+  }));
+
   it('should be able to set a custom panel connection element', () => {
     const fixture = createComponent(AutocompleteWithDifferentOrigin);
 

--- a/src/angular/autocomplete/autocomplete.ts
+++ b/src/angular/autocomplete/autocomplete.ts
@@ -239,7 +239,9 @@ export class SbbAutocomplete implements AfterContentInit, OnDestroy {
   ngAfterContentInit() {
     this._keyManager = new ActiveDescendantKeyManager<SbbOption>(this.options).withWrap();
     this._activeOptionChanges = this._keyManager.change.subscribe((index) => {
-      this.optionActivated.emit({ source: this, option: this.options.toArray()[index] || null });
+      if (this.isOpen) {
+        this.optionActivated.emit({ source: this, option: this.options.toArray()[index] || null });
+      }
     });
 
     // Set the initial visibility state.


### PR DESCRIPTION
Fixes that we were emitting the `optionActivated` event when the option is
reset programmatically when the panel closes.
The intent was to only emit the event as a result of a user action.

https://github.com/angular/components/pull/23437