### PR TITLE
fix(angular/datepicker): fix improper focus trapping with VoiceOver and ChromeVox

### DIFF
--- a/src/angular/datepicker/BUILD.bazel
+++ b/src/angular/datepicker/BUILD.bazel
@@ -21,6 +21,7 @@ ng_module(
     ] + glob(["**/*.html"]),
     deps = [
         "//src/angular/core",
+        "//src/angular/form-field",
         "//src/angular/icon",
         "//src/angular/input",
         "@npm//@angular/cdk",
@@ -58,6 +59,7 @@ ng_test_library(
         ":datepicker",
         "//src/angular/core",
         "//src/angular/core/testing",
+        "//src/angular/form-field",
         "//src/angular/icon",
         "//src/angular/icon/testing",
         "//src/angular/input",

--- a/src/angular/datepicker/date-input/date-input.directive.ts
+++ b/src/angular/datepicker/date-input/date-input.directive.ts
@@ -24,6 +24,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { SbbDateAdapter, SbbDateFormats, SBB_DATE_FORMATS, TypeRef } from '@sbb-esta/angular/core';
+import { SbbFormField, SBB_FORM_FIELD } from '@sbb-esta/angular/form-field';
 import { SBB_INPUT_VALUE_ACCESSOR } from '@sbb-esta/angular/input';
 import { Subscription } from 'rxjs';
 
@@ -253,7 +254,8 @@ export class SbbDateInput<D> implements ControlValueAccessor, Validator, OnInit,
     private _elementRef: ElementRef<HTMLInputElement>,
     @Optional() public _dateAdapter: SbbDateAdapter<D>,
     @Optional() @Inject(SBB_DATE_FORMATS) private _dateFormats: SbbDateFormats,
-    @Optional() public _datepicker: SbbDatepicker<D>
+    @Optional() public _datepicker: SbbDatepicker<D>,
+    @Optional() @Inject(SBB_FORM_FIELD) private _formField?: SbbFormField
   ) {
     if (!this._dateAdapter) {
       throw createMissingDateImplError('DateAdapter');
@@ -378,5 +380,14 @@ export class SbbDateInput<D> implements ControlValueAccessor, Validator, OnInit,
    */
   private _getValidDateOrNull(obj: any): D | null {
     return this._dateAdapter.isDateInstance(obj) && this._dateAdapter.isValid(obj) ? obj : null;
+  }
+
+  /** Gets the ID of an element that should be used a description for the calendar overlay. */
+  getOverlayLabelId(): string | null {
+    if (this._formField) {
+      return this._formField.getLabelId();
+    }
+
+    return this._elementRef.nativeElement.getAttribute('aria-labelledby');
   }
 }

--- a/src/angular/datepicker/datepicker-content/datepicker-content.html
+++ b/src/angular/datepicker/datepicker-content/datepicker-content.html
@@ -1,5 +1,9 @@
 <sbb-calendar
   cdkTrapFocus
+  role="dialog"
+  [attr.aria-modal]="true"
+  [attr.aria-labelledby]="_dialogLabelId ?? undefined"
+  class="sbb-datepicker-content-container"
   [id]="datepicker.id"
   [ngClass]="datepicker.panelClass"
   [startAt]="datepicker.startAt"

--- a/src/angular/datepicker/datepicker-content/datepicker-content.ts
+++ b/src/angular/datepicker/datepicker-content/datepicker-content.ts
@@ -37,6 +37,9 @@ export class SbbDatepickerContent<D> implements AfterViewInit {
   /** Whether the datepicker is above or below the input. */
   isAbove: boolean;
 
+  /** Id of the label for the `role="dialog"` element. */
+  _dialogLabelId: string | null;
+
   ngAfterViewInit() {
     this.calendar.focusActiveCell();
   }

--- a/src/angular/datepicker/datepicker/datepicker.spec.ts
+++ b/src/angular/datepicker/datepicker/datepicker.spec.ts
@@ -12,6 +12,7 @@ import {
   dispatchMouseEvent,
   JAN,
 } from '@sbb-esta/angular/core/testing';
+import { SbbFormField } from '@sbb-esta/angular/form-field';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
 import { SbbIconTestingModule } from '@sbb-esta/angular/icon/testing';
 import { SbbInputModule } from '@sbb-esta/angular/input';
@@ -20,184 +21,6 @@ import { SbbDateInput } from '../date-input/date-input.directive';
 import { SbbDatepickerModule } from '../datepicker.module';
 
 import { SbbDatepicker } from './datepicker';
-
-@Component({
-  template: `
-    <sbb-datepicker #d [disabled]="disabled" [opened]="opened">
-      <input sbbDateInput [value]="date" />
-    </sbb-datepicker>
-  `,
-})
-class StandardDatepickerComponent {
-  opened = false;
-  touch = false;
-  disabled = false;
-  date: Date | null = new Date(2020, JAN, 1);
-  @ViewChild('d', { static: true }) datepicker: SbbDatepicker<Date>;
-  @ViewChild(SbbDateInput, { static: true }) datepickerInput: SbbDateInput<Date>;
-}
-
-@Component({
-  template: `
-    <sbb-datepicker>
-      <input sbbDateInput />
-      <input sbbDateInput />
-    </sbb-datepicker>
-  `,
-})
-class MultiInputDatepickerComponent {}
-
-@Component({
-  template: ` <sbb-datepicker #d></sbb-datepicker> `,
-})
-class NoInputDatepickerComponent {
-  @ViewChild('d', { static: true }) datepicker: SbbDatepicker<Date>;
-}
-
-@Component({
-  template: `
-    <sbb-datepicker #d [startAt]="startDate">
-      <input sbbDateInput [value]="date" />
-    </sbb-datepicker>
-  `,
-})
-class DatepickerWithStartAtComponent {
-  date = new Date(2020, JAN, 1);
-  startDate = new Date(2010, JAN, 1);
-  @ViewChild('d', { static: true }) datepicker: SbbDatepicker<Date>;
-}
-
-@Component({
-  template: `
-    <sbb-datepicker #d>
-      <input [(ngModel)]="selected" sbbDateInput />
-    </sbb-datepicker>
-  `,
-})
-class DatepickerWithNgModelComponent {
-  selected: Date | null = null;
-  @ViewChild('d', { static: true }) datepicker: SbbDatepicker<Date>;
-  @ViewChild(SbbDateInput, { static: true }) datepickerInput: SbbDateInput<Date>;
-}
-
-@Component({
-  template: `
-    <sbb-datepicker #d>
-      <input [formControl]="formControl" sbbDateInput />
-    </sbb-datepicker>
-  `,
-})
-class DatepickerWithFormControlComponent {
-  formControl = new FormControl();
-  @ViewChild('d', { static: true }) datepicker: SbbDatepicker<Date>;
-  @ViewChild(SbbDateInput, { static: true }) datepickerInput: SbbDateInput<Date>;
-}
-
-@Component({
-  template: `
-    <sbb-datepicker #d>
-      <input sbbDateInput />
-    </sbb-datepicker>
-  `,
-})
-class DatepickerWithToggleComponent {
-  @ViewChild('d', { static: true }) datepicker: SbbDatepicker<Date>;
-  @ViewChild(SbbDateInput, { static: true }) input: SbbDateInput<Date>;
-}
-
-@Component({
-  template: `
-    <sbb-datepicker #d>
-      <input sbbDateInput [(ngModel)]="date" [min]="minDate" [max]="maxDate" />
-    </sbb-datepicker>
-  `,
-})
-class DatepickerWithMinAndMaxValidationComponent {
-  @ViewChild('d', { static: true }) datepicker: SbbDatepicker<Date>;
-  date: Date | null;
-  minDate = new Date(2010, JAN, 1);
-  maxDate = new Date(2020, JAN, 1);
-}
-
-@Component({
-  template: `
-    <sbb-datepicker (opened)="openedSpy()" (closed)="closedSpy()" #d>
-      <input [(ngModel)]="selected" sbbDateInput />
-    </sbb-datepicker>
-  `,
-})
-class DatepickerWithEventsComponent {
-  selected: Date | null = null;
-  openedSpy = jasmine.createSpy('opened spy');
-  closedSpy = jasmine.createSpy('closed spy');
-  @ViewChild('d', { static: true }) datepicker: SbbDatepicker<Date>;
-}
-
-@Component({
-  template: `
-    <sbb-datepicker #d>
-      <input (focus)="d.open()" sbbDateInput />
-    </sbb-datepicker>
-  `,
-})
-class DatepickerOpeningOnFocusComponent {
-  @ViewChild(SbbDatepicker, { static: true }) datepicker: SbbDatepicker<Date>;
-}
-
-@Component({
-  template: `<sbb-datepicker [connected]="second">
-      <input sbbDateInput sbbInput [formControl]="firstDatepicker" />
-    </sbb-datepicker>
-    <sbb-datepicker #second>
-      <input sbbDateInput sbbInput [formControl]="secondDatepicker" />
-    </sbb-datepicker>`,
-})
-class DatepickerConnectedComponent {
-  firstDatepicker = new FormControl();
-  secondDatepicker = new FormControl();
-}
-
-@Component({
-  template: `
-    <sbb-datepicker arrows #d class="default-arrow-labels" style="width: 300px">
-      <input sbbDateInput [value]="date" />
-    </sbb-datepicker>
-
-    <sbb-datepicker
-      arrows
-      #d
-      prevDayAriaLabel="Select previous day"
-      nextDayAriaLabel="Select next day"
-      class="custom-arrow-labels"
-    >
-      <input sbbDateInput [value]="date" />
-    </sbb-datepicker>
-  `,
-})
-class DatepickerWithArrows {
-  date: Date | null = new Date();
-  @ViewChild('d', { static: true }) datepicker: SbbDatepicker<Date>;
-  @ViewChild(SbbDateInput, { static: true }) datepickerInput: SbbDateInput<Date>;
-}
-
-@Component({
-  template: `
-    <sbb-datepicker arrows>
-      <input
-        sbbDateInput
-        sbbInput
-        [formControl]="date"
-        [readonly]="readonly"
-        [placeholder]="placeholder"
-      />
-    </sbb-datepicker>
-  `,
-})
-class DatepickerReadonlyComponent {
-  date = new FormControl();
-  readonly: boolean = false;
-  placeholder?: string = undefined;
-}
 
 describe('SbbDatepicker', () => {
   // Creates a test component fixture.
@@ -331,9 +154,26 @@ describe('SbbDatepicker', () => {
         flush();
 
         // tslint:disable-next-line:no-non-null-assertion
-        const popup = document.querySelector('.cdk-overlay-pane')!;
+        const popup = document.querySelector('.sbb-datepicker-content-container')!;
         expect(popup).toBeTruthy();
         expect(popup.getAttribute('role')).toBe('dialog');
+      }));
+
+      it('should set aria-labelledby to the one from the input, if not placed inside a sbb-form-field', fakeAsync(() => {
+        expect(fixture.nativeElement.querySelector('.sbb-form-field')).toBeFalsy();
+
+        const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+        input.setAttribute('aria-labelledby', 'test-label');
+
+        testComponent.datepicker.open();
+        fixture.detectChanges();
+        flush();
+
+        const popup = document.querySelector(
+          '.cdk-overlay-pane .sbb-datepicker-content-container'
+        )!;
+        expect(popup).toBeTruthy();
+        expect(popup.getAttribute('aria-labelledby')).toBe('test-label');
       }));
 
       it(
@@ -730,6 +570,42 @@ describe('SbbDatepicker', () => {
       }));
     });
 
+    describe('datepicker inside sbb-form-field', () => {
+      let fixture: ComponentFixture<FormFieldDatepicker>;
+      let testComponent: FormFieldDatepicker;
+
+      beforeEach(fakeAsync(() => {
+        fixture = createComponent(FormFieldDatepicker, []);
+        fixture.detectChanges();
+        testComponent = fixture.componentInstance;
+      }));
+
+      afterEach(fakeAsync(() => {
+        testComponent.datepicker.close();
+        fixture.detectChanges();
+        flush();
+      }));
+
+      it('should set aria-labelledby of the overlay to the form field label', fakeAsync(() => {
+        const label: HTMLElement = fixture.nativeElement.querySelector('.sbb-form-field-label');
+
+        expect(label).toBeTruthy();
+        expect(label.getAttribute('id')).toBeTruthy();
+
+        // When clicking toggle
+        fixture.debugElement.query(By.css('.sbb-datepicker-toggle-button')).nativeElement.click();
+        fixture.detectChanges();
+
+        flush();
+
+        const popup = document.querySelector(
+          '.cdk-overlay-pane .sbb-datepicker-content-container'
+        )!;
+        expect(popup).toBeTruthy();
+        expect(popup.getAttribute('aria-labelledby')).toBe(label.getAttribute('id'));
+      }));
+    });
+
     describe('datepicker with min and max dates and validation', () => {
       let fixture: ComponentFixture<DatepickerWithMinAndMaxValidationComponent>;
       let testComponent: DatepickerWithMinAndMaxValidationComponent;
@@ -1000,3 +876,197 @@ describe('SbbDatepicker', () => {
     });
   });
 });
+
+@Component({
+  template: `
+    <sbb-datepicker #d [disabled]="disabled" [opened]="opened">
+      <input sbbDateInput [value]="date" />
+    </sbb-datepicker>
+  `,
+})
+class StandardDatepickerComponent {
+  opened = false;
+  touch = false;
+  disabled = false;
+  date: Date | null = new Date(2020, JAN, 1);
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+  @ViewChild(SbbDateInput) datepickerInput: SbbDateInput<Date>;
+}
+
+@Component({
+  template: `
+    <sbb-datepicker>
+      <input sbbDateInput />
+      <input sbbDateInput />
+    </sbb-datepicker>
+  `,
+})
+class MultiInputDatepickerComponent {}
+
+@Component({
+  template: ` <sbb-datepicker #d></sbb-datepicker> `,
+})
+class NoInputDatepickerComponent {
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+}
+
+@Component({
+  template: `
+    <sbb-datepicker #d [startAt]="startDate">
+      <input sbbDateInput [value]="date" />
+    </sbb-datepicker>
+  `,
+})
+class DatepickerWithStartAtComponent {
+  date = new Date(2020, JAN, 1);
+  startDate = new Date(2010, JAN, 1);
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+}
+
+@Component({
+  template: `
+    <sbb-datepicker #d>
+      <input [(ngModel)]="selected" sbbDateInput />
+    </sbb-datepicker>
+  `,
+})
+class DatepickerWithNgModelComponent {
+  selected: Date | null = null;
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+  @ViewChild(SbbDateInput) datepickerInput: SbbDateInput<Date>;
+}
+
+@Component({
+  template: `
+    <sbb-datepicker #d>
+      <input [formControl]="formControl" sbbDateInput />
+    </sbb-datepicker>
+  `,
+})
+class DatepickerWithFormControlComponent {
+  formControl = new FormControl();
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+  @ViewChild(SbbDateInput) datepickerInput: SbbDateInput<Date>;
+}
+
+@Component({
+  template: `
+    <sbb-datepicker #d>
+      <input sbbDateInput />
+    </sbb-datepicker>
+  `,
+})
+class DatepickerWithToggleComponent {
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+  @ViewChild(SbbDateInput) input: SbbDateInput<Date>;
+}
+
+@Component({
+  template: `
+    <sbb-form-field>
+      <sbb-label>Pick a date</sbb-label>
+      <sbb-datepicker #d>
+        <input sbbInput sbbDateInput />
+      </sbb-datepicker>
+    </sbb-form-field>
+  `,
+})
+class FormFieldDatepicker {
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+  @ViewChild(SbbDateInput) datepickerInput: SbbDateInput<Date>;
+  @ViewChild(SbbFormField) formField: SbbFormField;
+}
+
+@Component({
+  template: `
+    <sbb-datepicker #d>
+      <input sbbDateInput [(ngModel)]="date" [min]="minDate" [max]="maxDate" />
+    </sbb-datepicker>
+  `,
+})
+class DatepickerWithMinAndMaxValidationComponent {
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+  date: Date | null;
+  minDate = new Date(2010, JAN, 1);
+  maxDate = new Date(2020, JAN, 1);
+}
+
+@Component({
+  template: `
+    <sbb-datepicker (opened)="openedSpy()" (closed)="closedSpy()" #d>
+      <input [(ngModel)]="selected" sbbDateInput />
+    </sbb-datepicker>
+  `,
+})
+class DatepickerWithEventsComponent {
+  selected: Date | null = null;
+  openedSpy = jasmine.createSpy('opened spy');
+  closedSpy = jasmine.createSpy('closed spy');
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+}
+
+@Component({
+  template: `
+    <sbb-datepicker #d>
+      <input (focus)="d.open()" sbbDateInput />
+    </sbb-datepicker>
+  `,
+})
+class DatepickerOpeningOnFocusComponent {
+  @ViewChild(SbbDatepicker) datepicker: SbbDatepicker<Date>;
+}
+
+@Component({
+  template: `<sbb-datepicker [connected]="second">
+      <input sbbDateInput sbbInput [formControl]="firstDatepicker" />
+    </sbb-datepicker>
+    <sbb-datepicker #second>
+      <input sbbDateInput sbbInput [formControl]="secondDatepicker" />
+    </sbb-datepicker>`,
+})
+class DatepickerConnectedComponent {
+  firstDatepicker = new FormControl();
+  secondDatepicker = new FormControl();
+}
+
+@Component({
+  template: `
+    <sbb-datepicker arrows #d class="default-arrow-labels" style="width: 300px">
+      <input sbbDateInput [value]="date" />
+    </sbb-datepicker>
+
+    <sbb-datepicker
+      arrows
+      #d
+      prevDayAriaLabel="Select previous day"
+      nextDayAriaLabel="Select next day"
+      class="custom-arrow-labels"
+    >
+      <input sbbDateInput [value]="date" />
+    </sbb-datepicker>
+  `,
+})
+class DatepickerWithArrows {
+  date: Date | null = new Date();
+  @ViewChild('d') datepicker: SbbDatepicker<Date>;
+  @ViewChild(SbbDateInput) datepickerInput: SbbDateInput<Date>;
+}
+
+@Component({
+  template: `
+    <sbb-datepicker arrows>
+      <input
+        sbbDateInput
+        sbbInput
+        [formControl]="date"
+        [readonly]="readonly"
+        [placeholder]="placeholder"
+      />
+    </sbb-datepicker>
+  `,
+})
+class DatepickerReadonlyComponent {
+  date = new FormControl();
+  readonly: boolean = false;
+  placeholder?: string = undefined;
+}

--- a/src/angular/datepicker/datepicker/datepicker.ts
+++ b/src/angular/datepicker/datepicker/datepicker.ts
@@ -449,6 +449,7 @@ export class SbbDatepicker<D> implements OnDestroy {
     if (!this.popupRef.hasAttached()) {
       this._popupComponentRef = this.popupRef.attach(this._calendarPortal);
       this._popupComponentRef.instance.datepicker = this;
+      this._popupComponentRef.instance._dialogLabelId = this.datepickerInput.getOverlayLabelId();
 
       // Update the position once the calendar has rendered.
       this._ngZone.onStable
@@ -471,7 +472,6 @@ export class SbbDatepicker<D> implements OnDestroy {
     });
 
     this.popupRef = this._overlay.create(overlayConfig);
-    this.popupRef.overlayElement.setAttribute('role', 'dialog');
 
     merge(
       this.popupRef.backdropClick(),


### PR DESCRIPTION
Fixes focus trapping on the datepicker dialog by putting `role="dialog"` `aria-modal="true"` and `cdkTrapFocus` all on the same element. This aligns the datepicker with how SbbDialog does focus trapping.

Without having them all on the same element, users could exit out of the focus trapping using screenreader specific navigation with VoiceOver and ChromeVox.