### PR TITLE
fix(angular/checkbox): model value not updated when using toggle method

### DIFF
--- a/src/angular/checkbox/checkbox.spec.ts
+++ b/src/angular/checkbox/checkbox.spec.ts
@@ -740,7 +740,7 @@ describe('SbbCheckbox', () => {
     let inputElement: HTMLInputElement;
     let ngModel: NgModel;
 
-    beforeEach(() => {
+    beforeEach(fakeAsync(() => {
       fixture = createComponent(CheckboxWithNgModel);
 
       fixture.componentInstance.isRequired = false;
@@ -751,7 +751,7 @@ describe('SbbCheckbox', () => {
       checkboxInstance = checkboxDebugElement.componentInstance;
       inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
       ngModel = checkboxDebugElement.injector.get<NgModel>(NgModel);
-    });
+    }));
 
     it('should be pristine, untouched, and valid initially', () => {
       expect(ngModel.valid).toBe(true);
@@ -849,6 +849,17 @@ describe('SbbCheckbox', () => {
       expect(checkboxInstance.checked).toBe(false);
       expect(ngModel.valid).toBe(false);
     });
+
+    it('should update the ngModel value when using the `toggle` method', fakeAsync(() => {
+      const checkbox = fixture.debugElement.query(By.directive(SbbCheckbox)).componentInstance;
+
+      expect(fixture.componentInstance.isGood).toBe(false);
+
+      checkbox.toggle();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.isGood).toBe(true);
+    }));
   });
 
   describe('with name attribute', () => {

--- a/src/angular/checkbox/checkbox.ts
+++ b/src/angular/checkbox/checkbox.ts
@@ -271,6 +271,7 @@ export class _SbbCheckboxBase
   /** Toggles the `checked` state of the checkbox. */
   toggle(): void {
     this.checked = !this.checked;
+    this._controlValueAccessorChangeFn(this.checked);
   }
 
   /**
@@ -301,7 +302,7 @@ export class _SbbCheckboxBase
         });
       }
 
-      this.toggle();
+      this._checked = !this._checked;
 
       // Emit our custom change event if the native input emitted one.
       // It is important to only emit it, if the native input triggered one, because


### PR DESCRIPTION
The checkbox doesn't update its `ControlValueAccessor` value when it is toggled via the `toggle` method.