### PR TITLE
fix(angular/tooltip): don't hide when pointer moves to tooltip

### DIFF
--- a/src/angular/tooltip/tooltip.scss
+++ b/src/angular/tooltip/tooltip.scss
@@ -132,3 +132,7 @@
     border-radius: 50%;
   }
 }
+
+.sbb-tooltip-panel-non-interactive {
+  pointer-events: none;
+}


### PR DESCRIPTION
Currently, we hide the tooltip as soon as the pointer leaves the trigger element which may be problematic with larger cursors that partially obstruct the content.

These changes allow hover events on the tooltip and add extra logic so that moving to it doesn't start the hiding sequence.