### PR TITLE
fix(angular/tabs): use buttons for paginator

### DIFF
--- a/src/angular/tabs/tab-header.html
+++ b/src/angular/tabs/tab-header.html
@@ -1,14 +1,17 @@
-<div
-  class="sbb-tab-header-pagination sbb-tab-header-pagination-before"
+<button
+  class="sbb-tab-header-pagination sbb-tab-header-pagination-before sbb-button-reset-frameless"
   #previousPaginator
   aria-hidden="true"
+  type="button"
+  tabindex="-1"
   [class.sbb-tab-header-pagination-disabled]="_disableScrollBefore"
+  [disabled]="_disableScrollBefore || null"
   (click)="_handlePaginatorClick('before')"
   (mousedown)="_handlePaginatorPress('before', $event)"
   (touchend)="_stopInterval()"
 >
   <sbb-icon svgIcon="kom:chevron-left-small" class="sbb-tab-header-pagination-chevron"></sbb-icon>
-</div>
+</button>
 
 <div
   class="sbb-tab-label-container sbb-scrollbar"
@@ -28,14 +31,17 @@
   </div>
 </div>
 
-<div
-  class="sbb-tab-header-pagination sbb-tab-header-pagination-after"
+<button
+  class="sbb-tab-header-pagination sbb-tab-header-pagination-after sbb-button-reset-frameless"
   #nextPaginator
   aria-hidden="true"
+  type="button"
   [class.sbb-tab-header-pagination-disabled]="_disableScrollAfter"
+  [disabled]="_disableScrollAfter || null"
+  tabindex="-1"
   (mousedown)="_handlePaginatorPress('after', $event)"
   (click)="_handlePaginatorClick('after')"
   (touchend)="_stopInterval()"
 >
   <sbb-icon svgIcon="kom:chevron-right-small" class="sbb-tab-header-pagination-chevron"></sbb-icon>
-</div>
+</button>

--- a/src/angular/tabs/tab-nav-bar.html
+++ b/src/angular/tabs/tab-nav-bar.html
@@ -1,14 +1,17 @@
-<div
-  class="sbb-tab-header-pagination sbb-tab-header-pagination-before"
+<button
+  class="sbb-tab-header-pagination sbb-tab-header-pagination-before sbb-button-reset-frameless"
   #previousPaginator
   aria-hidden="true"
+  type="button"
+  tabindex="-1"
   [class.sbb-tab-header-pagination-disabled]="_disableScrollBefore"
+  [disabled]="_disableScrollBefore || null"
   (click)="_handlePaginatorClick('before')"
   (mousedown)="_handlePaginatorPress('before', $event)"
   (touchend)="_stopInterval()"
 >
   <sbb-icon svgIcon="kom:chevron-left-small" class="sbb-tab-header-pagination-chevron"></sbb-icon>
-</div>
+</button>
 
 <div
   class="sbb-tab-link-container sbb-scrollbar"
@@ -27,14 +30,17 @@
   </div>
 </div>
 
-<div
-  class="sbb-tab-header-pagination sbb-tab-header-pagination-after"
+<button
+  class="sbb-tab-header-pagination sbb-tab-header-pagination-after sbb-button-reset-frameless"
   #nextPaginator
   aria-hidden="true"
+  type="button"
   [class.sbb-tab-header-pagination-disabled]="_disableScrollAfter"
+  [disabled]="_disableScrollAfter || null"
+  tabindex="-1"
   (mousedown)="_handlePaginatorPress('after', $event)"
   (click)="_handlePaginatorClick('after')"
   (touchend)="_stopInterval()"
 >
   <sbb-icon svgIcon="kom:chevron-right-small" class="sbb-tab-header-pagination-chevron"></sbb-icon>
-</div>
+</button>


### PR DESCRIPTION
Uses `button` elements, rather than styled `div`-s for the paginator buttons. This has the advantage of being more accessible, if we decided to make them focusable, and it stops calling the click listeners when the button is disabled (currently we do some expensive checks in them when we don't have to).