### PR TITLE
fix(angular/autocomplete): always emit closed event

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -192,6 +192,7 @@ export class SbbAutocompleteTrigger
   get autocomplete(): SbbAutocomplete {
     return this._autocomplete;
   }
+
   set autocomplete(autocomplete: SbbAutocomplete) {
     this._autocomplete = autocomplete;
 
@@ -231,6 +232,7 @@ export class SbbAutocompleteTrigger
         }
       });
   }
+
   private _autocomplete: SbbAutocomplete;
 
   /**
@@ -262,6 +264,7 @@ export class SbbAutocompleteTrigger
   get autocompleteDisabled(): boolean {
     return this._autocompleteDisabled;
   }
+
   set autocompleteDisabled(value: BooleanInput) {
     this._autocompleteDisabled = coerceBooleanProperty(value);
   }
@@ -324,6 +327,7 @@ export class SbbAutocompleteTrigger
   get panelOpen(): boolean {
     return this._overlayAttached && this.autocomplete.showPanel;
   }
+
   private _overlayAttached: boolean = false;
 
   /** Opens the autocomplete suggestion panel. */
@@ -598,7 +602,7 @@ export class SbbAutocompleteTrigger
               }
 
               if (wasOpen !== this.panelOpen) {
-                // If the `panelOpen` state changed to, we need to make sure to emit the `opened` or
+                // If the `panelOpen` state changed, we need to make sure to emit the `opened` or
                 // `closed` event, because we may not have emitted it. This can happen
                 // - if the users opens the panel and there are no options, but the
                 //   options come in slightly later or as a result of the value changing,

--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -192,7 +192,6 @@ export class SbbAutocompleteTrigger
   get autocomplete(): SbbAutocomplete {
     return this._autocomplete;
   }
-
   set autocomplete(autocomplete: SbbAutocomplete) {
     this._autocomplete = autocomplete;
 
@@ -232,7 +231,6 @@ export class SbbAutocompleteTrigger
         }
       });
   }
-
   private _autocomplete: SbbAutocomplete;
 
   /**
@@ -264,7 +262,6 @@ export class SbbAutocompleteTrigger
   get autocompleteDisabled(): boolean {
     return this._autocompleteDisabled;
   }
-
   set autocompleteDisabled(value: BooleanInput) {
     this._autocompleteDisabled = coerceBooleanProperty(value);
   }
@@ -327,7 +324,6 @@ export class SbbAutocompleteTrigger
   get panelOpen(): boolean {
     return this._overlayAttached && this.autocomplete.showPanel;
   }
-
   private _overlayAttached: boolean = false;
 
   /** Opens the autocomplete suggestion panel. */

--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -595,13 +595,20 @@ export class SbbAutocompleteTrigger
 
               if (this.panelOpen) {
                 this._overlayRef!.updatePosition();
+              }
 
-                // If the `panelOpen` state changed, we need to make sure to emit the `opened`
-                // event, because we may not have emitted it when the panel was attached. This
-                // can happen if the users opens the panel and there are no options, but the
-                // options come in slightly later or as a result of the value changing.
-                if (wasOpen !== this.panelOpen) {
+              if (wasOpen !== this.panelOpen) {
+                // If the `panelOpen` state changed to, we need to make sure to emit the `opened` or
+                // `closed` event, because we may not have emitted it. This can happen
+                // - if the users opens the panel and there are no options, but the
+                //   options come in slightly later or as a result of the value changing,
+                // - if the panel is closed after the user entered a string that did not match any
+                //   of the available options,
+                // - if a valid string is entered after an invalid one.
+                if (this.panelOpen) {
                   this.autocomplete.opened.emit();
+                } else {
+                  this.autocomplete.closed.emit();
                 }
               }
             });

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -654,24 +654,21 @@ describe('SbbAutocomplete', () => {
         .toContain('Zwei');
     });
 
-    it(
-      'should show the panel when the first open is after the initial zone stabilization',
-      waitForAsync(() => {
-        // Note that we're running outside the Angular zone, in order to be able
-        // to test properly without the subscription from `_subscribeToClosingActions`
-        // giving us a false positive.
-        // tslint:disable-next-line:no-non-null-assertion
-        fixture.ngZone!.runOutsideAngular(() => {
-          fixture.componentInstance.trigger.openPanel();
+    it('should show the panel when the first open is after the initial zone stabilization', waitForAsync(() => {
+      // Note that we're running outside the Angular zone, in order to be able
+      // to test properly without the subscription from `_subscribeToClosingActions`
+      // giving us a false positive.
+      // tslint:disable-next-line:no-non-null-assertion
+      fixture.ngZone!.runOutsideAngular(() => {
+        fixture.componentInstance.trigger.openPanel();
 
-          Promise.resolve().then(() => {
-            expect(fixture.componentInstance.panel.showPanel)
-              .withContext(`Expected panel to be visible.`)
-              .toBe(true);
-          });
+        Promise.resolve().then(() => {
+          expect(fixture.componentInstance.panel.showPanel)
+            .withContext(`Expected panel to be visible.`)
+            .toBe(true);
         });
-      })
-    );
+      });
+    }));
 
     it('should close the panel when the user clicks away', fakeAsync(() => {
       dispatchFakeEvent(input, 'focusin');

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -3240,11 +3240,15 @@ describe('SbbAutocomplete', () => {
       typeInElement(input, 'Eins'); // Valid option
       fixture.detectChanges();
       tick();
-      expect(openedSpy).toHaveBeenCalledTimes(1);
 
-      typeInElement(input, 'Einss'); // Invalid option
+      expect(openedSpy).toHaveBeenCalledTimes(1);
+      expect(closedSpy).toHaveBeenCalledTimes(0);
+
+      typeInElement(input, '_x'); // Invalidate option to 'Eins_x'
       fixture.detectChanges();
       tick();
+
+      expect(openedSpy).toHaveBeenCalledTimes(1);
       expect(closedSpy).toHaveBeenCalledTimes(1);
     }));
 

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -654,21 +654,24 @@ describe('SbbAutocomplete', () => {
         .toContain('Zwei');
     });
 
-    it('should show the panel when the first open is after the initial zone stabilization', waitForAsync(() => {
-      // Note that we're running outside the Angular zone, in order to be able
-      // to test properly without the subscription from `_subscribeToClosingActions`
-      // giving us a false positive.
-      // tslint:disable-next-line:no-non-null-assertion
-      fixture.ngZone!.runOutsideAngular(() => {
-        fixture.componentInstance.trigger.openPanel();
+    it(
+      'should show the panel when the first open is after the initial zone stabilization',
+      waitForAsync(() => {
+        // Note that we're running outside the Angular zone, in order to be able
+        // to test properly without the subscription from `_subscribeToClosingActions`
+        // giving us a false positive.
+        // tslint:disable-next-line:no-non-null-assertion
+        fixture.ngZone!.runOutsideAngular(() => {
+          fixture.componentInstance.trigger.openPanel();
 
-        Promise.resolve().then(() => {
-          expect(fixture.componentInstance.panel.showPanel)
-            .withContext(`Expected panel to be visible.`)
-            .toBe(true);
+          Promise.resolve().then(() => {
+            expect(fixture.componentInstance.panel.showPanel)
+              .withContext(`Expected panel to be visible.`)
+              .toBe(true);
+          });
         });
-      });
-    }));
+      })
+    );
 
     it('should close the panel when the user clicks away', fakeAsync(() => {
       dispatchFakeEvent(input, 'focusin');
@@ -3230,6 +3233,21 @@ describe('SbbAutocomplete', () => {
       expect(numberCtrl.value).toBe('ei');
       expect(input.value).toBe('ei');
       expect(trigger.panelOpen).toBe(false);
+      expect(closedSpy).toHaveBeenCalledTimes(1);
+    }));
+
+    it('should emit a closed event if no option is displayed', fakeAsync(() => {
+      const { openedSpy, closedSpy } = fixture.componentInstance;
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+      typeInElement(input, 'Eins'); // Valid option
+      fixture.detectChanges();
+      tick();
+      expect(openedSpy).toHaveBeenCalledTimes(1);
+
+      typeInElement(input, 'Einss'); // Invalid option
+      fixture.detectChanges();
+      tick();
       expect(closedSpy).toHaveBeenCalledTimes(1);
     }));
 


### PR DESCRIPTION
This PR ensures that the `closed` event is emitted after the panel was closed by entering a string that did not match any option.

Closes #1274