### PR TITLE
fix(angular/datepicker): use cdk-visually-hidden on calendar header

### DIFF
--- a/src/angular/datepicker/datepicker.md
+++ b/src/angular/datepicker/datepicker.md
@@ -114,7 +114,7 @@ due to the timezone conversion.
 | ----------------------------- | ------------------------ |
 | new Date(2020, 0, 1, 0, 0, 0) | 2019-12-31T23:00:00.000Z |
 
-We recommend to convert the `Date` object to a string represation of only the date part.
+We recommend converting the `Date` object to a string representation of only the date part.
 
 | Usage examples | Format `yyyy-mm-dd`                                                                                                              |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/angular/datepicker/month-view/month-view.html
+++ b/src/angular/datepicker/month-view/month-view.html
@@ -1,7 +1,10 @@
 <table class="sbb-calendar-table">
   <thead class="sbb-calendar-table-header">
     <tr>
-      <th *ngFor="let day of weekdays" [attr.aria-label]="day.long">{{ day.narrow }}</th>
+      <th *ngFor="let day of weekdays">
+        <span class="cdk-visually-hidden">{{day.long}}</span>
+        <span aria-hidden="true">{{day.narrow}}</span>
+      </th>
     </tr>
     <tr>
       <th class="sbb-calendar-table-header-divider" colspan="7" aria-hidden="true"></th>


### PR DESCRIPTION
Use cdk-visually-hidden to announce the days of the week on the calendar header in screenreaders. Previously, this was done with an `aria-label` on the `th` element, but NVDA does not read aria-labels on table elements and well as some other static content.

Fix NVDA incorrectly announcing the days of the week as "M", "T", etc. instead of "Monday".