### PR TITLE
build: add `exports` entries for Sass module resolution

### DIFF
--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -13,6 +13,14 @@
     "url": "https://github.com/sbb-design-systems/sbb-angular/issues"
   },
   "homepage": "https://angular.app.sbb.ch",
+  "exports": {
+    ".": {
+      "sass": "./_styles.scss"
+    },
+    "./typography.css": {
+      "style": "./typography.css"
+    }
+  },
   "peerDependencies": {
     "@angular/cdk": "0.0.0-CDK",
     "@angular/common": "0.0.0-NG",


### PR DESCRIPTION
Adds the `exports` field for module resolution of `@sbb-esta/angular` when Sass is requested.

Since these packages use the `exports` field already, to prevent
deep imports, we also need to expose the Sass entry-points and prebuilt
files. The webpack loader requires the `sass` conditional to be set
when the sbb-angular modules are loaded without the `includePaths` option.