### PR TITLE
fix(angular/autocomplete): use narrow value for aria-haspopup

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -107,7 +107,7 @@ export function getSbbAutocompleteMissingPanelError(): Error {
     '[attr.aria-activedescendant]': '(panelOpen && activeOption) ? activeOption.id : null',
     '[attr.aria-expanded]': 'autocompleteDisabled ? null : panelOpen.toString()',
     '[attr.aria-owns]': '(autocompleteDisabled || !panelOpen) ? null : autocomplete?.id',
-    '[attr.aria-haspopup]': '!autocompleteDisabled',
+    '[attr.aria-haspopup]': 'autocompleteDisabled ? null : "listbox"',
     '[class.sbb-focused]': 'panelOpen',
   },
 })

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -979,12 +979,12 @@ describe('SbbAutocomplete', () => {
     });
 
     it('should set aria-haspopup depending on whether the autocomplete is disabled', () => {
-      expect(input.getAttribute('aria-haspopup')).toBe('true');
+      expect(input.getAttribute('aria-haspopup')).toBe('listbox');
 
       fixture.componentInstance.autocompleteDisabled = true;
       fixture.detectChanges();
 
-      expect(input.getAttribute('aria-haspopup')).toBe('false');
+      expect(input.hasAttribute('aria-haspopup')).toBe(false);
     });
   });
 


### PR DESCRIPTION
[Based on the spec](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup),
`aria-haspopup` can be set to indicate what kind of popup the element has.
These changes update the autocomplete one to show that it opens a listbox.