### PR TITLE
fix(angular/table): remove role from sort header when disabled

### DIFF
--- a/src/angular/table/sort/sort-header.html
+++ b/src/angular/table/sort/sort-header.html
@@ -13,7 +13,7 @@
   [class.sbb-sort-header-sorted]="_isSorted()"
   [class.sbb-sort-header-position-before]="arrowPosition === 'before'"
   [attr.tabindex]="_isDisabled() ? null : 0"
-  role="button"
+  [attr.role]="_isDisabled() ? null : 'button'"
 >
   <div class="sbb-sort-header-content">
     <ng-content></ng-content>

--- a/src/angular/table/sort/sort-header.ts
+++ b/src/angular/table/sort/sort-header.ts
@@ -207,7 +207,7 @@ export class SbbSortHeader
 
     this._sort.register(this);
 
-    this._sortButton = this._elementRef.nativeElement.querySelector('[role="button"]')!;
+    this._sortButton = this._elementRef.nativeElement.querySelector('.sbb-sort-header-container')!;
     this._updateSortActionDescription(this._sortActionDescription);
   }
 

--- a/src/angular/table/sort/sort.spec.ts
+++ b/src/angular/table/sort/sort.spec.ts
@@ -246,13 +246,15 @@ describe('SbbSort', () => {
       component.sort('defaultA');
       expect(component.sbbSort.direction).toBe('asc');
       expect(container.getAttribute('tabindex')).toBe('0');
+      expect(container.getAttribute('role')).toBe('button');
 
       component.disabledColumnSort = true;
       fixture.detectChanges();
 
       component.sort('defaultA');
       expect(component.sbbSort.direction).toBe('asc');
-      expect(container.getAttribute('tabindex')).toBeFalsy();
+      expect(container.hasAttribute('tabindex')).toBe(false);
+      expect(container.hasAttribute('role')).toBe(false);
     });
 
     it('should allow for the cycling the sort direction to be disabled for all columns', () => {
@@ -417,7 +419,7 @@ describe('SbbSort', () => {
     }));
 
     it('should add a default aria description to sort buttons', () => {
-      const sortButton = fixture.nativeElement.querySelector('[role="button"]');
+      const sortButton = fixture.nativeElement.querySelector('.sbb-sort-header-container');
       const descriptionId = sortButton.getAttribute('aria-describedby');
       expect(descriptionId).toBeDefined();
 
@@ -426,7 +428,9 @@ describe('SbbSort', () => {
     });
 
     it('should add a custom aria description to sort buttons', () => {
-      const sortButton = fixture.nativeElement.querySelector('#defaultB [role="button"]');
+      const sortButton = fixture.nativeElement.querySelector(
+        '#defaultB .sbb-sort-header-container'
+      );
       let descriptionId = sortButton.getAttribute('aria-describedby');
       expect(descriptionId).toBeDefined();
 


### PR DESCRIPTION
When the sort header is disabled, we make it non-interactive by clearing its `tabindex`, however it still has the `role="button"` which can throw off screen readers if it doesn't have text.

These changes also clear the `role` from the header if it's disabled.