### PR TITLE
fix(angular/icon): make icon-registry compatible with Trusted Types

### DIFF
--- a/src/angular/icon/trusted-types.ts
+++ b/src/angular/icon/trusted-types.ts
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview
+ * A module to facilitate use of a Trusted Types policy internally within
+ * SBB Angular. It lazily constructs the Trusted Types policy, providing
+ * helper utilities for promoting strings to Trusted Types. When Trusted Types
+ * are not available, strings are used as a fallback.
+ * @security All use of this module is security-sensitive and should go through
+ * security review.
+ */
+
+export declare interface TrustedHTML {
+  __brand__: 'TrustedHTML';
+}
+
+export declare interface TrustedTypePolicyFactory {
+  createPolicy(
+    policyName: string,
+    policyOptions: {
+      createHTML?: (input: string) => string;
+    }
+  ): TrustedTypePolicy;
+}
+
+export declare interface TrustedTypePolicy {
+  createHTML(input: string): TrustedHTML;
+}
+
+/**
+ * The Trusted Types policy, or null if Trusted Types are not
+ * enabled/supported, or undefined if the policy has not been created yet.
+ */
+let policy: TrustedTypePolicy | null | undefined;
+
+/**
+ * Returns the Trusted Types policy, or null if Trusted Types are not
+ * enabled/supported. The first call to this function will create the policy.
+ */
+function getPolicy(): TrustedTypePolicy | null {
+  if (policy === undefined) {
+    policy = null;
+    if (typeof window !== 'undefined') {
+      const ttWindow = window as unknown as { trustedTypes?: TrustedTypePolicyFactory };
+      if (ttWindow.trustedTypes !== undefined) {
+        policy = ttWindow.trustedTypes.createPolicy('sbb-esta#angular', {
+          createHTML: (s: string) => s,
+        });
+      }
+    }
+  }
+  return policy;
+}
+
+/**
+ * Unsafely promote a string to a TrustedHTML, falling back to strings when
+ * Trusted Types are not available.
+ * @security This is a security-sensitive function; any use of this function
+ * must go through security review. In particular, it must be assured that the
+ * provided string will never cause an XSS vulnerability if used in a context
+ * that will be interpreted as HTML by a browser, e.g. when assigning to
+ * element.innerHTML.
+ */
+export function trustedHTMLFromString(html: string): TrustedHTML {
+  return getPolicy()?.createHTML(html) || (html as unknown as TrustedHTML);
+}


### PR DESCRIPTION
When SBB Angular is used in an environment that enforces Trusted
Types, the icon registry raises a Trusted Types violation due to its use
of element.innerHTML when initializing SVG icons.

To make the icon registry compatible with Trusted Types,
SvgIconConfig.svgText is changed to a TrustedHTML, and its users updated
to either produce TrustedHTML (making sure to only do so in cases where
its security can be readily assessed) or pass such values along.

To facilitate this, add a module that provides a Trusted Types policy,
'sbb-esta#angular'. The policy is created lazily and stored in a
module-local variable. This is the same as the approach taken by Angular
proper in
https://github.com/angular/angular/blob/master/packages/core/src/util/security/trusted_types.ts