### PR TITLE
fix(angular/chips): create new array or set on update

### DIFF
--- a/src/angular/chips/chip-input.ts
+++ b/src/angular/chips/chip-input.ts
@@ -270,7 +270,7 @@ export class SbbChipInput implements SbbChipTextControl, OnChanges, OnDestroy, A
     const isArray = Array.isArray(currentCollection);
     const isSet = currentCollection instanceof Set;
     if (isArray) {
-      control.patchValue([...currentCollection, inputValue]); // .push(inputValue);
+      control.patchValue([...currentCollection, inputValue]);
     } else if (isSet) {
       control.patchValue(new Set([...currentCollection, inputValue]));
     }

--- a/src/angular/chips/chip-input.ts
+++ b/src/angular/chips/chip-input.ts
@@ -270,12 +270,11 @@ export class SbbChipInput implements SbbChipTextControl, OnChanges, OnDestroy, A
     const isArray = Array.isArray(currentCollection);
     const isSet = currentCollection instanceof Set;
     if (isArray) {
-      currentCollection.push(inputValue);
+      control.patchValue([...currentCollection, inputValue]); // .push(inputValue);
     } else if (isSet) {
-      currentCollection.add(inputValue);
+      control.patchValue(new Set([...currentCollection, inputValue]));
     }
     if (isArray || isSet) {
-      control.updateValueAndValidity();
       this.clear();
     }
   }

--- a/src/angular/chips/chip-list.spec.ts
+++ b/src/angular/chips/chip-list.spec.ts
@@ -857,6 +857,25 @@ describe('SbbChipList', () => {
         expect(testChipsAutocomplete.selectedFruits.value).toEqual([]);
       });
 
+      it('should return a new array on update', async () => {
+        expect(testChipsAutocomplete.selectedFruits.value).toEqual(['Lemon']);
+        const before = testChipsAutocomplete.selectedFruits.value;
+
+        input.focus();
+        typeInElement(input, 'Apple');
+        dispatchKeyboardEvent(input, 'keydown', ENTER);
+        await fixture.whenStable();
+
+        const afterAdd = testChipsAutocomplete.selectedFruits.value;
+        expect(afterAdd === before).toBeFalse();
+
+        chips.last.remove();
+        await fixture.whenStable();
+
+        const afterRemove = testChipsAutocomplete.selectedFruits.value;
+        expect(afterRemove === afterAdd).toBeFalse();
+      });
+
       it('should add value to form control Set', async () => {
         testChipsAutocomplete.selectedFruits = new FormControl(new Set(['Lemon']));
         fixture.detectChanges();

--- a/src/angular/chips/chip-list.spec.ts
+++ b/src/angular/chips/chip-list.spec.ts
@@ -876,6 +876,26 @@ describe('SbbChipList', () => {
         expect(afterRemove === afterAdd).toBeFalse();
       });
 
+      it('should return a new Set on update', async () => {
+        testChipsAutocomplete.selectedFruits = new FormControl(new Set(['Lemon']));
+        fixture.detectChanges();
+        const before = testChipsAutocomplete.selectedFruits.value;
+
+        input.focus();
+        typeInElement(input, 'Banana');
+        dispatchKeyboardEvent(input, 'keydown', ENTER);
+        await fixture.whenStable();
+
+        const afterAdd = testChipsAutocomplete.selectedFruits.value;
+        expect(afterAdd === before).toBeFalse();
+
+        chips.last.remove();
+        await fixture.whenStable();
+
+        const afterRemove = testChipsAutocomplete.selectedFruits.value;
+        expect(afterRemove === afterAdd).toBeFalse();
+      });
+
       it('should add value to form control Set', async () => {
         testChipsAutocomplete.selectedFruits = new FormControl(new Set(['Lemon']));
         fixture.detectChanges();

--- a/src/angular/chips/chip.ts
+++ b/src/angular/chips/chip.ts
@@ -235,15 +235,14 @@ export class SbbChip
     }
     const currentCollection = control.value;
     if (Array.isArray(currentCollection)) {
-      const index = currentCollection.indexOf(this.value);
-      if (index === -1) {
+      if (!currentCollection.includes(this.value)) {
         return;
       }
-      currentCollection.splice(index, 1);
-      control.updateValueAndValidity();
+      control.patchValue(currentCollection.filter((val) => val !== this.value));
     } else if (currentCollection instanceof Set) {
-      currentCollection.delete(this.value);
-      control.updateValueAndValidity();
+      const newCurrentCollection = new Set(currentCollection);
+      newCurrentCollection.delete(this.value);
+      control.patchValue(newCurrentCollection);
     }
   }
 


### PR DESCRIPTION
Before this change the chip control modified the underlying array or set instance in place. This led to unexpected behaviour, e.g. when used with `distinctUntilChanged((prev, curr) => prev === curr)` (where `prev` and `curr` point to the same array). Therefore, we now return a new array or set instance after a chip was removed or added.