### PR TITLE
test: clean up IE/Edge test workarounds

### DIFF
--- a/src/angular/input/input.spec.ts
+++ b/src/angular/input/input.spec.ts
@@ -1,4 +1,4 @@
-import { Platform, PlatformModule } from '@angular/cdk/platform';
+import { getSupportedInputTypes } from '@angular/cdk/platform';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -37,23 +37,20 @@ import { SbbInputModule } from './input.module';
 describe('SbbInput without forms', () => {
   it('should not be treated as empty if type is date', fakeAsync(() => {
     const fixture = createComponent(SbbInputDateTestController);
-    const platform = TestBed.inject(Platform);
     fixture.detectChanges();
 
-    if (!(platform.TRIDENT || (platform.SAFARI && !platform.IOS))) {
+    if (getSupportedInputTypes().has('date')) {
       const el = fixture.debugElement.query(By.css('label'))!.nativeElement;
       expect(el).not.toBeNull();
       expect(el.classList.contains('sbb-form-field-empty')).toBe(false);
     }
   }));
 
-  // Safari Desktop and IE don't support type="date" and fallback to type="text".
-  it('should be treated as empty if type is date in Safari Desktop or IE', fakeAsync(() => {
+  it('should be treated as empty if type is date on unsupported browser', fakeAsync(() => {
     const fixture = createComponent(SbbInputDateTestController);
-    const platform = TestBed.inject(Platform);
     fixture.detectChanges();
 
-    if (platform.TRIDENT || (platform.SAFARI && !platform.IOS)) {
+    if (!getSupportedInputTypes().has('date')) {
       const el = fixture.debugElement.query(By.css('label'))!.nativeElement;
       expect(el).not.toBeNull();
       expect(el.classList.contains('sbb-form-field-empty')).toBe(true);
@@ -897,7 +894,6 @@ function createComponent<T>(
       SbbFormFieldModule,
       SbbInputModule,
       BrowserAnimationsModule,
-      PlatformModule,
       ReactiveFormsModule,
       ...imports,
     ],

--- a/src/angular/select/select/select.spec.ts
+++ b/src/angular/select/select/select.spec.ts
@@ -13,7 +13,6 @@ import {
   UP_ARROW,
 } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { Platform } from '@angular/cdk/platform';
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import {
   ChangeDetectionStrategy,
@@ -885,7 +884,7 @@ describe('SbbSelect', () => {
       ],
     }).compileComponents();
 
-    inject([OverlayContainer, Platform], (oc: OverlayContainer) => {
+    inject([OverlayContainer], (oc: OverlayContainer) => {
       overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();
     })();

--- a/src/angular/sidebar/icon-sidebar/icon-sidebar.spec.ts
+++ b/src/angular/sidebar/icon-sidebar/icon-sidebar.spec.ts
@@ -1,6 +1,5 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { MediaMatcher } from '@angular/cdk/layout';
-import { PlatformModule } from '@angular/cdk/platform';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { CommonModule } from '@angular/common';
 import { Component, DebugElement, ElementRef, ViewChild } from '@angular/core';
@@ -45,7 +44,6 @@ describe('SbbIconSidebar', () => {
         imports: [
           SbbSidebarModule,
           A11yModule,
-          PlatformModule,
           NoopAnimationsModule,
           CommonModule,
           SbbIconModule,
@@ -381,7 +379,6 @@ describe('SbbIconSidebarContainer', () => {
         imports: [
           SbbSidebarModule,
           A11yModule,
-          PlatformModule,
           NoopAnimationsModule,
           SbbIconModule,
           SbbIconTestingModule,

--- a/src/angular/sidebar/sidebar/sidebar.spec.ts
+++ b/src/angular/sidebar/sidebar/sidebar.spec.ts
@@ -2,7 +2,6 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { Direction } from '@angular/cdk/bidi';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { MediaMatcher } from '@angular/cdk/layout';
-import { PlatformModule } from '@angular/cdk/platform';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { CommonModule } from '@angular/common';
 import { Component, DebugElement, ElementRef, ViewChild } from '@angular/core';
@@ -60,7 +59,6 @@ describe('SbbSidebar', () => {
         imports: [
           SbbSidebarModule,
           A11yModule,
-          PlatformModule,
           NoopAnimationsModule,
           CommonModule,
           SbbIconTestingModule,
@@ -660,7 +658,6 @@ describe('SbbSidebarContainer', () => {
         imports: [
           SbbSidebarModule,
           A11yModule,
-          PlatformModule,
           NoopAnimationsModule,
           CommonModule,
           SbbIconTestingModule,
@@ -861,7 +858,6 @@ describe('SbbSidebar Usage', () => {
         imports: [
           SbbSidebarModule,
           A11yModule,
-          PlatformModule,
           NoopAnimationsModule,
           SbbAccordionModule,
           RouterTestingModule.withRoutes([

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,7 +2746,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@7.2.0", "@types/glob@^7.1.1", "@types/glob@^7.2.0":
+"@types/glob@^7.1.1", "@types/glob@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
   integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==


### PR DESCRIPTION
The workarounds shouldn't be necessary since we don't run tests against IE and legacy Edge anymore.