### PR TITLE
fix(angular/autocomplete): closing immediately when input is focused programmatically

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -422,6 +422,11 @@ export class SbbAutocompleteTrigger
         return (
           this._overlayAttached &&
           clickTarget !== this._element.nativeElement &&
+          // Normally focus moves inside `mousedown` so this condition will almost always be
+          // true. Its main purpose is to handle the case where the input is focused from an
+          // outside click which propagates up to the `body` listener within the same sequence
+          // and causes the panel to close immediately (see angular/components#3106).
+          this._document.activeElement !== this._element.nativeElement &&
           (!formField || !formField.contains(clickTarget)) &&
           (!customOrigin || !customOrigin.contains(clickTarget)) &&
           !!this._overlayRef &&

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -33,6 +33,7 @@ import {
   dispatchEvent,
   dispatchFakeEvent,
   dispatchKeyboardEvent,
+  dispatchMouseEvent,
   MockNgZone,
   typeInElement,
 } from '@sbb-esta/angular/core/testing';
@@ -1772,6 +1773,23 @@ describe('SbbAutocomplete', () => {
       expect(overlayContainerElement.querySelector('.sbb-autocomplete-panel')).toBeFalsy(
         'Expected panel to be removed.'
       );
+    }));
+
+    it('should not close when a click event occurs on the outside while the panel has focus', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+
+      input.focus();
+      flush();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(input, 'Expected input to be focused.');
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to be open.');
+
+      dispatchMouseEvent(document.body, 'click');
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(input, 'Expected input to continue to be focused.');
+      expect(trigger.panelOpen).toBe(true, 'Expected panel to stay open.');
     }));
 
     it('should reset the active option when closing with the escape key', fakeAsync(() => {


### PR DESCRIPTION
Each autocomplete has a `click` listener on the body that closes the panel when the
user has clicked somewhere outside of it. This breaks down if the panel is opened
through a click outside of the form field, because we bind the listener before the
event has bubbled all the way to the `body` so when it does get there, it closes
immediately.

These changes fix the issue by taking advantage of the fact that focus usually moves
on `mousedown` so for "real" click the input will have already lost focus by the time
the `click` event happens.