### PR TITLE
fix(angular/tabs): wrong scroll distance if selected tab is removed

### DIFF
--- a/src/angular/tabs/paginated-tab-header.ts
+++ b/src/angular/tabs/paginated-tab-header.ts
@@ -233,7 +233,16 @@ export abstract class SbbPaginatedTabHeader
         // We need to defer this to give the browser some time to recalculate
         // the element dimensions. The call has to be wrapped in `NgZone.run`,
         // because the viewport change handler runs outside of Angular.
-        this._ngZone.run(() => Promise.resolve().then(realign));
+        this._ngZone.run(() => {
+          Promise.resolve().then(() => {
+            // Clamp the scroll distance, because it can change with the number of tabs.
+            this._scrollDistance = Math.max(
+              0,
+              Math.min(this._getMaxScrollDistance(), this._scrollDistance)
+            );
+            realign();
+          });
+        });
       });
 
     // If there is a change in the focus key manager we need to emit the `indexFocused`

--- a/src/angular/tabs/tab-header.spec.ts
+++ b/src/angular/tabs/tab-header.spec.ts
@@ -277,6 +277,28 @@ describe('SbbTabHeader', () => {
         fixture.detectChanges();
         expect(appComponent.tabHeader.scrollDistance).toBe(0);
       });
+
+      it('should update the scroll distance if a tab is removed and no tabs are selected', fakeAsync(() => {
+        appComponent.selectedIndex = 0;
+        appComponent.addTabsForScrolling();
+        fixture.detectChanges();
+
+        // Focus the last tab so the header scrolls to the end.
+        appComponent.tabHeader.focusIndex = appComponent.tabs.length - 1;
+        fixture.detectChanges();
+        expect(appComponent.tabHeader.scrollDistance).toBe(
+          appComponent.tabHeader._getMaxScrollDistance()
+        );
+
+        // Remove the first two tabs which includes the selected tab.
+        appComponent.tabs = appComponent.tabs.slice(2);
+        fixture.detectChanges();
+        tick();
+
+        expect(appComponent.tabHeader.scrollDistance).toBe(
+          appComponent.tabHeader._getMaxScrollDistance()
+        );
+      }));
     });
 
     describe('scrolling when holding paginator', () => {


### PR DESCRIPTION
Fixes the case where the user has scrolled to the end of the tab list and the selected tab from the beginning is removed. Since we no longer have a selected tab, the scroll distance wasn't being updated.