### PR TITLE
fix(angular/autocomplete): reopen panel on input click

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -20,7 +20,6 @@ import {
   ElementRef,
   forwardRef,
   Host,
-  HostListener,
   Inject,
   InjectionToken,
   Input,
@@ -109,6 +108,13 @@ export function getSbbAutocompleteMissingPanelError(): Error {
     '[attr.aria-owns]': '(autocompleteDisabled || !panelOpen) ? null : autocomplete?.id',
     '[attr.aria-haspopup]': 'autocompleteDisabled ? null : "listbox"',
     '[class.sbb-focused]': 'panelOpen',
+    // Note: we use `focusin`, as opposed to `focus`, in order to open the panel
+    // a little earlier. This avoids issues where IE delays the focusing of the input.
+    '(focusin)': '_handleFocus()',
+    '(blur)': '_onTouched()',
+    '(input)': '_handleInput($event)',
+    '(keydown)': '_handleKeydown($event)',
+    '(click)': '_handleClick()',
   },
 })
 export class SbbAutocompleteTrigger
@@ -170,7 +176,6 @@ export class SbbAutocompleteTrigger
   _onChange: (value: any) => void = () => {};
 
   /** `View -> model callback called when autocomplete has been touched` */
-  @HostListener('blur')
   _onTouched: () => void = () => {};
 
   /** The autocomplete panel to be attached to this trigger. */
@@ -457,7 +462,6 @@ export class SbbAutocompleteTrigger
   }
 
   /** @docs-private */
-  @HostListener('keydown', ['$event'])
   _handleKeydown(event: TypeRef<KeyboardEvent>): void {
     const keyCode = event.keyCode;
     const hasModifier = hasModifierKey(event);
@@ -491,7 +495,6 @@ export class SbbAutocompleteTrigger
   }
 
   /** @docs-private */
-  @HostListener('input', ['$event'])
   _handleInput(event: TypeRef<KeyboardEvent>): void {
     const target = event.target as HTMLInputElement;
     let value: number | string | null = target.value;
@@ -521,13 +524,18 @@ export class SbbAutocompleteTrigger
    * Note: we use `focusin`, as opposed to `focus`, in order to open the panel
    * a little earlier. This avoids issues where IE delays the focusing of the input.
    */
-  @HostListener('focusin')
   _handleFocus(): void {
     if (!this._canOpenOnNextFocus) {
       this._canOpenOnNextFocus = true;
     } else if (this._canOpen()) {
       this._previousValue = this._element.nativeElement.value;
       this._attachOverlay();
+    }
+  }
+
+  _handleClick(): void {
+    if (this._canOpen() && !this.panelOpen) {
+      this.openPanel();
     }
   }
 

--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -461,8 +461,7 @@ export class SbbAutocompleteTrigger
     this._element.nativeElement.disabled = isDisabled;
   }
 
-  /** @docs-private */
-  _handleKeydown(event: TypeRef<KeyboardEvent>): void {
+  _handleKeydown(event: KeyboardEvent): void {
     const keyCode = event.keyCode;
     const hasModifier = hasModifierKey(event);
 
@@ -494,8 +493,7 @@ export class SbbAutocompleteTrigger
     }
   }
 
-  /** @docs-private */
-  _handleInput(event: TypeRef<KeyboardEvent>): void {
+  _handleInput(event: KeyboardEvent): void {
     const target = event.target as HTMLInputElement;
     let value: number | string | null = target.value;
 

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -987,6 +987,31 @@ describe('SbbAutocomplete', () => {
 
       expect(input.hasAttribute('aria-haspopup')).toBe(false);
     });
+
+    it('should close the panel when pressing escape', fakeAsync(() => {
+      const trigger = fixture.componentInstance.trigger;
+
+      input.focus();
+      flush();
+      fixture.detectChanges();
+
+      expect(document.activeElement).withContext('Expected input to be focused.').toBe(input);
+      expect(trigger.panelOpen).withContext('Expected panel to be open.').toBe(true);
+
+      trigger.closePanel();
+      fixture.detectChanges();
+
+      expect(document.activeElement)
+        .withContext('Expected input to continue to be focused.')
+        .toBe(input);
+      expect(trigger.panelOpen).withContext('Expected panel to be closed.').toBe(false);
+
+      input.click();
+      flush();
+      fixture.detectChanges();
+
+      expect(trigger.panelOpen).withContext('Expected panel to reopen on click.').toBe(true);
+    }));
   });
 
   it('should not close the panel when clicking on the input', fakeAsync(() => {


### PR DESCRIPTION
Currently, if the user clicks an autocomplete to open it, selects an option and then clicks again, the panel won't open, because we use `focus` and the input was focused already. These changes add an extra `click` listener so the panel can reopen.