### PR TITLE
fix(angular/menu): focus lost if active item is removed

### DIFF
--- a/src/angular/menu/menu-item.ts
+++ b/src/angular/menu/menu-item.ts
@@ -1,4 +1,5 @@
 import { FocusableOption, FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
+import { DOCUMENT } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -69,7 +70,8 @@ export class SbbMenuItem
      * @deprecated `_changeDetectorRef` to become a required parameter.
      * @breaking-change 14.0.0
      */
-    private _changeDetectorRef?: ChangeDetectorRef
+    private _changeDetectorRef?: ChangeDetectorRef,
+    @Inject(DOCUMENT) private _document?: any
   ) {
     super();
   }
@@ -146,5 +148,9 @@ export class SbbMenuItem
     // @breaking-change 14.0.0 Remove null check for `_changeDetectorRef`.
     this._highlighted = isHighlighted;
     this._changeDetectorRef?.markForCheck();
+  }
+
+  _hasFocus(): boolean {
+    return this._document && this._document.activeElement === this._getHostElement();
   }
 }

--- a/src/angular/menu/menu-item.ts
+++ b/src/angular/menu/menu-item.ts
@@ -71,6 +71,10 @@ export class SbbMenuItem
      * @breaking-change 14.0.0
      */
     private _changeDetectorRef?: ChangeDetectorRef,
+    /**
+     * @deprecated `_document` to become a required parameter.
+     * @breaking-change 14.0.0
+     */
     @Inject(DOCUMENT) private _document?: any
   ) {
     super();

--- a/src/angular/menu/menu.spec.ts
+++ b/src/angular/menu/menu.spec.ts
@@ -256,6 +256,26 @@ describe('SbbMenu', () => {
     tick(500);
   }));
 
+  it('should move focus to another item if the active item is destroyed', fakeAsync(() => {
+    const fixture = createComponent(MenuWithRepeatedItems, [], [FakeIcon]);
+    fixture.detectChanges();
+    const triggerEl = fixture.componentInstance.triggerEl.nativeElement;
+
+    triggerEl.click();
+    fixture.detectChanges();
+    tick(500);
+
+    const items = overlayContainerElement.querySelectorAll('.sbb-menu-panel .sbb-menu-item');
+
+    expect(document.activeElement).toBe(items[0]);
+
+    fixture.componentInstance.items.shift();
+    fixture.detectChanges();
+    tick(500);
+
+    expect(document.activeElement).toBe(items[1]);
+  }));
+
   it('should be able to set a custom class on the backdrop', fakeAsync(() => {
     const fixture = createComponent(SimpleMenu, [], [FakeIcon]);
 
@@ -348,6 +368,7 @@ describe('SbbMenu', () => {
     // Add 50 items to make the menu scrollable
     fixture.componentInstance.extraItems = new Array(50).fill('Hello there');
     fixture.detectChanges();
+    tick(50);
 
     const triggerEl = fixture.componentInstance.triggerEl.nativeElement;
     dispatchFakeEvent(triggerEl, 'mousedown');
@@ -3196,6 +3217,21 @@ class StaticAriaLabelledByMenu {}
   template: '<sbb-menu aria-describedby="some-element"></sbb-menu>',
 })
 class StaticAriaDescribedbyMenu {}
+
+@Component({
+  template: `
+    <button [sbbMenuTriggerFor]="menu" #triggerEl>Toggle menu</button>
+    <sbb-menu #menu="sbbMenu">
+      <button *ngFor="let item of items" sbb-menu-item>{{ item }}</button>
+    </sbb-menu>
+  `,
+})
+class MenuWithRepeatedItems {
+  @ViewChild(SbbMenuTrigger, { static: false }) trigger: SbbMenuTrigger;
+  @ViewChild('triggerEl', { static: false }) triggerEl: ElementRef<HTMLElement>;
+  @ViewChild(SbbMenu, { static: false }) menu: SbbMenu;
+  items = ['One', 'Two', 'Three'];
+}
 
 @Component({
   template: `<button [sbbMenuTriggerFor]="animals" aria-label="Show animals">


### PR DESCRIPTION
Fixes the user's focus being lost if the active item is destroyed while a menu is open.

See https://stackblitz.com/edit/angular-v1c2k9?file=src%2Fapp%2Fmenu-overview-example.ts