### PR TITLE
fix(angular/tabs): focus wrapping back to selected label when using shift + tab

### DIFF
--- a/src/angular/tabs/tab-group.spec.ts
+++ b/src/angular/tabs/tab-group.spec.ts
@@ -1,4 +1,4 @@
-import { LEFT_ARROW } from '@angular/cdk/keycodes';
+import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import { CommonModule } from '@angular/common';
 import { Component, DebugElement, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import {
@@ -313,6 +313,23 @@ describe('SbbTabGroup', () => {
       fixture.detectChanges();
 
       expect(tabHeader.focusIndex).not.toBe(3);
+    });
+
+    it('should update the tabindex of the labels when navigating via keyboard', () => {
+      fixture.detectChanges();
+
+      const tabLabels = fixture.debugElement
+        .queryAll(By.css('.sbb-tab-label'))
+        .map((label) => label.nativeElement);
+      const tabLabelContainer = fixture.debugElement.query(By.css('.sbb-tab-label-container'))
+        .nativeElement as HTMLElement;
+
+      expect(tabLabels.map((label) => label.getAttribute('tabindex'))).toEqual(['-1', '0', '-1']);
+
+      dispatchKeyboardEvent(tabLabelContainer, 'keydown', RIGHT_ARROW);
+      fixture.detectChanges();
+
+      expect(tabLabels.map((label) => label.getAttribute('tabindex'))).toEqual(['-1', '-1', '0']);
     });
   });
 

--- a/src/angular/tabs/tab-group.ts
+++ b/src/angular/tabs/tab-group.ts
@@ -67,6 +67,9 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
   /** The tab index that should be selected after the content has been checked. */
   private _indexToSelect: number | null = 0;
 
+  /** Index of the tab that was focused last. */
+  private _lastFocusedTabIndex: number | null = null;
+
   /** Snapshot of the height of the tab body wrapper before another tab is activated. */
   private _tabBodyWrapperHeight: number = 0;
 
@@ -231,6 +234,7 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
 
     if (this._selectedIndex !== indexToSelect) {
       this._selectedIndex = indexToSelect;
+      this._lastFocusedTabIndex = null;
       this._changeDetectorRef.markForCheck();
     }
   }
@@ -255,6 +259,7 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
             // event, otherwise the consumer may end up in an infinite loop in some edge cases like
             // adding a tab within the `selectedIndexChange` event.
             this._indexToSelect = this._selectedIndex = i;
+            this._lastFocusedTabIndex = null;
             break;
           }
         }
@@ -309,6 +314,7 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
   }
 
   _focusChanged(index: number) {
+    this._lastFocusedTabIndex = index;
     this.focusChange.emit(this._createChangeEvent(index));
   }
 
@@ -391,11 +397,12 @@ export abstract class SbbTabGroupBase implements AfterContentInit, AfterContentC
   }
 
   /** Retrieves the tabindex for the tab. */
-  _getTabIndex(tab: SbbTab, idx: number): number | null {
+  _getTabIndex(tab: SbbTab, index: number): number | null {
     if (tab.disabled) {
       return null;
     }
-    return this.selectedIndex === idx ? 0 : -1;
+    const targetIndex = this._lastFocusedTabIndex ?? this.selectedIndex;
+    return index === targetIndex ? 0 : -1;
   }
 
   /** Callback for when the focused state of a tab has changed. */


### PR DESCRIPTION
Currently, the `tabindex` of each of the tab labels is determined by the selected index. This means that if the user tabbed into the header, pressed the right arrow and then pressed shift + tab, their focus would end up on the selected tab. These changes switch to basing the `tabindex` on the focused index which is tied both to the selected index and the user's keyboard navigation.