### PR TITLE
refactor(angular/form-field): allow AbstractControlDirective as MatFormFieldControl.ngControl

### DIFF
--- a/src/angular/form-field/form-field-control.ts
+++ b/src/angular/form-field/form-field-control.ts
@@ -1,4 +1,4 @@
-import { NgControl } from '@angular/forms';
+import { AbstractControlDirective, NgControl } from '@angular/forms';
 import { Observable } from 'rxjs';
 
 /** An interface which allows a control to work inside of a `SbbField`. */
@@ -12,8 +12,8 @@ export abstract class SbbFormFieldControl<TValue> {
   readonly stateChanges: Observable<void>;
   /** The id of the form field. */
   readonly id: string;
-  /** The attached NgControl, if any exists. */
-  readonly ngControl: NgControl | undefined;
+  /** The attached NgControl or AbstractControlDirective, if any exists. */
+  readonly ngControl: NgControl | AbstractControlDirective | undefined;
   /** Whether the control is focused. */
   readonly focused: boolean;
   /** Whether the control is empty. */

--- a/src/angular/form-field/form-field.ts
+++ b/src/angular/form-field/form-field.ts
@@ -14,7 +14,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { NgControl } from '@angular/forms';
+import { AbstractControlDirective } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 
@@ -132,10 +132,13 @@ export class SbbFormField implements AfterContentInit, AfterContentChecked, OnDe
     this._destroyed.complete();
   }
 
-  /** Determines whether a class from the NgControl should be forwarded to the host element. */
-  _shouldForward(prop: keyof NgControl): boolean {
-    const ngControl = this._control ? this._control.ngControl : null;
-    return ngControl && ngControl[prop];
+  /**
+   * Determines whether a class from the AbstractControlDirective
+   * should be forwarded to the host element.
+   */
+  _shouldForward(prop: keyof AbstractControlDirective): boolean {
+    const control = this._control ? this._control.ngControl : null;
+    return control && control[prop];
   }
 
   _hasLabel() {


### PR DESCRIPTION
Allows for an `AbstractControlDirective` to be passed in as the `SbbFormFieldControl.ngControl`. The advantage of passing in the abstract control directive is that it allows both form controls and form groups. This is necessary for the date range picker.