### PR TITLE
fix(angular/dialog): provide defaults for dialog animation

### DIFF
--- a/src/angular/dialog/dialog-animations.ts
+++ b/src/angular/dialog/dialog-animations.ts
@@ -11,6 +11,14 @@ import {
 } from '@angular/animations';
 
 /**
+ * Default parameters for the animation for backwards compatibility.
+ * @docs-private
+ */
+export const defaultParams = {
+  params: { enterAnimationDuration: '150ms', exitAnimationDuration: '75ms' },
+};
+
+/**
  * Animations used by SbbDialog.
  * @docs-private
  */
@@ -32,14 +40,16 @@ export const sbbDialogAnimations: {
           style({ transform: 'none', opacity: 1 })
         ),
         query('@*', animateChild(), { optional: true }),
-      ])
+      ]),
+      defaultParams
     ),
     transition(
       '* => void, * => exit',
       group([
         animate('{{exitAnimationDuration}} cubic-bezier(0.4, 0.0, 0.2, 1)', style({ opacity: 0 })),
         query('@*', animateChild(), { optional: true }),
-      ])
+      ]),
+      defaultParams
     ),
   ]),
 };

--- a/src/angular/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog-config.ts
@@ -1,6 +1,8 @@
 import { ScrollStrategy } from '@angular/cdk/overlay';
 import { ComponentFactoryResolver, ViewContainerRef } from '@angular/core';
 
+import { defaultParams } from './dialog-animations';
+
 /** Valid ARIA roles for a dialog element. */
 export type SbbDialogRole = 'dialog' | 'alertdialog';
 
@@ -108,10 +110,10 @@ export class SbbDialogConfig<D = any> {
   componentFactoryResolver?: ComponentFactoryResolver;
 
   /** Duration of the enter animation. Has to be a valid CSS value (e.g. 100ms). */
-  enterAnimationDuration?: string = '150ms';
+  enterAnimationDuration?: string = defaultParams.params.enterAnimationDuration;
 
   /** Duration of the exit animation. Has to be a valid CSS value (e.g. 50ms). */
-  exitAnimationDuration?: string = '75ms';
+  exitAnimationDuration?: string = defaultParams.params.exitAnimationDuration;
 
   // TODO(jelbourn): add configuration for lifecycle hooks, ARIA labelling.
 }

--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -25,7 +25,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 
-import { sbbDialogAnimations } from './dialog-animations';
+import { defaultParams, sbbDialogAnimations } from './dialog-animations';
 import { SbbDialogConfig } from './dialog-config';
 
 /** Event that captures the state of dialog container animations. */
@@ -299,8 +299,10 @@ export class SbbDialogContainer extends _SbbDialogContainerBase {
     return {
       value: this._state,
       params: {
-        enterAnimationDuration: this._config.enterAnimationDuration || '150ms',
-        exitAnimationDuration: this._config.exitAnimationDuration || '75ms',
+        enterAnimationDuration:
+          this._config.enterAnimationDuration || defaultParams.params.enterAnimationDuration,
+        exitAnimationDuration:
+          this._config.exitAnimationDuration || defaultParams.params.exitAnimationDuration,
       },
     };
   }

--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -299,9 +299,10 @@ export class SbbDialogContainer extends _SbbDialogContainerBase {
     return {
       value: this._state,
       params: {
-        'enterAnimationDuration':
+        // see https://github.com/angular/components/commit/575332c9296c28776376f4b4f7fb39c9743761aa
+        'enterAnimationDuration': // prettier-ignore
           this._config.enterAnimationDuration || defaultParams.params.enterAnimationDuration,
-        'exitAnimationDuration':
+        'exitAnimationDuration': // prettier-ignore
           this._config.exitAnimationDuration || defaultParams.params.exitAnimationDuration,
       },
     };

--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -299,7 +299,7 @@ export class SbbDialogContainer extends _SbbDialogContainerBase {
     return {
       value: this._state,
       params: {
-        // see https://github.com/angular/components/commit/575332c9296c28776376f4b4f7fb39c9743761aa
+        // See https://github.com/angular/components/commit/575332c9296c28776376f4b4f7fb39c9743761aa
         'enterAnimationDuration': // prettier-ignore
           this._config.enterAnimationDuration || defaultParams.params.enterAnimationDuration,
         'exitAnimationDuration': // prettier-ignore

--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -301,7 +301,7 @@ export class SbbDialogContainer extends _SbbDialogContainerBase {
       params: {
         enterAnimationDuration:
           this._config.enterAnimationDuration || defaultParams.params.enterAnimationDuration,
-        exitAnimationDuration:
+        'exitAnimationDuration':
           this._config.exitAnimationDuration || defaultParams.params.exitAnimationDuration,
       },
     };

--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -299,7 +299,7 @@ export class SbbDialogContainer extends _SbbDialogContainerBase {
     return {
       value: this._state,
       params: {
-        enterAnimationDuration:
+        'enterAnimationDuration':
           this._config.enterAnimationDuration || defaultParams.params.enterAnimationDuration,
         'exitAnimationDuration':
           this._config.exitAnimationDuration || defaultParams.params.exitAnimationDuration,

--- a/src/angular/dialog/public-api.ts
+++ b/src/angular/dialog/public-api.ts
@@ -4,4 +4,4 @@ export * from './dialog-container';
 export * from './dialog-content-directives';
 export * from './dialog-config';
 export * from './dialog-ref';
-export * from './dialog-animations';
+export { sbbDialogAnimations } from './dialog-animations';


### PR DESCRIPTION
Even though we provide defaults when we construct the animation object, some internal cases break because there are no defaults in the animation definition itself. These changes provide the defaults in the animation definition as well.