### PR TITLE
fix(angular/autocomplete): able to tab into descendants with visibility while closed

### DIFF
--- a/src/angular/accordion/expansion-panel.scss
+++ b/src/angular/accordion/expansion-panel.scss
@@ -119,6 +119,16 @@
   flex-direction: column;
   overflow: visible;
 
+  // Usually the `visibility: hidden` added by the animation is enough to prevent focus from
+  // entering the collapsed content, but children with their own `visibility` can override it.
+  // In other components we set a `display: none` at the root to stop focus from reaching the
+  // elements, however we can't do that here, because the content can determine the width
+  // of an expansion panel. The most practical fallback is to use `!important` to override
+  // any custom visibility.
+  &[style*='visibility: hidden'] * {
+    visibility: hidden !important;
+  }
+
   &.ng-animating,
   .sbb-expansion-panel:not(.sbb-expanded) & {
     overflow: hidden;


### PR DESCRIPTION
The expansion panel sets `visibility: hidden` while it's closed in order to prevent users from tabbing into the content. This breaks down if a child has its own `visibility`, because it overrides the one coming from the parent. We can't use `display` in the animation definition, because it prevents the animations module from calculating the height when animating.