### PR TITLE
fix(angular/datepicker): update active date on focusing a calendar cell

### DIFF
--- a/src/angular/datepicker/calendar-body/calendar-body.html
+++ b/src/angular/datepicker/calendar-body/calendar-body.html
@@ -21,6 +21,8 @@
     role="gridcell"
     class="sbb-calendar-body-cell-container"
     [style.width.%]="100 / numCols"
+    [attr.data-sbb-row]="rowIndex"
+    [attr.data-sbb-col]="colIndex"
   >
     <button
       type="button"
@@ -39,6 +41,7 @@
       [attr.aria-pressed]="selectedValue === item.value"
       [attr.aria-current]="todayValue === item.value ? 'date' : null"
       (click)="cellClicked(item)"
+      (focus)="_emitActiveDateChange(item, $event)"
     >
       <div class="sbb-calendar-body-cell-content">{{ item.displayValue }}</div>
     </button>

--- a/src/angular/datepicker/calendar-body/calendar-body.ts
+++ b/src/angular/datepicker/calendar-body/calendar-body.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewChecked,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
@@ -37,7 +38,12 @@ export class SbbCalendarCell {
     role: 'grid',
   },
 })
-export class SbbCalendarBody {
+export class SbbCalendarBody implements AfterViewChecked {
+  /**
+   * Used to focus the active cell after change detection has run.
+   */
+  private _focusActiveCellAfterViewChecked = false;
+
   /** The label for the table. (e.g. "Jan 2017"). */
   @Input() label: string;
 
@@ -65,13 +71,28 @@ export class SbbCalendarBody {
   /** Emits when a new value is selected. */
   @Output() readonly selectedValueChange: EventEmitter<number> = new EventEmitter<number>();
 
+  @Output() readonly activeDateChange = new EventEmitter<number>();
+
   constructor(private _elementRef: ElementRef<HTMLElement>, private _ngZone: NgZone) {}
+
+  ngAfterViewChecked() {
+    if (this._focusActiveCellAfterViewChecked) {
+      this.focusActiveCell();
+      this._focusActiveCellAfterViewChecked = false;
+    }
+  }
 
   cellClicked(cell: SbbCalendarCell): void {
     if (!this.allowDisabledSelection && !cell.enabled) {
       return;
     }
     this.selectedValueChange.emit(cell.value);
+  }
+
+  _emitActiveDateChange(cell: SbbCalendarCell, event: FocusEvent): void {
+    if (cell.enabled) {
+      this.activeDateChange.emit(cell.value);
+    }
   }
 
   /** The number of blank cells to put at the beginning for the first row. */
@@ -108,5 +129,10 @@ export class SbbCalendarBody {
           }
         });
     });
+  }
+
+  /** Focuses the active cell after change detection has run and the microtask queue is empty. */
+  _scheduleFocusActiveCellAfterViewChecked() {
+    this._focusActiveCellAfterViewChecked = true;
   }
 }

--- a/src/angular/datepicker/month-view/month-view.html
+++ b/src/angular/datepicker/month-view/month-view.html
@@ -16,6 +16,7 @@
     [labelMinRequiredCells]="3"
     [activeCell]="_dateAdapter.getDate(activeDate) - 1"
     (selectedValueChange)="dateSelected($event)"
+    (activeDateChange)="_updateActiveDate($event)"
     (keydown)="handleCalendarBodyKeydown($event)"
   ></tbody>
 </table>

--- a/src/angular/datepicker/month-view/month-view.spec.ts
+++ b/src/angular/datepicker/month-view/month-view.spec.ts
@@ -252,6 +252,30 @@ describe('SbbMonthView', () => {
 
           expect(testComponent.selected).toEqual(new Date(2017, JAN, 4));
         });
+
+        it('should go to month that is focused', () => {
+          const jan11Cell = fixture.debugElement.nativeElement.querySelector(
+            '[data-sbb-row="2"][data-sbb-col="2"] button'
+          ) as HTMLElement;
+
+          dispatchFakeEvent(jan11Cell, 'focus');
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 11));
+        });
+
+        it('should not call `.focus()` when the active date is focused', () => {
+          const jan5Cell = fixture.debugElement.nativeElement.querySelector(
+            '[data-sbb-row="1"][data-sbb-col="3"] button'
+          ) as HTMLElement;
+          const focusSpy = (jan5Cell.focus = jasmine.createSpy('cellFocused'));
+
+          dispatchFakeEvent(jan5Cell, 'focus');
+          fixture.detectChanges();
+
+          expect(calendarInstance.date).toEqual(new Date(2017, JAN, 5));
+          expect(focusSpy).not.toHaveBeenCalled();
+        });
       });
     });
   });


### PR DESCRIPTION
When a date cell on the calendar recieves focus, set the active date to that cell. This ensures that the active date matches the date with browser focus.

Previously, we set the active date on keydown and click, but that was problematic for screenreaders. That's because many screenreaders trigger a focus event instead of a keydown event when using screenreader specific navigation (VoiceOver, Chromevox, NVDA).