### PR TITLE
fix(angular/datepicker): use aria-live over cdkAriaLive on period button

### DIFF
--- a/src/angular/datepicker/calendar/calendar-header.html
+++ b/src/angular/datepicker/calendar/calendar-header.html
@@ -9,7 +9,7 @@
     >
       <sbb-icon svgIcon="kom:chevron-small-left-small"></sbb-icon>
     </button>
-    <span class="sbb-calendar-controls-label" [attr.aria-label]="monthText" cdkAriaLive="polite"
+    <span class="sbb-calendar-controls-label" [attr.aria-label]="monthText" aria-live="polite"
       >{{ monthText }}</span
     >
     <button
@@ -32,7 +32,7 @@
     >
       <sbb-icon svgIcon="kom:chevron-small-left-small"></sbb-icon>
     </button>
-    <span class="sbb-calendar-controls-label" [attr.aria-label]="yearText" cdkAriaLive="polite"
+    <span class="sbb-calendar-controls-label" [attr.aria-label]="yearText" aria-live="polite"
       >{{ yearText }}</span
     >
     <button


### PR DESCRIPTION
On the period button on the calendar, use `aria-live` over `cdkAriaLive` because that seems to work better with VoiceOver. This fixes an issue where VoiceOver did not announce the month after clicking the "Month" / "Previous Month" buttons