### PR TITLE
fix(angular/sidebar): prevent focus from entering hidden sidenav if child element has a visibility

### DIFF
--- a/src/angular/sidebar/sidebar/sidebar.scss
+++ b/src/angular/sidebar/sidebar/sidebar.scss
@@ -75,6 +75,17 @@
   transform: translate3d(-100%, 0, 0);
   border-right: var(--sbb-border-width-thin) solid var(--sbb-color-cloud);
   background-color: var(--sbb-color-background);
+
+  // Usually the `visibility: hidden` added by the animation is enough to prevent focus from
+  // entering the hidden sidebar content, but children with their own `visibility` can override it.
+  // This is a fallback that completely hides the content when the element becomes hidden.
+  // Note that we can't do this in the animation definition, because the style gets recomputed too
+  // late, breaking the animation because Angular didn't have time to figure out the target
+  // transform. This can also be achieved with JS, but it has issues when starting an
+  // animation before the previous one has finished.
+  &[style*='visibility: hidden'] {
+    display: none;
+  }
 }
 
 .sbb-sidebar-side {

--- a/src/angular/tabs/tab-body.scss
+++ b/src/angular/tabs/tab-body.scss
@@ -11,7 +11,7 @@
   // This is a fallback that completely hides the content when the element becomes hidden.
   // Note that we can't do this in the animation definition, because the style gets recomputed too
   // late, breaking the animation because Angular didn't have time to figure out the target height.
-  // This can also be achieved with JS, but it has issues when when starting an animation before
+  // This can also be achieved with JS, but it has issues when starting an animation before
   // the previous one has finished.
   &[style*='visibility: hidden'] {
     display: none;


### PR DESCRIPTION
This is a similar fix that we've made for other components. Usually we set `visibility: hidden` on the sidebar which is enough to prevent the user from tabbing into it, however one of the children could override it with `visibility: visible`. These changes add an extra `display: none` on top which will prevent such issues. This has come up on AIO recently angular/angular#44990.