### PR TITLE
feat(angular/tabs): add the ability to keep content inside the DOM while off-screen

### DIFF
--- a/src/angular/tabs/tab-body.scss
+++ b/src/angular/tabs/tab-body.scss
@@ -5,4 +5,15 @@
   .sbb-tab-group-dynamic-height & {
     overflow: hidden;
   }
+
+  // Usually the `visibility: hidden` added by the animation is enough to prevent focus from
+  // entering the collapsed content, but children with their own `visibility` can override it.
+  // This is a fallback that completely hides the content when the element becomes hidden.
+  // Note that we can't do this in the animation definition, because the style gets recomputed too
+  // late, breaking the animation because Angular didn't have time to figure out the target height.
+  // This can also be achieved with JS, but it has issues when when starting an animation before
+  // the previous one has finished.
+  &[style*='visibility: hidden'] {
+    display: none;
+  }
 }

--- a/src/angular/tabs/tab-body.ts
+++ b/src/angular/tabs/tab-body.ts
@@ -64,7 +64,9 @@ export class SbbTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
       });
 
     this._leavingSub = this._host._afterLeavingCenter.subscribe(() => {
-      this.detach();
+      if (!this._host.preserveContent) {
+        this.detach();
+      }
     });
   }
 
@@ -115,6 +117,9 @@ export abstract class _SbbTabBodyBase implements OnDestroy {
 
   /** Position that will be used when the tab is immediately becoming visible after creation. */
   @Input() origin: number | null;
+
+  /** Whether the tab's content should be kept in the DOM while it's off-screen. */
+  @Input() preserveContent: boolean = false;
 
   /** The shifted index position of the tab body, where zero represents the active center tab. */
   @Input()

--- a/src/angular/tabs/tab-config.ts
+++ b/src/angular/tabs/tab-config.ts
@@ -11,6 +11,13 @@ export interface SbbTabsConfig {
 
   /** Whether the tab group should grow to the size of the active tab. */
   dynamicHeight?: boolean;
+
+  /**
+   * By default tabs remove their content from the DOM while it's off-screen.
+   * Setting this to `true` will keep it in the DOM which will prevent elements
+   * like iframes and videos from reloading next time it comes back into the view.
+   */
+  preserveContent?: boolean;
 }
 
 /** Injection token that can be used to provide the default options the tabs module. */

--- a/src/angular/tabs/tab-group.html
+++ b/src/angular/tabs/tab-group.html
@@ -52,6 +52,7 @@
     [content]="tab.content!"
     [position]="tab.position!"
     [origin]="tab.origin"
+    [preserveContent]="preserveContent"
     (_onCentered)="_removeTabBodyWrapperHeight()"
     (_onCentering)="_setTabBodyWrapperHeight($event)"
   >

--- a/src/angular/tabs/tab-group.spec.ts
+++ b/src/angular/tabs/tab-group.spec.ts
@@ -590,6 +590,56 @@ describe('SbbTabGroup', () => {
       expect(fixture.nativeElement.textContent).not.toContain('Pizza, fries');
       expect(fixture.nativeElement.textContent).toContain('Peanuts');
     }));
+
+    it('should be able to opt into keeping the inactive tab content in the DOM', fakeAsync(() => {
+      fixture.componentInstance.preserveContent = true;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('Pizza, fries');
+      expect(fixture.nativeElement.textContent).not.toContain('Peanuts');
+
+      tabGroup.selectedIndex = 3;
+      fixture.detectChanges();
+      tick();
+
+      expect(fixture.nativeElement.textContent).toContain('Pizza, fries');
+      expect(fixture.nativeElement.textContent).toContain('Peanuts');
+    }));
+
+    it('should visibly hide the content of inactive tabs', fakeAsync(() => {
+      const contentElements: HTMLElement[] = Array.from(
+        fixture.nativeElement.querySelectorAll('.sbb-tab-body-content')
+      );
+
+      expect(contentElements.map((element) => element.style.visibility)).toEqual([
+        '',
+        'hidden',
+        'hidden',
+        'hidden',
+      ]);
+
+      tabGroup.selectedIndex = 2;
+      fixture.detectChanges();
+      tick();
+
+      expect(contentElements.map((element) => element.style.visibility)).toEqual([
+        'hidden',
+        'hidden',
+        '',
+        'hidden',
+      ]);
+
+      tabGroup.selectedIndex = 1;
+      fixture.detectChanges();
+      tick();
+
+      expect(contentElements.map((element) => element.style.visibility)).toEqual([
+        'hidden',
+        '',
+        'hidden',
+        'hidden',
+      ]);
+    }));
   });
 
   describe('lazy loaded tabs', () => {
@@ -995,7 +1045,7 @@ class AsyncTabsTestApp implements OnInit {
 
 @Component({
   template: `
-    <sbb-tab-group>
+    <sbb-tab-group [preserveContent]="preserveContent">
       <sbb-tab label="Junk food"> Pizza, fries </sbb-tab>
       <sbb-tab label="Vegetables"> Broccoli, spinach </sbb-tab>
       <sbb-tab [label]="otherLabel"> {{ otherContent }} </sbb-tab>
@@ -1004,6 +1054,7 @@ class AsyncTabsTestApp implements OnInit {
   `,
 })
 class TabGroupWithSimpleApi {
+  preserveContent = false;
   otherLabel = 'Fruit';
   otherContent = 'Apples, grapes';
   @ViewChild('legumes') legumes: any;

--- a/src/angular/tabs/tab-group.ts
+++ b/src/angular/tabs/tab-group.ts
@@ -104,6 +104,14 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
   @Input()
   disablePagination: boolean;
 
+  /**
+   * By default tabs remove their content from the DOM while it's off-screen.
+   * Setting this to `true` will keep it in the DOM which will prevent elements
+   * like iframes and videos from reloading next time it comes back into the view.
+   */
+  @Input()
+  preserveContent: boolean;
+
   /** Output to enable support for two-way binding on `[(selectedIndex)]` */
   @Output() readonly selectedIndexChange: EventEmitter<number> = new EventEmitter<number>();
 
@@ -134,6 +142,7 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
         : false;
     this.dynamicHeight =
       defaultConfig && defaultConfig.dynamicHeight != null ? defaultConfig.dynamicHeight : false;
+    this.preserveContent = !!defaultConfig?.preserveContent;
   }
 
   /**

--- a/src/angular/tabs/tabs-animations.ts
+++ b/src/angular/tabs/tabs-animations.ts
@@ -1,4 +1,11 @@
-import { animate, AnimationTriggerMetadata, style, transition, trigger } from '@angular/animations';
+import {
+  animate,
+  AnimationTriggerMetadata,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
 
 /**
  * Animations used by the SBB tabs.
@@ -8,12 +15,20 @@ export const sbbTabsAnimations: {
   readonly translateTab: AnimationTriggerMetadata;
 } = {
   translateTab: trigger('translateTab', [
+    state(
+      'hidden',
+      style({
+        // Normally this is redundant since we detach the content from the DOM, but if the user
+        // opted into keeping the content in the DOM, we have to hide it so it isn't focusable.
+        visibility: 'hidden',
+      })
+    ),
     transition('* => void, * => hidden', [
       style({ opacity: 1 }),
       animate('150ms ease', style({ opacity: 0 })),
     ]),
     transition('hidden => show', [
-      style({ opacity: 0 }),
+      style({ opacity: 0, visibility: 'visible' }),
       animate('500ms ease', style({ opacity: 1 })),
     ]),
     transition('void => show', animate('0s')),

--- a/src/angular/tabs/tabs.md
+++ b/src/angular/tabs/tabs.md
@@ -111,6 +111,30 @@ with the `sbbTabContent` attribute.
 </sbb-tab>
 ```
 
+### Keeping the tab content inside the DOM while it's off-screen
+
+By default the `<sbb-tab-group>` will remove the content of off-screen tabs from the DOM until they
+come into the view. This is optimal for most cases since it keeps the DOM size smaller, but it
+isn't great for others like when a tab has an `<audio>` or `<video>` element, because the content
+will be re-initialized whenever the user navigates to the tab. If you want to keep the content of
+off-screen tabs in the DOM, you can set the `preserveContent` input to `true`.
+
+```html
+<sbb-tab-group [preserveContent]="true">
+  <sbb-tab label="First">
+    <iframe
+      width="560"
+      height="315"
+      src="https://www.youtube.com/embed/B-lipaiZII8"
+      frameborder="0"
+      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    ></iframe>
+  </sbb-tab>
+  <sbb-tab label="Second">Note how the video from the previous tab is still playing.</sbb-tab>
+</sbb-tab-group>
+```
+
 ### Accessibility
 
 `SbbTabGroup` and `SbbTabNavBar` implement different interaction patterns for different use-cases.

--- a/src/components-examples/angular/tabs/index.ts
+++ b/src/components-examples/angular/tabs/index.ts
@@ -15,6 +15,7 @@ import { TabGroupCustomLabelExample } from './tab-group-custom-label/tab-group-c
 import { TabGroupDynamicHeightExample } from './tab-group-dynamic-height/tab-group-dynamic-height-example';
 import { TabGroupDynamicExample } from './tab-group-dynamic/tab-group-dynamic-example';
 import { TabGroupLazyLoadedExample } from './tab-group-lazy-loaded/tab-group-lazy-loaded-example';
+import { TabGroupPreserveContentExample } from './tab-group-preserve-content/tab-group-preserve-content-example';
 import { TabNavBarBasicExample } from './tab-nav-bar-basic/tab-nav-bar-basic-example';
 
 export {
@@ -26,6 +27,7 @@ export {
   TabGroupDynamicHeightExample,
   TabGroupLazyLoadedExample,
   TabNavBarBasicExample,
+  TabGroupPreserveContentExample,
 };
 
 const EXAMPLES = [
@@ -37,6 +39,7 @@ const EXAMPLES = [
   TabGroupDynamicHeightExample,
   TabGroupLazyLoadedExample,
   TabNavBarBasicExample,
+  TabGroupPreserveContentExample,
 ];
 
 @NgModule({

--- a/src/components-examples/angular/tabs/tab-group-preserve-content/tab-group-preserve-content-example.html
+++ b/src/components-examples/angular/tabs/tab-group-preserve-content/tab-group-preserve-content-example.html
@@ -1,0 +1,15 @@
+<p>Start the video in the first tab and navigate to the second one to see how it keeps playing.</p>
+
+<sbb-tab-group [preserveContent]="true">
+  <sbb-tab label="First">
+    <iframe
+      width="560"
+      height="315"
+      src="https://www.youtube.com/embed/B-lipaiZII8"
+      frameborder="0"
+      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen
+    ></iframe>
+  </sbb-tab>
+  <sbb-tab label="Second">Note how the video from the previous tab is still playing.</sbb-tab>
+</sbb-tab-group>

--- a/src/components-examples/angular/tabs/tab-group-preserve-content/tab-group-preserve-content-example.ts
+++ b/src/components-examples/angular/tabs/tab-group-preserve-content/tab-group-preserve-content-example.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+/**
+ * @title Tab group that keeps its content inside the DOM when it's off-screen.
+ * @order 90
+ */
+@Component({
+  selector: 'sbb-tab-group-preserve-content-example',
+  templateUrl: 'tab-group-preserve-content-example.html',
+})
+export class TabGroupPreserveContentExample {}


### PR DESCRIPTION
Adds the `preserveContent` input which allows consumers to opt into keeping the content of off-screen tabs inside the DOM. This is useful primarily for edge cases like iframes and videos where removing the element from the DOM will cause it to reload.

One gotcha here is that we have to set `visibility: hidden` on the off-screen content so that users can't tab into it.

https://github.com/angular/components/commit/cad087220848b2cd2c252520bac26a42d8b279aa