### PR TITLE
fix(angular/radio-button-panel): only show error styles when parent group is invalid

### DIFF
--- a/src/angular/radio-button/radio-button.ts
+++ b/src/angular/radio-button/radio-button.ts
@@ -67,7 +67,11 @@ export const SBB_RADIO_GROUP = new InjectionToken<_SbbRadioGroupBase<_SbbRadioBu
  */
 export const SBB_RADIO_BUTTON = new InjectionToken<_SbbRadioButtonBase>('SbbRadioButton');
 
-@Directive()
+@Directive({
+  host: {
+    class: 'sbb-radio-group-base',
+  },
+})
 // tslint:disable-next-line: naming-convention class-name
 export abstract class _SbbRadioGroupBase<TRadio extends _SbbRadioButtonBase>
   implements AfterContentInit, ControlValueAccessor

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -1723,7 +1723,7 @@ textarea {
   // or on a wrapper (e.g. sbb-radio-group) with both manual
   // classes and Angular Form Validation classes.
   &:is(.sbb-selection-error, .ng-touched.ng-invalid),
-  :is(.sbb-selection-error, .ng-touched.ng-invalid) & {
+  .sbb-radio-group-base:is(.sbb-selection-error, .ng-touched.ng-invalid) & {
     border-color: var(--sbb-color-error);
     color: var(--sbb-color-error);
   }


### PR DESCRIPTION
Previously we would show error styles, when any ancestor had .ng-touched.ng-invalid assigned.
This could also be the FormGroup element, which would cause the radio-button-panel
to incorrectly be marked as invalid.

Closes #1078 