### PR TITLE
build: remove commit message max line length limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,10 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "body-max-line-length": [0, "always", 0]
+    }
   },
   "lint-staged": {
     "*.{js,ts,css,scss,json,md,html}": [


### PR DESCRIPTION
With this change we remove the lines length restriction in commit message body. This was previously in place due to a bug in GitHub UI, which is now fixed.