### PR TITLE
feat(angular/icon): allow multiple classes in setDefaultFontSetClass

### DIFF
--- a/src/angular/icon/icon-registry.ts
+++ b/src/angular/icon/icon-registry.ts
@@ -134,10 +134,10 @@ export class SbbIconRegistry implements OnDestroy {
   private _resolvers: IconResolver[] = [];
 
   /**
-   * The CSS class to apply when an `<sbb-icon>` component has no icon name, url, or font specified.
-   * The default is 'sbb-icons'.
+   * The CSS classes to apply when an `<sbb-icon>` component has no icon name, url, or font
+   * specified.
    */
-  private _defaultFontSetClass = 'sbb-icons';
+  private _defaultFontSetClass = ['sbb-icons'];
 
   /**
    * A list of internally supported namespaces, which can be served from the icon CDN.
@@ -296,19 +296,19 @@ export class SbbIconRegistry implements OnDestroy {
   }
 
   /**
-   * Sets the CSS class name to be used for icon fonts when an `<sbb-icon>` component does not
+   * Sets the CSS classes to be used for icon fonts when an `<sbb-icon>` component does not
    * have a fontSet input value, and is not loading an icon by name or URL.
    */
-  setDefaultFontSetClass(className: string): this {
-    this._defaultFontSetClass = className;
+  setDefaultFontSetClass(...classNames: string[]): this {
+    this._defaultFontSetClass = classNames;
     return this;
   }
 
   /**
-   * Returns the CSS class name to be used for icon fonts when an `<sbb-icon>` component does not
+   * Returns the CSS classes to be used for icon fonts when an `<sbb-icon>` component does not
    * have a fontSet input value, and is not loading an icon by name or URL.
    */
-  getDefaultFontSetClass(): string {
+  getDefaultFontSetClass(): string[] {
     return this._defaultFontSetClass;
   }
 

--- a/src/angular/icon/testing/fake-icon-registry.ts
+++ b/src/angular/icon/testing/fake-icon-registry.ts
@@ -55,7 +55,7 @@ export class FakeSbbIconRegistry implements PublicApi<SbbIconRegistry>, OnDestro
   }
 
   getDefaultFontSetClass() {
-    return 'sbb-icons';
+    return ['sbb-icons'];
   }
 
   getSvgIconFromUrl(): Observable<SVGElement> {


### PR DESCRIPTION
Allows for the consumer to pass in multiple classes to `SbbIconRegistry.setDefaultFontSetClass`.