### PR TITLE
fix(angular/datepicker): fix Voiceover losing focus on PageDown

### DIFF
--- a/src/angular/datepicker/calendar-body/calendar-body.ts
+++ b/src/angular/datepicker/calendar-body/calendar-body.ts
@@ -117,7 +117,7 @@ export class SbbCalendarBody implements AfterViewChecked {
    * Focuses the active cell after the microtask queue is empty.
    *
    * Adding a 0ms setTimeout seems to fix Voiceover losing focus when pressing PageUp/PageDown
-   * (issue #24330).
+   * (issue angular/components#24330).
    *
    * Determined a 0ms by gradually increasing duration from 0 and testing two use cases with screen
    * reader enabled:

--- a/src/angular/datepicker/calendar-body/calendar-body.ts
+++ b/src/angular/datepicker/calendar-body/calendar-body.ts
@@ -113,20 +113,43 @@ export class SbbCalendarBody implements AfterViewChecked {
     return cellNumber === this.activeCell;
   }
 
-  /** Focuses the active cell after the microtask queue is empty. */
+  /**
+   * Focuses the active cell after the microtask queue is empty.
+   *
+   * Adding a 0ms setTimeout seems to fix Voiceover losing focus when pressing PageUp/PageDown
+   * (issue #24330).
+   *
+   * Determined a 0ms by gradually increasing duration from 0 and testing two use cases with screen
+   * reader enabled:
+   *
+   * 1. Pressing PageUp/PageDown repeatedly with pausing between each key press.
+   * 2. Pressing and holding the PageDown key with repeated keys enabled.
+   *
+   * Test 1 worked roughly 95-99% of the time with 0ms and got a little bit better as the duration
+   * increased. Test 2 got slightly better until the duration was long enough to interfere with
+   * repeated keys. If the repeated key speed was faster than the timeout duration, then pressing
+   * and holding pagedown caused the entire page to scroll.
+   *
+   * Since repeated key speed can verify across machines, determined that any duration could
+   * potentially interfere with repeated keys. 0ms would be best because it almost entirely
+   * eliminates the focus being lost in Voiceover without causing unintended side effects.
+   * Adding delay also complicates writing tests.
+   */
   focusActiveCell() {
     this._ngZone.runOutsideAngular(() => {
       this._ngZone.onStable
         .asObservable()
         .pipe(take(1))
         .subscribe(() => {
-          const activeCell: HTMLElement | null = this._elementRef.nativeElement.querySelector(
-            '.sbb-calendar-body-active'
-          );
+          setTimeout(() => {
+            const activeCell: HTMLElement | null = this._elementRef.nativeElement.querySelector(
+              '.sbb-calendar-body-active'
+            );
 
-          if (activeCell) {
-            activeCell.focus();
-          }
+            if (activeCell) {
+              activeCell.focus();
+            }
+          });
         });
     });
   }

--- a/src/angular/datepicker/datepicker/datepicker.spec.ts
+++ b/src/angular/datepicker/datepicker/datepicker.spec.ts
@@ -523,7 +523,7 @@ describe('SbbDatepicker', () => {
         expect(toggle.getAttribute('type')).toBe('button');
       });
 
-      it('should restore focus to the toggle after the calendar is closed', () => {
+      it('should restore focus to the toggle after the calendar is closed', fakeAsync(() => {
         const toggle = fixture.debugElement.query(By.css('button')).nativeElement;
 
         fixture.detectChanges();
@@ -533,6 +533,7 @@ describe('SbbDatepicker', () => {
 
         fixture.componentInstance.datepicker.open();
         fixture.detectChanges();
+        tick();
 
         // tslint:disable-next-line:no-non-null-assertion
         const pane = document.querySelector('.cdk-overlay-pane')!;
@@ -544,11 +545,12 @@ describe('SbbDatepicker', () => {
 
         fixture.componentInstance.datepicker.close();
         fixture.detectChanges();
+        flush();
 
         expect(document.activeElement)
           .withContext('Expected focus to be restored to toggle.')
           .toBe(toggle);
-      });
+      }));
 
       it('should toggle the active state of the datepicker toggle', fakeAsync(() => {
         const toggle = fixture.debugElement.query(By.css('sbb-datepicker-toggle')).nativeElement;


### PR DESCRIPTION
Add a timeout before programmatically focusing cells on the calendar. This seems to fix an issue where Voiceover loses focus when pressing the PageDown/PageUp keys.