### PR TITLE
fix(angular/autocomplete): don't block default arrow keys when using modifiers

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -455,16 +455,17 @@ export class SbbAutocompleteTrigger
   @HostListener('keydown', ['$event'])
   _handleKeydown(event: TypeRef<KeyboardEvent>): void {
     const keyCode = event.keyCode;
+    const hasModifier = hasModifierKey(event);
 
     // Prevent the default action on all escape key presses. This is here primarily to bring IE
     // in line with other browsers. By default, pressing escape on IE will cause it to revert
     // the input value to the one that it had on focus, however it won't dispatch any events
     // which means that the model value will be out of sync with the view.
-    if (keyCode === ESCAPE && !hasModifierKey(event)) {
+    if (keyCode === ESCAPE && !hasModifier) {
       event.preventDefault();
     }
 
-    if (this.activeOption && keyCode === ENTER && this.panelOpen && !hasModifierKey(event)) {
+    if (this.activeOption && keyCode === ENTER && this.panelOpen && !hasModifier) {
       this.activeOption._selectViaInteraction();
       this._resetActiveItem();
       event.preventDefault();
@@ -472,7 +473,7 @@ export class SbbAutocompleteTrigger
       const prevActiveItem = this.autocomplete._keyManager.activeItem;
       const isArrowKey = keyCode === UP_ARROW || keyCode === DOWN_ARROW;
 
-      if (this.panelOpen || keyCode === TAB) {
+      if (keyCode === TAB || (isArrowKey && !hasModifier && this.panelOpen)) {
         this.autocomplete._keyManager.onKeydown(event);
       } else if (isArrowKey && this._canOpen()) {
         this.openPanel();

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -1801,6 +1801,20 @@ describe('SbbAutocomplete', () => {
       expect(!!trigger.activeOption).withContext('Expected no active options.').toBe(false);
     }));
 
+    it('should not prevent the default action when a modifier key is pressed', () => {
+      ['metaKey', 'ctrlKey', 'altKey', 'shiftKey'].forEach((name) => {
+        const event = createKeyboardEvent('keydown', DOWN_ARROW);
+        Object.defineProperty(event, name, { get: () => true });
+
+        fixture.componentInstance.trigger._handleKeydown(event);
+        fixture.detectChanges();
+
+        expect(event.defaultPrevented)
+          .withContext(`Expected autocomplete not to block ${name} key`)
+          .toBe(false);
+      });
+    });
+
     it('should reset the active option when closing by selecting with enter', fakeAsync(() => {
       const trigger = fixture.componentInstance.trigger;
 


### PR DESCRIPTION
Currently, we hijack all up/down arrow key events, however this interferes with keyboard shortcuts such as shift + up arrow for marking all of the text. These changes stop intercepting the arrow keys, if they're used with a modifier.

These changes also fix an issue where all the mocked out key events had the `metaKey` set to `true` on some browsers.