### PR TITLE
fix(angular/autocomplete): correct color of hover elements

### DIFF
--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -2437,12 +2437,13 @@ $menuItemPaddingTopBottom: 4;
     @include user-select(none);
   }
 
-  &:is(:not(:disabled):not([disabled]):not(.sbb-disabled):is(:hover, :focus, :hover strong, :focus
-        strong), .sbb-focused) {
-    color: var(--sbb-color-red);
+  &:is(:not(:disabled):not([disabled]):not(.sbb-disabled):is(:hover, :focus), .sbb-focused) {
+    :is(&, & strong) {
+      color: var(--sbb-color-red);
 
-    :where(html.sbb-lean) & {
-      @include sbbMenuItemRedLean();
+      :where(html.sbb-lean) & {
+        @include sbbMenuItemRedLean();
+      }
     }
   }
 


### PR DESCRIPTION
When hovering over an autocomplete item, the `strong` part does not change its color. This is because the selector `.sbb-menu-item:is(:hover strong)` did not select the `strong` tag.