### PR TITLE
fix(angular/select): value set through property not being propagated to value accessor

### DIFF
--- a/src/angular/select/select.spec.ts
+++ b/src/angular/select/select.spec.ts
@@ -2947,6 +2947,17 @@ describe('SbbSelect', () => {
           .withContext(`Expected control to stay pristine after programmatic change.`)
           .toEqual(false);
       }));
+
+      it('should propagate the value set through the `value` property to the form field', fakeAsync(() => {
+        const control = fixture.componentInstance.control;
+
+        expect(control.value).toBeFalsy();
+
+        fixture.componentInstance.select.value = 'pizza-1';
+        fixture.detectChanges();
+
+        expect(control.value).toBe('pizza-1');
+      }));
     });
 
     describe('disabled behavior', () => {

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -408,13 +408,9 @@ export class SbbSelect
     return this._value;
   }
   set value(newValue: any) {
-    // Always re-assign an array, because it might have been mutated.
-    if (newValue !== this._value || (this._multiple && Array.isArray(newValue))) {
-      if (this.options) {
-        this._setSelectionByValue(newValue);
-      }
-
-      this._value = newValue;
+    const hasAssigned = this._assignValue(newValue);
+    if (hasAssigned) {
+      this._onChange(newValue);
     }
   }
   private _value: any;
@@ -679,7 +675,7 @@ export class SbbSelect
    * @param value New value to be written to the model.
    */
   writeValue(value: any): void {
-    this.value = value;
+    this._assignValue(value);
   }
 
   /**
@@ -897,10 +893,10 @@ export class SbbSelect
         throw getSbbSelectNonArrayValueError();
       }
 
-      value.forEach((currentValue: any) => this._selectValue(currentValue));
+      value.forEach((currentValue: any) => this._selectOptionByValue(currentValue));
       this._sortValues();
     } else {
-      const correspondingOption = this._selectValue(value);
+      const correspondingOption = this._selectOptionByValue(value);
 
       // Shift focus to the active item. Note that we shouldn't do this in multiple
       // mode, because we don't know what option the user interacted with last.
@@ -920,7 +916,7 @@ export class SbbSelect
    * Finds and selects and option based on its value.
    * @returns Option that has the corresponding value.
    */
-  private _selectValue(value: any): SbbOption | undefined {
+  private _selectOptionByValue(value: any): SbbOption | undefined {
     const correspondingOption = this.options.find((option: SbbOption) => {
       // Skip options that are already in the model. This allows us to handle cases
       // where the same primitive value is selected multiple times.
@@ -945,6 +941,20 @@ export class SbbSelect
     }
 
     return correspondingOption;
+  }
+
+  /** Assigns a specific value to the select. Returns whether the value has changed. */
+  private _assignValue(newValue: any | any[]): boolean {
+    // Always re-assign an array, because it might have been mutated.
+    if (newValue !== this._value || (this._multiple && Array.isArray(newValue))) {
+      if (this.options) {
+        this._setSelectionByValue(newValue);
+      }
+
+      this._value = newValue;
+      return true;
+    }
+    return false;
   }
 
   /** Sets up a key manager to listen to keyboard events on the overlay panel. */


### PR DESCRIPTION
Fixes values set through the `value` property not being propagated to the `value` in the `ControlValueAccessor`.