### PR TITLE
feat(angular/autocomplete): add the ability to auto-select the active option while navigating

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -581,6 +581,7 @@ export class SbbAutocompleteTrigger
             const wasOpen = this.panelOpen;
             this._resetActiveItem();
             this.autocomplete._setVisibility();
+            this._changeDetectorRef.detectChanges();
 
             if (this.panelOpen) {
               this._overlayRef!.updatePosition();

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -3137,6 +3137,213 @@ describe('SbbAutocomplete', () => {
     expect(spy).not.toHaveBeenCalled();
   }));
 
+  describe('automatically selecting the active option', () => {
+    let fixture: ComponentFixture<SimpleAutocomplete>;
+
+    beforeEach(() => {
+      fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+      fixture.componentInstance.trigger.autocomplete.autoSelectActiveOption = true;
+    });
+
+    it('should update the input value as the user is navigating, without changing the model value or closing the panel', fakeAsync(() => {
+      const { trigger, numberCtrl, closedSpy } = fixture.componentInstance;
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBeFalsy();
+      expect(trigger.panelOpen).toBe(true);
+      expect(closedSpy).not.toHaveBeenCalled();
+
+      dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBe('Eins');
+      expect(trigger.panelOpen).toBe(true);
+      expect(closedSpy).not.toHaveBeenCalled();
+
+      dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBe('Zwei');
+      expect(trigger.panelOpen).toBe(true);
+      expect(closedSpy).not.toHaveBeenCalled();
+    }));
+
+    it('should revert back to the last typed value if the user presses escape', fakeAsync(() => {
+      const { trigger, numberCtrl, closedSpy } = fixture.componentInstance;
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+      typeInElement(input, 'ei');
+      fixture.detectChanges();
+      tick();
+
+      expect(numberCtrl.value).toBe('ei');
+      expect(input.value).toBe('ei');
+      expect(trigger.panelOpen).toBe(true);
+      expect(closedSpy).not.toHaveBeenCalled();
+
+      dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBe('ei');
+      expect(input.value).toBe('Eins');
+      expect(trigger.panelOpen).toBe(true);
+      expect(closedSpy).not.toHaveBeenCalled();
+
+      dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBe('ei');
+      expect(input.value).toBe('ei');
+      expect(trigger.panelOpen).toBe(false);
+      expect(closedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it(
+      'should clear the input if the user presses escape while there was a pending ' +
+        'auto selection and there is no previous value',
+      fakeAsync(() => {
+        const { trigger, numberCtrl } = fixture.componentInstance;
+        const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+        trigger.openPanel();
+        fixture.detectChanges();
+        zone.simulateZoneExit();
+        fixture.detectChanges();
+
+        expect(numberCtrl.value).toBeFalsy();
+        expect(input.value).toBeFalsy();
+
+        dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+        fixture.detectChanges();
+
+        expect(numberCtrl.value).toBeFalsy();
+        expect(input.value).toBe('Eins');
+
+        dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
+        fixture.detectChanges();
+
+        expect(numberCtrl.value).toBeFalsy();
+        expect(input.value).toBeFalsy();
+      })
+    );
+
+    it('should propagate the auto-selected value if the user clicks away', fakeAsync(() => {
+      const { trigger, numberCtrl } = fixture.componentInstance;
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBeFalsy();
+
+      dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBe('Eins');
+
+      dispatchFakeEvent(document, 'click');
+      fixture.detectChanges();
+
+      expect(numberCtrl.value.name).toEqual('Eins');
+      expect(input.value).toBe('Eins');
+    }));
+
+    it('should propagate the auto-selected value if the user tabs away', fakeAsync(() => {
+      const { trigger, numberCtrl } = fixture.componentInstance;
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBeFalsy();
+
+      dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBe('Eins');
+
+      dispatchKeyboardEvent(input, 'keydown', TAB);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value.name).toEqual('Eins');
+      expect(input.value).toBe('Eins');
+    }));
+
+    it('should propagate the auto-selected value if the user presses enter on it', fakeAsync(() => {
+      const { trigger, numberCtrl } = fixture.componentInstance;
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBeFalsy();
+
+      dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBe('Eins');
+
+      dispatchKeyboardEvent(input, 'keydown', ENTER);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value.name).toEqual('Eins');
+      expect(input.value).toBe('Eins');
+    }));
+
+    it('should allow the user to click on an option different from the auto-selected one', fakeAsync(() => {
+      const { trigger, numberCtrl } = fixture.componentInstance;
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBeFalsy();
+
+      dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+      fixture.detectChanges();
+
+      expect(numberCtrl.value).toBeFalsy();
+      expect(input.value).toBe('Eins');
+
+      const options = overlayContainerElement.querySelectorAll(
+        'sbb-option'
+      ) as NodeListOf<HTMLElement>;
+      options[2].click();
+      fixture.detectChanges();
+
+      expect(numberCtrl.value.name).toEqual('Drei');
+      expect(input.value).toBe('Drei');
+    }));
+  });
+
   it('should have correct width when opened', () => {
     const widthFixture = createComponent(SimpleAutocomplete);
     widthFixture.componentInstance.width = 300;

--- a/src/angular/autocomplete/autocomplete.ts
+++ b/src/angular/autocomplete/autocomplete.ts
@@ -53,6 +53,9 @@ export interface SbbAutocompleteDefaultOptions {
   /** Whether the first option should be highlighted when an autocomplete panel is opened. */
   autoActiveFirstOption?: boolean;
 
+  /** Whether the active option should be selected as the user is navigating. */
+  autoSelectActiveOption?: boolean;
+
   /** Class or list of classes to be applied to the autocomplete's overlay panel. */
   overlayPanelClass?: string | string[];
 }
@@ -68,7 +71,7 @@ export const SBB_AUTOCOMPLETE_DEFAULT_OPTIONS = new InjectionToken<SbbAutocomple
 
 /** @docs-private */
 export function SBB_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY(): SbbAutocompleteDefaultOptions {
-  return { autoActiveFirstOption: false };
+  return { autoActiveFirstOption: false, autoSelectActiveOption: false };
 }
 
 @Component({
@@ -163,6 +166,16 @@ export class SbbAutocomplete implements AfterContentInit, OnDestroy {
   }
   private _autoActiveFirstOption: boolean;
 
+  /** Whether the active option should be selected as the user is navigating. */
+  @Input()
+  get autoSelectActiveOption(): boolean {
+    return this._autoSelectActiveOption;
+  }
+  set autoSelectActiveOption(value: BooleanInput) {
+    this._autoSelectActiveOption = coerceBooleanProperty(value);
+  }
+  private _autoSelectActiveOption: boolean;
+
   /**
    * Specify the width of the autocomplete panel.  Can be any CSS sizing value, otherwise it will
    * match the width of its host.
@@ -234,6 +247,7 @@ export class SbbAutocomplete implements AfterContentInit, OnDestroy {
     // option altogether.
     this.inertGroups = platform?.SAFARI || false;
     this._autoActiveFirstOption = !!defaults.autoActiveFirstOption;
+    this._autoSelectActiveOption = !!defaults.autoSelectActiveOption;
   }
 
   ngAfterContentInit() {


### PR DESCRIPTION
Adds the `autoSelectActiveOption` input to `sbb-autocomplete` which allows the
consumer to opt into the behavior where the autocomplete will assign the active
option value as the user is navigating through the list. The value is only propagated
to the model once the panel is closed.

There are a couple of UX differences when the new option is enabled:
1. If the user presses escape while there's a pending auto-selected option, the value
is reverted to the last text they typed before they started navigating.
2. If the user clicks away, tabs away or presses enter while there's a pending option,
it will be selected.

The aforementioned UX differences are based on the Google search autocomplete and
one of the examples from the W3C here:
https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html

Closes #261