### PR TITLE
ci: implement maintenance workflow

### DIFF
--- a/.github/workflows/maintenance-cherry-pick-workflow.yml
+++ b/.github/workflows/maintenance-cherry-pick-workflow.yml
@@ -1,0 +1,40 @@
+name: cherry-pick on maintenance branch
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cherry_pick:
+    runs-on: ubuntu-latest
+    outputs:
+      output: ${{ steps.cherry_pick.outputs.output }}
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'target: maintenance')
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: "Cherry-pick changes into maintenance"
+      id: cherry_pick
+      run: |
+        git checkout maintenance
+        echo "::set-output name=output::$(git -c user.name="cherry.picker" \
+          -c user.email="cherry.picker@sbb.ch" cherry-pick ${{ github.sha }} | xargs)"
+        git push
+  update_maintenance_issue:
+    runs-on: ubuntu-latest
+    needs: cherry_pick
+    if: ${{ contains(needs.cherry_pick.outputs.output, 'CONFLICT') }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - uses: ./.github/actions/yarn-install
+    - name: "Update maintenance issue"
+      run: yarn ts-node scripts/update-maintenance-issue.ts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/maintenance-tagging-workflow.yml
+++ b/.github/workflows/maintenance-tagging-workflow.yml
@@ -1,0 +1,26 @@
+name: Add or remove maintenance labels
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: "Get @breaking-change annotation counts"
+      id: deprecations
+      run: echo "::set-output name=count::$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | egrep "^\+" | grep '@breaking-change' -c)"
+    - name: "Add maintenance label"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: steps.deprecations.outputs.count == '0'
+      with:
+        labels: "target: maintenance"
+    - name: "Remove maintenance label"
+      uses: actions-ecosystem/action-remove-labels@v1
+      if: steps.deprecations.outputs.count != '0'
+      with:
+        labels: "target: maintenance"

--- a/scripts/update-maintenance-issue.ts
+++ b/scripts/update-maintenance-issue.ts
@@ -1,0 +1,61 @@
+import { Octokit } from 'octokit';
+
+const githubToken = process.env['GITHUB_TOKEN'];
+const pullRequestNumber = parseInt(process.env['PR_NUMBER']!, 10);
+
+const repoConfig = {
+  owner: 'sbb-design-systems',
+  repo: 'sbb-angular',
+};
+
+const issuePath = {
+  ...repoConfig,
+  issue_number: 1346,
+};
+
+const prPath = {
+  ...repoConfig,
+  pull_number: pullRequestNumber,
+};
+
+export class MaintenanceIssueUpdater {
+  constructor(private _octokit: Octokit, private _now: Date) {}
+
+  async run() {
+    const issue = await this._octokit.rest.issues.get(issuePath);
+    const pr = await this._octokit.rest.pulls.get(prPath);
+
+    if (!issue.data.body) {
+      throw new Error('Could not load issue body');
+    }
+
+    if (!pr.data.title || !pr.data.html_url) {
+      throw new Error('Could not load pull request');
+    }
+
+    const hint = '**Unable to merge the following pull requests into the maintenance branch**';
+    const dateInfo = `${this._now.toISOString()}`;
+    let openTasks = this._extractOpenTasks(issue.data.body);
+    openTasks.push(`- [ ] [${pr.data.title}](${pr.data.html_url})`);
+    openTasks = [...new Set(openTasks)];
+
+    return this._octokit.rest.issues.update({
+      ...issuePath,
+      body: `${hint}\r\n${openTasks.join('\r\n')}\r\n${dateInfo}`,
+    });
+  }
+
+  private _extractOpenTasks(issueBody: string = ''): string[] {
+    return issueBody.split('\r\n').filter((line) => line.startsWith('- [ ]'));
+  }
+}
+
+if (module === require.main) {
+  const maintenanceIssueUpdater = new MaintenanceIssueUpdater(
+    new Octokit({
+      auth: githubToken,
+    }),
+    new Date()
+  );
+  maintenanceIssueUpdater.run();
+}


### PR DESCRIPTION
This pull request uses GitHub actions to
- check for `@breaking-change` annotations
- add the "target: maintenance" label if the pr is not a breaking change
- cherry-picks non-breaking changes into the maintenance branch
- collects failed cherry-picks in an issue