### PR TITLE
fix(angular/datepicker): change calendar cells to buttons

### DIFF
--- a/src/angular/datepicker/calendar-body/calendar-body.html
+++ b/src/angular/datepicker/calendar-body/calendar-body.html
@@ -29,7 +29,7 @@
       [class.sbb-calendar-body-disabled]="!item.enabled"
       [class.sbb-calendar-body-active]="isActiveCell(rowIndex, colIndex)"
       [class.sbb-calendar-body-range-background]="item.rangeBackground === 'range'"
-      [class.sbb-calendar-body-range-background-offset-start]="item.rangeBackground === 'range' && rowIndex === 0 && firstRowOffset && colIndex === 0"
+      [class.sbb-calendar-body-range-background-offset-start]="item.rangeBackground !== null && rowIndex === 0 && firstRowOffset && colIndex === 0"
       [class.sbb-calendar-body-selected-begin]="item.rangeBackground === 'begin'"
       [class.sbb-calendar-body-selected-end]="item.rangeBackground === 'end'"
       [class.sbb-calendar-body-selected]="selectedValue === item.value"

--- a/src/angular/datepicker/calendar-body/calendar-body.html
+++ b/src/angular/datepicker/calendar-body/calendar-body.html
@@ -1,36 +1,46 @@
 <!-- Create the first row separately so we can include a special spacer cell. -->
 <tr *ngFor="let row of rows; let rowIndex = index" role="row">
   <!--
-    We mark this cell as aria-hidden so it doesn't get read out as one of the days in the week.
-    The aspect ratio of the table cells is maintained by setting the top and bottom padding as a
-    percentage of the width (a variant of the trick described here:
-    https://www.w3schools.com/howto/howto_css_aspect_ratio.asp).
+    This cell is purely decorative, but we can't put `aria-hidden` or `role="presentation"` on it,
+    because it throws off the week days for the rest of the row on NVDA. The aspect ratio of the
+    table cells is maintained by setting the top and bottom padding as a percentage of the width
+    (a variant of the trick described here: https://www.w3schools.com/howto/howto_css_aspect_ratio.asp).
   -->
   <td
     *ngIf="rowIndex === 0 && firstRowOffset"
-    aria-hidden="true"
     class="sbb-calendar-body-label"
     [attr.colspan]="firstRowOffset"
   ></td>
+  <!--
+    Each gridcell in the calendar contains a button, which signals to assistive technology that the
+    cell is interactable, as well as the selection state via `aria-pressed`. See angular/components#23476 for
+    background.
+  -->
   <td
     *ngFor="let item of row; let colIndex = index"
     role="gridcell"
-    class="sbb-calendar-body-cell"
-    [tabindex]="isActiveCell(rowIndex, colIndex) ? 0 : -1"
-    [class.sbb-calendar-body-disabled]="!item.enabled"
-    [class.sbb-calendar-body-active]="isActiveCell(rowIndex, colIndex)"
-    [class.sbb-calendar-body-range-background]="item.rangeBackground === 'range'"
-    [class.sbb-calendar-body-range-background-offset-start]="item.rangeBackground === 'range' && rowIndex === 0 && firstRowOffset && colIndex === 0"
-    [class.sbb-calendar-body-selected-begin]="item.rangeBackground === 'begin'"
-    [class.sbb-calendar-body-selected-end]="item.rangeBackground === 'end'"
-    [class.sbb-calendar-body-selected]="selectedValue === item.value"
-    [class.sbb-calendar-body-today]="todayValue === item.value"
-    [attr.aria-label]="item.ariaLabel"
-    [attr.aria-disabled]="!item.enabled || null"
-    [attr.aria-selected]="selectedValue === item.value"
-    (click)="cellClicked(item)"
+    class="sbb-calendar-body-cell-container"
     [style.width.%]="100 / numCols"
   >
-    <div class="sbb-calendar-body-cell-content">{{ item.displayValue }}</div>
+    <button
+      type="button"
+      class="sbb-calendar-body-cell sbb-button-reset-frameless"
+      [tabindex]="isActiveCell(rowIndex, colIndex) ? 0 : -1"
+      [class.sbb-calendar-body-disabled]="!item.enabled"
+      [class.sbb-calendar-body-active]="isActiveCell(rowIndex, colIndex)"
+      [class.sbb-calendar-body-range-background]="item.rangeBackground === 'range'"
+      [class.sbb-calendar-body-range-background-offset-start]="item.rangeBackground === 'range' && rowIndex === 0 && firstRowOffset && colIndex === 0"
+      [class.sbb-calendar-body-selected-begin]="item.rangeBackground === 'begin'"
+      [class.sbb-calendar-body-selected-end]="item.rangeBackground === 'end'"
+      [class.sbb-calendar-body-selected]="selectedValue === item.value"
+      [class.sbb-calendar-body-today]="todayValue === item.value"
+      [attr.aria-label]="item.ariaLabel"
+      [attr.aria-disabled]="!item.enabled || null"
+      [attr.aria-pressed]="selectedValue === item.value"
+      [attr.aria-current]="todayValue === item.value ? 'date' : null"
+      (click)="cellClicked(item)"
+    >
+      <div class="sbb-calendar-body-cell-content">{{ item.displayValue }}</div>
+    </button>
   </td>
 </tr>

--- a/src/angular/datepicker/calendar-body/calendar-body.spec.ts
+++ b/src/angular/datepicker/calendar-body/calendar-body.spec.ts
@@ -135,15 +135,13 @@ describe('SbbCalendarBody', () => {
       expect(selectedCell.innerHTML.trim()).toBe('4');
     });
 
-    it('should set aria-selected correctly', () => {
-      const selectedCells = cellEls.filter((c) => c.getAttribute('aria-selected') === 'true');
-      const deselectedCells = cellEls.filter((c) => c.getAttribute('aria-selected') === 'false');
+    it('should set aria-pressed correctly', () => {
+      const pressedCells = cellEls.filter((c) => c.getAttribute('aria-pressed') === 'true');
+      const depressedCells = cellEls.filter((c) => c.getAttribute('aria-pressed') === 'false');
 
-      expect(selectedCells.length)
-        .withContext('Expected one cell to be marked as selected.')
-        .toBe(1);
-      expect(deselectedCells.length)
-        .withContext('Expected remaining cells to be marked as deselected.')
+      expect(pressedCells.length).withContext('Expected one cell to be marked as pressed.').toBe(1);
+      expect(depressedCells.length)
+        .withContext('Expected remaining cells to be marked as not pressed.')
         .toBe(cellEls.length - 1);
     });
 

--- a/src/angular/datepicker/datepicker-content/datepicker-content.scss
+++ b/src/angular/datepicker/datepicker-content/datepicker-content.scss
@@ -202,12 +202,25 @@
   height: calc(#{pxToRem(15)} * var(--sbb-scaling-factor));
 }
 
-.sbb-calendar-body-cell {
+.sbb-calendar-body-cell-container {
   position: relative;
   height: 0;
+  padding: 0;
   line-height: 0;
   text-align: center;
-  outline: 0;
+}
+
+.sbb-calendar-body-cell {
+  position: relative;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: none;
+  text-align: center;
+  outline: none;
+  font-family: inherit;
+  margin: 0;
   cursor: pointer;
 
   &:is(.sbb-calendar-body-range-background, .sbb-calendar-body-selected-begin, .sbb-calendar-body-selected-end)::before {

--- a/src/angular/datepicker/datepicker-content/datepicker-content.scss
+++ b/src/angular/datepicker/datepicker-content/datepicker-content.scss
@@ -231,31 +231,38 @@
     left: 0;
   }
 
-  &:is(.sbb-calendar-body-selected-begin, .sbb-calendar-body-selected-end, .sbb-calendar-body-range-background:is(:last-child, :first-child), .sbb-calendar-body-range-background-offset-start)::before {
+  :is(.sbb-calendar-body-cell-container:is(:last-child, :first-child)
+      > &.sbb-calendar-body-range-background, &:is(.sbb-calendar-body-selected-begin, .sbb-calendar-body-selected-end, .sbb-calendar-body-range-background-offset-start))::before {
     width: 50%;
   }
 
-  &:is(.sbb-calendar-body-selected-begin, .sbb-calendar-body-range-background:first-child, .sbb-calendar-body-range-background-offset-start)::before {
+  :is(.sbb-calendar-body-cell-container:first-child
+      > &.sbb-calendar-body-range-background, &:is(.sbb-calendar-body-selected-begin, .sbb-calendar-body-range-background-offset-start))::before {
     left: auto;
     right: 0;
   }
 
-  &:is(.sbb-calendar-body-range-background:is(:last-child, :first-child), .sbb-calendar-body-range-background-offset-start)::after {
+  :is(.sbb-calendar-body-cell-container:is(:last-child, :first-child)
+      > &.sbb-calendar-body-range-background, &.sbb-calendar-body-range-background-offset-start)::after {
     @include datePickerCellContentBase();
     content: '';
     background-color: var(--sbb-datepicker-calendar-table-range-bg-color);
   }
 
-  &:is(.sbb-calendar-body-range-background:first-child, .sbb-calendar-body-range-background-offset-start)::after {
+  :is(.sbb-calendar-body-cell-container:first-child
+      > &.sbb-calendar-body-range-background, &.sbb-calendar-body-range-background-offset-start)::after {
     border-radius: 50% 0 0 50%;
   }
 
-  &.sbb-calendar-body-range-background:last-child::after {
+  .sbb-calendar-body-cell-container:last-child > &.sbb-calendar-body-range-background::after {
     border-radius: 0 50% 50% 0;
   }
 
   // If there is only one label in a row, or start is first or last entry
-  &:is(.sbb-calendar-body-range-background:first-child:last-child, .sbb-calendar-body-range-background-offset-start:last-child, .sbb-calendar-body-selected-end:first-child, .sbb-calendar-body-selected-begin:last-child) {
+  :is(.sbb-calendar-body-cell-container:first-child:last-child
+      > &.sbb-calendar-body-range-background, .sbb-calendar-body-cell-container:last-child
+      > &:is(.sbb-calendar-body-range-background-offset-start, .sbb-calendar-body-selected-begin), .sbb-calendar-body-cell-container:first-child
+      > &.sbb-calendar-body-selected-end, &.sbb-calendar-body-range-background-offset-start.sbb-calendar-body-selected-end) {
     &::before {
       display: none;
     }


### PR DESCRIPTION
Makes changes to the DOM structure of calendar cells for better screen reader experience. Previously, the DOM
structure looked like this:

```
<!-- Existing DOM structure of each calendar body cell -->
<td
 class="sbb-calendar-body-cell"
 role="gridcell"
 aria-disabled="false"
 aria-current="date"
 aria-selected="true"
 <!-- ... -->
>
 <!-- additional details ommited -->
</>
```

Using the `gridcell` role allows screenreaders to use table specific
navigation and some screenreaders would announce that the cells are
interactible because of the presence of `aria-selected`. However, some
screenreaders did not announce the cells as interactable and treated it
the same as a cell in a static table (e.g. VoiceOver announces element
type incorrectly angular/components#23476).

This changes the DOM structure to nest buttons
inside of a gridcell to make it more explicit that the table cells can
be interacted with and are not static content. The gridcell role is
still present, so table navigation will continue to work, but the
interaction is done with buttons nested inside the `td` elements.
The `td` element is only for adding information to the a11y tree and not used for visual purposes.

Updated DOM structure:

```
<td
  role="gridcell"
  class="sbb-calendar-body-cell-container"
>
  <button
   class="sbb-calendar-body-cell"
   aria-disabled="false"
   aria-current="date"
   aria-pressed="true"
   <!-- ... -->
  >
   <!-- additional details ommited -->
  </button>
</td>
```

Signed-off-by: Jeremias Peier <jeremias.peier@sbb.ch>