### PR TITLE
fix(angular/dialog): don't block child component animations on open

### DIFF
--- a/src/angular/dialog/dialog-animations.ts
+++ b/src/angular/dialog/dialog-animations.ts
@@ -1,6 +1,9 @@
 import {
   animate,
+  animateChild,
   AnimationTriggerMetadata,
+  group,
+  query,
   state,
   style,
   transition,
@@ -23,11 +26,17 @@ export const sbbDialogAnimations: {
     state('enter', style({ transform: 'none' })),
     transition(
       '* => enter',
-      animate('150ms cubic-bezier(0, 0, 0.2, 1)', style({ transform: 'none', opacity: 1 }))
+      group([
+        animate('150ms cubic-bezier(0, 0, 0.2, 1)', style({ transform: 'none', opacity: 1 })),
+        query('@*', animateChild(), { optional: true }),
+      ])
     ),
     transition(
       '* => void, * => exit',
-      animate('75ms cubic-bezier(0.4, 0.0, 0.2, 1)', style({ opacity: 0 }))
+      group([
+        animate('75ms cubic-bezier(0.4, 0.0, 0.2, 1)', style({ opacity: 0 })),
+        query('@*', animateChild(), { optional: true }),
+      ])
     ),
   ]),
 };


### PR DESCRIPTION
Reworks several components that usually contain projected content not to block animations within that content. This prevents things like expansion panels from appearing as open.

Demo: https://stackblitz.com/edit/angular-7yh3kk?file=src%2Fapp%2Fcomponent-data-dialog-example.html