### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/angular/schematics/ng-add/migrations/merge-refactor/badge-migration.ts
+++ b/src/angular/schematics/ng-add/migrations/merge-refactor/badge-migration.ts
@@ -30,7 +30,7 @@ export class BadgeMigration extends RefactorMigration {
     element.recorder.remove(start + startTag.endOffset, endTag.startOffset - startTag.endOffset);
     const badge =
       content.startsWith('{{') && content.endsWith('}}')
-        ? `[sbbBadge]="${content.substr(2, content.length - 4).trim()}"`
+        ? `[sbbBadge]="${content.slice(2, content.length - 2).trim()}"`
         : `sbbBadge="${content}"`;
     element.recorder.remove(start + startTag.startOffset + 1, 9);
     element.recorder.insertRight(start + startTag.startOffset + 1, `span ${badge}`);

--- a/src/angular/schematics/ng-add/migrations/merge-refactor/processflow-migration.ts
+++ b/src/angular/schematics/ng-add/migrations/merge-refactor/processflow-migration.ts
@@ -27,7 +27,7 @@ export class ProcessflowMigration extends RefactorMigration {
 
     for (const property of element.properties()) {
       if (property.name.startsWith('#')) {
-        const name = property.name.substr(1);
+        const name = property.name.slice(1);
         const prevStepRegex = new RegExp(`${name}\\.prevStep()`, 'g');
         let match: RegExpMatchArray | null;
         while ((match = prevStepRegex.exec(element.resource.content))) {

--- a/src/angular/schematics/utils.ts
+++ b/src/angular/schematics/utils.ts
@@ -364,10 +364,7 @@ export class MigrationElement {
   }
 
   outerHtml() {
-    return this.resource.content.substr(
-      this.location.startOffset,
-      this.location.endOffset - this.location.startOffset
-    );
+    return this.resource.content.slice(this.location.startOffset, this.location.endOffset);
   }
 
   innerHtml() {
@@ -464,9 +461,6 @@ export class MigrationElementProperty {
   }
 
   toString() {
-    return this._element.resource.content.substr(
-      this.location.startOffset,
-      this.location.endOffset - this.location.startOffset
-    );
+    return this._element.resource.content.slice(this.location.startOffset, this.location.endOffset);
   }
 }

--- a/tools/dgeni/processors/entry-point-grouper.ts
+++ b/tools/dgeni/processors/entry-point-grouper.ts
@@ -229,7 +229,7 @@ export class EntryPointGrouper implements Processor {
   private _findMatchingEntryPoint(relativeFilePath: string): string | null {
     let foundEntryPoint: string | null = null;
     if (relativeFilePath.startsWith('../external/npm/node_modules/@angular')) {
-      return path.dirname(relativeFilePath.substr(29));
+      return path.dirname(relativeFilePath.slice(29));
     }
 
     for (const entryPoint of this.entryPoints) {

--- a/tools/markdown-to-html/docs-marked-renderer.ts
+++ b/tools/markdown-to-html/docs-marked-renderer.ts
@@ -53,7 +53,7 @@ export class DocsMarkdownRenderer extends Renderer {
 
     // Keep track of all fragments discovered in a file.
     if (href.startsWith('#')) {
-      this._referencedFragments.add(href.substr(1));
+      this._referencedFragments.add(href.slice(1));
     }
 
     return super.link(href, title, text);

--- a/tools/region-parser/region-parser.ts
+++ b/tools/region-parser/region-parser.ts
@@ -130,5 +130,5 @@ function leftAlign(lines: string[]): string[] {
       indent = Math.min(lineIndent, indent);
     }
   });
-  return lines.map((line) => line.substr(indent));
+  return lines.map((line) => line.slice(indent));
 }


### PR DESCRIPTION
.substr() is deprecated, so we replace it with .slice() which works similarly but isn't deprecated