### PR TITLE
fix(angular/button): avoid setting a tabindex on all link buttons

### DIFF
--- a/src/angular/button/button.spec.ts
+++ b/src/angular/button/button.spec.ts
@@ -250,11 +250,11 @@ describe('SbbButton', () => {
       const fixture = TestBed.createComponent(ButtonTest);
       const testComponent = fixture.debugElement.componentInstance;
       const buttonDebugElement = fixture.debugElement.query(By.css('a'))!;
-      expect(buttonDebugElement.nativeElement.getAttribute('tabIndex')).toBe(null);
+      expect(buttonDebugElement.nativeElement.hasAttribute('tabindex')).toBe(false);
 
       testComponent.isDisabled = true;
       fixture.detectChanges();
-      expect(buttonDebugElement.nativeElement.getAttribute('tabIndex')).toBe('-1');
+      expect(buttonDebugElement.nativeElement.getAttribute('tabindex')).toBe('-1');
     });
 
     it('should add aria-disabled attribute if disabled', () => {
@@ -299,16 +299,24 @@ describe('SbbButton', () => {
       fixture.componentInstance.tabIndex = 3;
       fixture.detectChanges();
 
-      expect(buttonElement.getAttribute('tabIndex'))
+      expect(buttonElement.getAttribute('tabindex'))
         .withContext('Expected custom tabindex to be set')
         .toBe('3');
 
       testComponent.isDisabled = true;
       fixture.detectChanges();
 
-      expect(buttonElement.getAttribute('tabIndex'))
+      expect(buttonElement.getAttribute('tabindex'))
         .withContext('Expected custom tabindex to be overwritten when disabled.')
         .toBe('-1');
+    });
+
+    it('should not set a default tabindex on enabled links', () => {
+      const fixture = TestBed.createComponent(ButtonTest);
+      const buttonElement = fixture.debugElement.query(By.css('a'))!.nativeElement;
+      fixture.detectChanges();
+
+      expect(buttonElement.hasAttribute('tabindex')).toBe(false);
     });
 
     describe('change detection behavior', () => {

--- a/src/angular/button/button.ts
+++ b/src/angular/button/button.ts
@@ -166,7 +166,7 @@ export class SbbButton
     // Note that we ignore the user-specified tabindex when it's disabled for
     // consistency with the `sbb-button` applied on native buttons where even
     // though they have an index, they're not tabbable.
-    '[attr.tabindex]': 'disabled ? -1 : (tabIndex || 0)',
+    '[attr.tabindex]': 'disabled ? -1 : tabIndex',
     '[attr.disabled]': 'disabled || null',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[class._sbb-animation-noopable]': '_animationMode === "NoopAnimations"',


### PR DESCRIPTION
Fixes that the button component was always setting a `tabindex="0"` when it's placed on a link element. This is unnecessary, because links are in the tab order by default.

We actually had a test that has an assertion against this, but it was passing by accident because we weren't running change detection before making the asserting.