### PR TITLE
fix(angular/icon): clip overflowing icon elements

### DIFF
--- a/src/angular/icon/icon.scss
+++ b/src/angular/icon/icon.scss
@@ -5,6 +5,10 @@
   display: inline-block;
   line-height: 0;
 
+  // In some cases the icon elements may extend beyond the container. Clip these cases
+  // in order to avoid weird overflows and click areas. See angular/components#11826.
+  overflow: hidden;
+
   svg:not(.color-immutable) {
     [fill]:not([fill='none']) {
       fill: currentColor;


### PR DESCRIPTION
Clips any elements that are overflowing an icon. This avoids issues where parts of the icon could stick out and layouts.