### PR TITLE
fix(angular): allow coercing of booleans for all inputs

### DIFF
--- a/src/angular/datepicker/datepicker/datepicker.ts
+++ b/src/angular/datepicker/datepicker/datepicker.ts
@@ -170,8 +170,8 @@ export class SbbDatepicker<D> implements OnDestroy {
   get opened(): boolean {
     return this._opened;
   }
-  set opened(value: boolean) {
-    value ? this.open() : this.close();
+  set opened(value: BooleanInput) {
+    coerceBooleanProperty(value) ? this.open() : this.close();
   }
   private _opened = false;
 

--- a/src/angular/radio-button/radio-button.ts
+++ b/src/angular/radio-button/radio-button.ts
@@ -391,7 +391,7 @@ export class _SbbRadioButtonBase
   get required(): boolean {
     return this._required || (this.radioGroup && this.radioGroup.required);
   }
-  set required(value: boolean) {
+  set required(value: BooleanInput) {
     this._required = coerceBooleanProperty(value);
   }
 

--- a/src/angular/tabs/paginated-tab-header.ts
+++ b/src/angular/tabs/paginated-tab-header.ts
@@ -1,5 +1,10 @@
 import { FocusableOption, FocusKeyManager } from '@angular/cdk/a11y';
-import { coerceNumberProperty, NumberInput } from '@angular/cdk/coercion';
+import {
+  BooleanInput,
+  coerceBooleanProperty,
+  coerceNumberProperty,
+  NumberInput,
+} from '@angular/cdk/coercion';
 import { ENTER, hasModifierKey, SPACE } from '@angular/cdk/keycodes';
 import { normalizePassiveListenerOptions, Platform } from '@angular/cdk/platform';
 import { ViewportRuler } from '@angular/cdk/scrolling';
@@ -128,7 +133,13 @@ export abstract class SbbPaginatedTabHeader
    * This applies only for lean design.
    */
   @Input()
-  disablePagination: boolean = false;
+  get disablePagination(): boolean {
+    return this._disablePagination;
+  }
+  set disablePagination(value: BooleanInput) {
+    this._disablePagination = coerceBooleanProperty(value);
+  }
+  private _disablePagination: boolean = false;
 
   /** The index of the active tab. */
   get selectedIndex(): number {

--- a/src/angular/tabs/tab-group.ts
+++ b/src/angular/tabs/tab-group.ts
@@ -84,7 +84,7 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
   set dynamicHeight(value: BooleanInput) {
     this._dynamicHeight = coerceBooleanProperty(value);
   }
-  private _dynamicHeight: boolean;
+  private _dynamicHeight: boolean = false;
 
   /** The index of the active tab. */
   @Input()
@@ -102,7 +102,13 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
    * This applies only for lean design.
    */
   @Input()
-  disablePagination: boolean;
+  get disablePagination(): boolean {
+    return this._disablePagination;
+  }
+  set disablePagination(value: BooleanInput) {
+    this._disablePagination = coerceBooleanProperty(value);
+  }
+  private _disablePagination: boolean = false;
 
   /**
    * By default tabs remove their content from the DOM while it's off-screen.
@@ -110,7 +116,13 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
    * like iframes and videos from reloading next time it comes back into the view.
    */
   @Input()
-  preserveContent: boolean;
+  get preserveContent(): boolean {
+    return this._preserveContent;
+  }
+  set preserveContent(value: BooleanInput) {
+    this._preserveContent = coerceBooleanProperty(value);
+  }
+  private _preserveContent: boolean = false;
 
   /** Output to enable support for two-way binding on `[(selectedIndex)]` */
   @Output() readonly selectedIndexChange: EventEmitter<number> = new EventEmitter<number>();

--- a/src/angular/tabs/tabs.md
+++ b/src/angular/tabs/tabs.md
@@ -121,7 +121,7 @@ will be re-initialized whenever the user navigates to the tab. If you want to ke
 off-screen tabs in the DOM, you can set the `preserveContent` input to `true`.
 
 ```html
-<sbb-tab-group [preserveContent]="true">
+<sbb-tab-group preserveContent>
   <sbb-tab label="First">
     <iframe
       width="560"

--- a/src/angular/textarea/textarea/textarea.ts
+++ b/src/angular/textarea/textarea/textarea.ts
@@ -163,7 +163,7 @@ export class SbbTextarea
   get required(): boolean {
     return this._required;
   }
-  set required(value: boolean) {
+  set required(value: BooleanInput) {
     this._required = coerceBooleanProperty(value);
     this.stateChanges.next();
   }
@@ -174,7 +174,7 @@ export class SbbTextarea
   get autosizeDisabled(): boolean {
     return this._autosizeDisabled;
   }
-  set autosizeDisabled(value: boolean) {
+  set autosizeDisabled(value: BooleanInput) {
     this._autosizeDisabled = coerceBooleanProperty(value);
   }
   private _autosizeDisabled = false;

--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -6,7 +6,12 @@ import {
   FocusOrigin,
   FocusTrap,
 } from '@angular/cdk/a11y';
-import { coerceBooleanProperty, coerceNumberProperty, NumberInput } from '@angular/cdk/coercion';
+import {
+  BooleanInput,
+  coerceBooleanProperty,
+  coerceNumberProperty,
+  NumberInput,
+} from '@angular/cdk/coercion';
 import { ESCAPE, hasModifierKey } from '@angular/cdk/keycodes';
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { ConnectionPositionPair, Overlay, OverlayRef, ScrollStrategy } from '@angular/cdk/overlay';
@@ -167,7 +172,7 @@ export abstract class _SbbTooltipBase<T extends _TooltipComponentBase>
   get disabled(): boolean {
     return this._disabled;
   }
-  set disabled(value) {
+  set disabled(value: BooleanInput) {
     this._disabled = coerceBooleanProperty(value);
 
     // If tooltip is disabled, hide immediately.

--- a/src/components-examples/angular/tabs/tab-group-preserve-content/tab-group-preserve-content-example.html
+++ b/src/components-examples/angular/tabs/tab-group-preserve-content/tab-group-preserve-content-example.html
@@ -1,6 +1,6 @@
 <p>Start the video in the first tab and navigate to the second one to see how it keeps playing.</p>
 
-<sbb-tab-group [preserveContent]="true">
+<sbb-tab-group preserveContent>
   <sbb-tab label="First">
     <iframe
       width="560"


### PR DESCRIPTION
Previously, some properties were declared as BooleanInput and some not. With this commit, all boolean inputs are threat as BooleanInput and therefore the input values are being coerced.