### PR TITLE
feat(angular/schematics): add option not to include animations module in ng-add

### DIFF
--- a/src/angular/schematics/ng-add/index.spec.ts
+++ b/src/angular/schematics/ng-add/index.spec.ts
@@ -237,12 +237,15 @@ describe('ngAdd', () => {
       // Simulate the case where a developer uses `ng-add` on an Angular CLI project which already
       // explicitly uses the `BrowserAnimationsModule`. It would be wrong to forcibly change
       // to noop animations.
-      const fileContent = addModuleImportToRootModule(
+      addModuleImportToRootModule(
         tree,
         'BrowserAnimationsModule',
         '@angular/platform-browser/animations',
         project
       );
+
+      const fileContent = readStringFile(tree, '/projects/dummy/src/app/app.module.ts');
+
       expect(fileContent).not.toContain(
         'NoopAnimationsModule',
         'Expected the project app module to not import the "NoopAnimationsModule".'

--- a/src/angular/schematics/ng-add/schema.json
+++ b/src/angular/schematics/ng-add/schema.json
@@ -12,10 +12,18 @@
       }
     },
     "animations": {
-      "type": "boolean",
-      "default": true,
-      "description": "Whether Angular browser animations should be set up.",
-      "x-prompt": "Set up browser animations for sbb angular?"
+      "type": "string",
+      "default": "enabled",
+      "description": "Whether Angular browser animations should be included.",
+      "x-prompt": {
+        "message": "Include the Angular animations module?",
+        "type": "list",
+        "items": [
+          { "value": "enabled", "label": "Include and enable animations" },
+          { "value": "disabled", "label": "Include, but disable animations" },
+          { "value": "excluded", "label": "Do not include" }
+        ]
+      }
     },
     "variant": {
       "type": "string",

--- a/src/angular/schematics/ng-add/schema.ts
+++ b/src/angular/schematics/ng-add/schema.ts
@@ -2,8 +2,8 @@ export interface Schema {
   /** Name of the project. */
   project: string;
 
-  /** Whether Angular browser animations should be set up. */
-  animations: boolean;
+  /** Whether the Angular browser animations module should be included and enabled. */
+  animations: 'enabled' | 'disabled' | 'excluded';
 
   /** Design variant. */
   variant: 'standard (previously known as public)' | 'lean (previously known as business)';

--- a/src/angular/schematics/ng-add/setup-project.ts
+++ b/src/angular/schematics/ng-add/setup-project.ts
@@ -64,7 +64,7 @@ function addAnimationsModule(options: Schema) {
     const project = getProjectFromWorkspace(workspace, options.project);
     const appModulePath = getAppModulePath(host, getProjectMainFile(project));
 
-    if (options.animations) {
+    if (options.animations === 'enabled') {
       // In case the project explicitly uses the NoopAnimationsModule, we should print a warning
       // message that makes the user aware of the fact that we won't automatically set up
       // animations. If we would add the BrowserAnimationsModule while the NoopAnimationsModule
@@ -75,18 +75,18 @@ function addAnimationsModule(options: Schema) {
             `because "${NOOP_ANIMATIONS_MODULE_NAME}" is already imported.`
         );
         context.logger.info(`Please manually set up browser animations.`);
-        return;
+      } else {
+        addModuleImportToRootModule(
+          host,
+          BROWSER_ANIMATIONS_MODULE_NAME,
+          '@angular/platform-browser/animations',
+          project
+        );
       }
-
-      addModuleImportToRootModule(
-        host,
-        BROWSER_ANIMATIONS_MODULE_NAME,
-        '@angular/platform-browser/animations',
-        project
-      );
-
-      context.logger.info(`✔️ Added ${BROWSER_ANIMATIONS_MODULE_NAME} to ${appModulePath}.`);
-    } else if (!hasNgModuleImport(host, appModulePath, BROWSER_ANIMATIONS_MODULE_NAME)) {
+    } else if (
+      options.animations === 'disabled' &&
+      !hasNgModuleImport(host, appModulePath, BROWSER_ANIMATIONS_MODULE_NAME)
+    ) {
       // Do not add the NoopAnimationsModule module if the project already explicitly uses
       // the BrowserAnimationsModule.
       addModuleImportToRootModule(


### PR DESCRIPTION
Adds a third option to the `ng-add` schematic that allows users to opt out of including any of the animations modules.