### PR TITLE
fix(angular/autocomplete): always emit closed event

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -111,7 +111,7 @@ export function getSbbAutocompleteMissingPanelError(): Error {
     // Note: we use `focusin`, as opposed to `focus`, in order to open the panel
     // a little earlier. This avoids issues where IE delays the focusing of the input.
     '(focusin)': '_handleFocus()',
-    '(blur)': '_onTouched()',
+    '(blur)': '_handleBlur()',
     '(input)': '_handleInput($event)',
     '(keydown)': '_handleKeydown($event)',
     '(click)': '_handleClick()',
@@ -549,6 +549,17 @@ export class SbbAutocompleteTrigger
       this._previousValue = this._element.nativeElement.value;
       this._attachOverlay();
     }
+  }
+
+  /**
+   * Ensure the close event is always emitted if the panel was open before,
+   * even if the user entered a string that does not match any option.
+   */
+  _handleBlur(): void {
+    if (this.autocomplete._isOpen) {
+      this.autocomplete.closed.emit();
+    }
+    this._onTouched();
   }
 
   _handleClick(): void {

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -3236,6 +3236,25 @@ describe('SbbAutocomplete', () => {
       expect(closedSpy).toHaveBeenCalledTimes(1);
     }));
 
+    it('should emit a closed event on blur if it was not emitted before', fakeAsync(() => {
+      const { trigger, openedSpy, closedSpy } = fixture.componentInstance;
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      typeInElement(input, 'Zweiundvierzig'); // not a valid option
+      fixture.detectChanges();
+      tick();
+
+      expect(closedSpy).not.toHaveBeenCalled();
+
+      input.blur();
+      fixture.detectChanges();
+
+      expect(openedSpy).toHaveBeenCalledTimes(1);
+      expect(closedSpy).toHaveBeenCalledTimes(1);
+    }));
+
     it(
       'should clear the input if the user presses escape while there was a pending ' +
         'auto selection and there is no previous value',


### PR DESCRIPTION
If the user enters a string that does not match any option, the `closed` event was not emitted before. This PR ensures that a `closed` event is emitted on blur if the panel is still open.

Closes #1274