### PR TITLE
feat(angular/dialog): add the ability to control the animation duration

### DIFF
--- a/src/angular/dialog/dialog-animations.ts
+++ b/src/angular/dialog/dialog-animations.ts
@@ -27,14 +27,17 @@ export const sbbDialogAnimations: {
     transition(
       '* => enter',
       group([
-        animate('150ms cubic-bezier(0, 0, 0.2, 1)', style({ transform: 'none', opacity: 1 })),
+        animate(
+          '{{enterAnimationDuration}} cubic-bezier(0, 0, 0.2, 1)',
+          style({ transform: 'none', opacity: 1 })
+        ),
         query('@*', animateChild(), { optional: true }),
       ])
     ),
     transition(
       '* => void, * => exit',
       group([
-        animate('75ms cubic-bezier(0.4, 0.0, 0.2, 1)', style({ opacity: 0 })),
+        animate('{{exitAnimationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)', style({ opacity: 0 })),
         query('@*', animateChild(), { optional: true }),
       ])
     ),

--- a/src/angular/dialog/dialog-animations.ts
+++ b/src/angular/dialog/dialog-animations.ts
@@ -11,6 +11,14 @@ import {
 } from '@angular/animations';
 
 /**
+ * Default parameters for the animation for backwards compatibility.
+ * @docs-private
+ */
+export const defaultParams = {
+  params: { enterAnimationDuration: '150ms', exitAnimationDuration: '75ms' },
+};
+
+/**
  * Animations used by SbbDialog.
  * @docs-private
  */
@@ -32,14 +40,16 @@ export const sbbDialogAnimations: {
           style({ transform: 'none', opacity: 1 })
         ),
         query('@*', animateChild(), { optional: true }),
-      ])
+      ]),
+      defaultParams
     ),
     transition(
       '* => void, * => exit',
       group([
         animate('{{exitAnimationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)', style({ opacity: 0 })),
         query('@*', animateChild(), { optional: true }),
-      ])
+      ]),
+      defaultParams
     ),
   ]),
 };

--- a/src/angular/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog-config.ts
@@ -107,5 +107,11 @@ export class SbbDialogConfig<D = any> {
   /** Alternate `ComponentFactoryResolver` to use when resolving the associated component. */
   componentFactoryResolver?: ComponentFactoryResolver;
 
+  /** Duration of the enter animation. Has to be a valid CSS value (e.g. 100ms). */
+  enterAnimationDuration?: string = '150ms';
+
+  /** Duration of the exit animation. Has to be a valid CSS value (e.g. 50ms). */
+  exitAnimationDuration?: string = '75ms';
+
   // TODO(jelbourn): add configuration for lifecycle hooks, ARIA labelling.
 }

--- a/src/angular/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog-config.ts
@@ -1,6 +1,8 @@
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { ComponentFactoryResolver, ViewContainerRef } from '@angular/core';
 
+import { defaultParams } from './dialog-animations';
+
 /** Valid ARIA roles for a dialog element. */
 export type SbbDialogRole = 'dialog' | 'alertdialog';
 
@@ -108,10 +110,10 @@ export class SbbDialogConfig<D = any> {
   componentFactoryResolver?: ComponentFactoryResolver;
 
   /** Duration of the enter animation. Has to be a valid CSS value (e.g. 100ms). */
-  enterAnimationDuration?: string = '150ms';
+  enterAnimationDuration?: string = defaultParams.params.enterAnimationDuration;
 
   /** Duration of the exit animation. Has to be a valid CSS value (e.g. 50ms). */
-  exitAnimationDuration?: string = '75ms';
+  exitAnimationDuration?: string = defaultParams.params.exitAnimationDuration;
 
   // TODO(jelbourn): add configuration for lifecycle hooks, ARIA labelling.
 }

--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -247,7 +247,7 @@ export abstract class _SbbDialogContainerBase extends BasePortalOutlet {
     '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledBy',
     '[attr.aria-label]': '_config.ariaLabel',
     '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
-    '[@dialogContainer]': '_state',
+    '[@dialogContainer]': `_getAnimationState()`,
   },
 })
 export class SbbDialogContainer extends _SbbDialogContainerBase {
@@ -293,5 +293,15 @@ export class SbbDialogContainer extends _SbbDialogContainerBase {
     if (!this._config.delayFocusTrap) {
       this._trapFocus();
     }
+  }
+
+  _getAnimationState() {
+    return {
+      value: this._state,
+      params: {
+        enterAnimationDuration: this._config.enterAnimationDuration || '150ms',
+        exitAnimationDuration: this._config.exitAnimationDuration || '75ms',
+      },
+    };
   }
 }

--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -52,6 +52,9 @@ export function throwSbbDialogContentAlreadyAttachedError() {
 export abstract class _SbbDialogContainerBase extends BasePortalOutlet {
   protected _document: Document;
 
+  /** State of the animation. */
+  _state: 'void' | 'enter' | 'exit' = 'enter';
+
   /** The portal outlet inside of this container into which the dialog content will be loaded. */
   @ViewChild(CdkPortalOutlet, { static: true }) _portalOutlet: CdkPortalOutlet;
 
@@ -143,6 +146,19 @@ export abstract class _SbbDialogContainerBase extends BasePortalOutlet {
 
     return this._portalOutlet.attachDomPortal(portal);
   };
+
+  _getAnimationState() {
+    return {
+      value: this._state,
+      params: {
+        // See https://github.com/angular/components/commit/575332c9296c28776376f4b4f7fb39c9743761aa
+        'enterAnimationDuration': // prettier-ignore
+            this._config.enterAnimationDuration || defaultParams.params.enterAnimationDuration,
+        'exitAnimationDuration': // prettier-ignore
+            this._config.exitAnimationDuration || defaultParams.params.exitAnimationDuration,
+      },
+    };
+  }
 
   /** Moves focus back into the dialog if it was moved out. */
   _recaptureFocus() {
@@ -251,9 +267,6 @@ export abstract class _SbbDialogContainerBase extends BasePortalOutlet {
   },
 })
 export class SbbDialogContainer extends _SbbDialogContainerBase {
-  /** State of the dialog animation. */
-  _state: 'void' | 'enter' | 'exit' = 'enter';
-
   /** Callback, invoked whenever an animation on the host completes. */
   @HostListener('@dialogContainer.done', ['$event'])
   _onAnimationDone({ toState, totalTime }: AnimationEvent) {
@@ -293,18 +306,5 @@ export class SbbDialogContainer extends _SbbDialogContainerBase {
     if (!this._config.delayFocusTrap) {
       this._trapFocus();
     }
-  }
-
-  _getAnimationState() {
-    return {
-      value: this._state,
-      params: {
-        // See https://github.com/angular/components/commit/575332c9296c28776376f4b4f7fb39c9743761aa
-        'enterAnimationDuration': // prettier-ignore
-          this._config.enterAnimationDuration || defaultParams.params.enterAnimationDuration,
-        'exitAnimationDuration': // prettier-ignore
-          this._config.exitAnimationDuration || defaultParams.params.exitAnimationDuration,
-      },
-    };
   }
 }

--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -25,7 +25,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
-import { sbbDialogAnimations } from './dialog-animations';
+import { defaultParams, sbbDialogAnimations } from './dialog-animations';
 import { SbbDialogConfig } from './dialog-config';
 
 /** Event that captures the state of dialog container animations. */
@@ -299,8 +299,11 @@ export class SbbDialogContainer extends _SbbDialogContainerBase {
     return {
       value: this._state,
       params: {
-        enterAnimationDuration: this._config.enterAnimationDuration || '150ms',
-        exitAnimationDuration: this._config.exitAnimationDuration || '75ms',
+        // See https://github.com/angular/components/commit/575332c9296c28776376f4b4f7fb39c9743761aa
+        'enterAnimationDuration': // prettier-ignore
+          this._config.enterAnimationDuration || defaultParams.params.enterAnimationDuration,
+        'exitAnimationDuration': // prettier-ignore
+          this._config.exitAnimationDuration || defaultParams.params.exitAnimationDuration,
       },
     };
   }

--- a/src/angular/dialog/public-api.ts
+++ b/src/angular/dialog/public-api.ts
@@ -4,4 +4,4 @@ export * from './dialog-container';
 export * from './dialog-content-directives';
 export * from './dialog-config';
 export * from './dialog-ref';
-export * from './dialog-animations';
+export { sbbDialogAnimations } from './dialog-animations';

--- a/src/angular/lightbox/lightbox-animations.ts
+++ b/src/angular/lightbox/lightbox-animations.ts
@@ -8,6 +8,14 @@ import {
 } from '@angular/animations';
 
 /**
+ * Default parameters for the animation for backwards compatibility.
+ * @docs-private
+ */
+export const defaultParams = {
+  params: { enterAnimationDuration: '150ms', exitAnimationDuration: '75ms' },
+};
+
+/**
  * Animations used by SbbLightbox.
  * @docs-private
  */
@@ -23,11 +31,16 @@ export const sbbLightboxAnimations: {
     state('enter', style({ transform: 'none' })),
     transition(
       '* => enter',
-      animate('150ms cubic-bezier(0, 0, 0.2, 1)', style({ transform: 'none', opacity: 1 }))
+      animate(
+        '{{enterAnimationDuration}} cubic-bezier(0, 0, 0.2, 1)',
+        style({ transform: 'none', opacity: 1 })
+      ),
+      defaultParams
     ),
     transition(
       '* => void, * => exit',
-      animate('75ms cubic-bezier(0.4, 0.0, 0.2, 1)', style({ opacity: 0 }))
+      animate('{{exitAnimationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)', style({ opacity: 0 })),
+      defaultParams
     ),
   ]),
 };

--- a/src/angular/lightbox/lightbox-config.ts
+++ b/src/angular/lightbox/lightbox-config.ts
@@ -2,6 +2,8 @@ import { ScrollStrategy } from '@angular/cdk/overlay';
 import { ComponentFactoryResolver, ViewContainerRef } from '@angular/core';
 import { SbbDialogRole } from '@sbb-esta/angular/dialog';
 
+import { defaultParams } from './lightbox-animations';
+
 /**
  * Configuration for opening a modal dialog with the SbbLightbox service.
  */
@@ -59,6 +61,12 @@ export class SbbLightboxConfig<D = any> {
 
   /** Alternate `ComponentFactoryResolver` to use when resolving the associated component. */
   componentFactoryResolver?: ComponentFactoryResolver;
+
+  /** Duration of the enter animation. Has to be a valid CSS value (e.g. 100ms). */
+  enterAnimationDuration?: string = defaultParams.params.enterAnimationDuration;
+
+  /** Duration of the exit animation. Has to be a valid CSS value (e.g. 50ms). */
+  exitAnimationDuration?: string = defaultParams.params.exitAnimationDuration;
 
   // TODO(jelbourn): add configuration for lifecycle hooks, ARIA labelling.
 }

--- a/src/angular/lightbox/lightbox-container.ts
+++ b/src/angular/lightbox/lightbox-container.ts
@@ -26,7 +26,7 @@ import { sbbLightboxAnimations } from './lightbox-animations';
     '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledBy',
     '[attr.aria-label]': '_config.ariaLabel',
     '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
-    '[@lightboxContainer]': '_state',
+    '[@lightboxContainer]': `_getAnimationState()`,
   },
 })
 export class SbbLightboxContainer extends _SbbDialogContainerBase {

--- a/src/angular/lightbox/lightbox-container.ts
+++ b/src/angular/lightbox/lightbox-container.ts
@@ -30,9 +30,6 @@ import { sbbLightboxAnimations } from './lightbox-animations';
   },
 })
 export class SbbLightboxContainer extends _SbbDialogContainerBase {
-  /** State of the lightbox animation. */
-  _state: 'void' | 'enter' | 'exit' = 'enter';
-
   /** Callback, invoked whenever an animation on the host completes. */
   @HostListener('@lightboxContainer.done', ['$event'])
   _onAnimationDone({ toState, totalTime }: AnimationEvent) {

--- a/src/angular/lightbox/public-api.ts
+++ b/src/angular/lightbox/public-api.ts
@@ -6,3 +6,4 @@ export * from './lightbox-content-directives';
 export * from './lightbox-config';
 export * from './lightbox-ref';
 export * from './lightbox-animations';
+export { sbbLightboxAnimations } from './lightbox-animations';

--- a/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.css
+++ b/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.css
@@ -1,0 +1,3 @@
+button {
+  margin-right: 8px;
+}

--- a/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.html
+++ b/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.html
@@ -1,0 +1,4 @@
+<button sbb-secondary-button (click)="openDialog('2000ms', '1000ms')">Open dialog slowly</button>
+<button sbb-secondary-button (click)="openDialog('0ms', '0ms')">
+  Open dialog without animation
+</button>

--- a/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.ts
+++ b/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { SbbDialog, SbbDialogRef } from '@sbb-esta/angular/dialog';
+import { SbbDialog } from '@sbb-esta/angular/dialog';
 
 /**
  * @title Dialog Animations
@@ -33,6 +33,4 @@ export class DialogAnimationsExample {
     </div>
   `,
 })
-export class DialogAnimationsExampleDialog {
-  constructor(public dialogRef: SbbDialogRef<DialogAnimationsExampleDialog>) {}
-}
+export class DialogAnimationsExampleDialog {}

--- a/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.ts
+++ b/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+import { SbbDialog, SbbDialogRef } from '@sbb-esta/angular/dialog';
+
+/**
+ * @title Dialog Animations
+ * @order 40
+ */
+@Component({
+  selector: 'sbb-dialog-animations-example',
+  styleUrls: ['dialog-animations-example.css'],
+  templateUrl: 'dialog-animations-example.html',
+})
+export class DialogAnimationsExample {
+  constructor(public dialog: SbbDialog) {}
+
+  openDialog(enterAnimationDuration: string, exitAnimationDuration: string): void {
+    this.dialog.open(DialogAnimationsExampleDialog, {
+      width: '350px',
+      enterAnimationDuration,
+      exitAnimationDuration,
+    });
+  }
+}
+
+@Component({
+  selector: 'sbb-dialog-animations-example-dialog',
+  template: `
+    <div sbbDialogTitle>Delete file</div>
+    <div sbbDialogContent>Would you like to delete train.jpeg?</div>
+    <div sbbDialogActions>
+      <button sbb-button sbbDialogClose>Ok</button>
+      <button sbb-secondary-button sbbDialogClose>No</button>
+    </div>
+  `,
+})
+export class DialogAnimationsExampleDialog {
+  constructor(public dialogRef: SbbDialogRef<DialogAnimationsExampleDialog>) {}
+}

--- a/src/components-examples/angular/dialog/index.ts
+++ b/src/components-examples/angular/dialog/index.ts
@@ -10,6 +10,10 @@ import {
   ComponentDataDialogExample,
 } from './component-data-dialog/component-data-dialog-example';
 import {
+  DialogAnimationsExample,
+  DialogAnimationsExampleDialog,
+} from './dialog-animations/dialog-animations-example';
+import {
   SharedDataDialogComponent,
   SharedDataDialogExample,
 } from './shared-data-dialog/shared-data-dialog-example';
@@ -21,6 +25,8 @@ export {
   SharedDataDialogComponent,
   SharedDataDialogExample,
   TemplateDialogExample,
+  DialogAnimationsExample,
+  DialogAnimationsExampleDialog,
 };
 
 const EXAMPLES = [
@@ -29,6 +35,8 @@ const EXAMPLES = [
   SharedDataDialogComponent,
   SharedDataDialogExample,
   TemplateDialogExample,
+  DialogAnimationsExample,
+  DialogAnimationsExampleDialog,
 ];
 
 @NgModule({

--- a/src/components-examples/angular/lightbox/index.ts
+++ b/src/components-examples/angular/lightbox/index.ts
@@ -8,6 +8,10 @@ import { SbbLightboxModule } from '@sbb-esta/angular/lightbox';
 import { SbbRadioButtonModule } from '@sbb-esta/angular/radio-button';
 
 import {
+  LightboxAnimationsExample,
+  LightboxAnimationsExampleContent,
+} from './lightbox-animations/lightbox-animations-example';
+import {
   LightboxComponentExample,
   LightboxComponentExampleContent,
 } from './lightbox-component/lightbox-component-example';
@@ -26,6 +30,8 @@ export {
   LightboxConfirmationExample,
   LightboxWithConfirmationOnClose,
   LightboxTemplateExample,
+  LightboxAnimationsExample,
+  LightboxAnimationsExampleContent,
 };
 
 const EXAMPLES = [
@@ -36,6 +42,8 @@ const EXAMPLES = [
   LightboxConfirmationExample,
   LightboxWithConfirmationOnClose,
   LightboxTemplateExample,
+  LightboxAnimationsExample,
+  LightboxAnimationsExampleContent,
 ];
 
 @NgModule({

--- a/src/components-examples/angular/lightbox/lightbox-animations/lightbox-animations-example.css
+++ b/src/components-examples/angular/lightbox/lightbox-animations/lightbox-animations-example.css
@@ -1,0 +1,3 @@
+button {
+  margin-right: 8px;
+}

--- a/src/components-examples/angular/lightbox/lightbox-animations/lightbox-animations-example.html
+++ b/src/components-examples/angular/lightbox/lightbox-animations/lightbox-animations-example.html
@@ -1,0 +1,6 @@
+<button sbb-secondary-button (click)="openLightbox('2000ms', '1000ms')">
+  Open lightbox slowly
+</button>
+<button sbb-secondary-button (click)="openLightbox('0ms', '0ms')">
+  Open lightbox without animation
+</button>

--- a/src/components-examples/angular/lightbox/lightbox-animations/lightbox-animations-example.ts
+++ b/src/components-examples/angular/lightbox/lightbox-animations/lightbox-animations-example.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { SbbLightbox } from '@sbb-esta/angular/lightbox';
+
+/**
+ * @title Lightbox Animations
+ * @order 50
+ */
+@Component({
+  selector: 'sbb-lightbox-animations-example',
+  styleUrls: ['lightbox-animations-example.css'],
+  templateUrl: 'lightbox-animations-example.html',
+})
+export class LightboxAnimationsExample {
+  constructor(public lightbox: SbbLightbox) {}
+
+  openLightbox(enterAnimationDuration: string, exitAnimationDuration: string): void {
+    this.lightbox.open(LightboxAnimationsExampleContent, {
+      enterAnimationDuration,
+      exitAnimationDuration,
+    });
+  }
+}
+
+@Component({
+  selector: 'sbb-lightbox-animations-example-content',
+  template: `
+    <sbb-lightbox-title>
+      <span>Delete file</span>
+    </sbb-lightbox-title>
+    <sbb-lightbox-content>Would you like to delete train.jpeg?</sbb-lightbox-content>
+    <sbb-lightbox-actions>
+      <button sbb-button sbbLightboxClose>Ok</button>
+      <button sbb-secondary-button sbbLightboxClose>No</button>
+    </sbb-lightbox-actions>
+  `,
+})
+export class LightboxAnimationsExampleContent {}


### PR DESCRIPTION
Since the dialog animation is on the `SbbDialogContainer`, consumers aren't able to disable the animation. These changes add properties to the dialog config that allow consumers to set the duration of the dialog's enter and exit animations.

**Memo**: Merge #1287 first