### PR TITLE
fix(angular/chips): don't stop propagation on all click events

### DIFF
--- a/src/angular/chips/chip.ts
+++ b/src/angular/chips/chip.ts
@@ -248,8 +248,6 @@ export class SbbChip
   _handleClick(event: Event) {
     if (this.disabled) {
       event.preventDefault();
-    } else {
-      event.stopPropagation();
     }
   }
 


### PR DESCRIPTION
Historically we've had to stop propagation on clicks so that clicking on a chip won't move focus to the first chip once the event bubbles up to the list. This isn't necessary because we changed how we detect clicks from inside a chip. These changes remove the call since it can prevent people's global click listeners from firing.