### PR TITLE
fix(angular/radio-button): clicks not propagating to wrapper elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,6 +239,11 @@
         0,
         "always",
         0
+      ],
+      "footer-max-line-length": [
+        0,
+        "always",
+        0
       ]
     }
   },

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -1750,6 +1750,10 @@ textarea {
   width: 100%;
   height: 100%;
   cursor: inherit;
+
+  // Puts the input behind the circle while keeping it visible so that
+  // it allows `click` events to propagate up to the `label` wrapper.
+  z-index: -1;
 }
 
 // ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a regression caused by #1172 where clicking directly on the `input` element will prevent the click from reaching custom `click` listeners outside the radio button.