### PR TITLE
fix(angular/datepicker): avoid rerender when min/maxDate changes to different time on the same day

### DIFF
--- a/src/angular/datepicker/calendar/calendar.spec.ts
+++ b/src/angular/datepicker/calendar/calendar.spec.ts
@@ -266,6 +266,16 @@ describe('SbbCalendar', () => {
       expect(calendarInstance.monthView.init).toHaveBeenCalled();
     });
 
+    it('should not re-render the month view when the minDate changes to the same day at a different time', () => {
+      fixture.detectChanges();
+      spyOn(calendarInstance.monthView, 'init').and.callThrough();
+
+      testComponent.minDate = new Date(2016, JAN, 1, 0, 0, 0, 1);
+      fixture.detectChanges();
+
+      expect(calendarInstance.monthView.init).not.toHaveBeenCalled();
+    });
+
     it('should re-render the month view when the maxDate changes', () => {
       fixture.detectChanges();
       spyOn(calendarInstance.monthView, 'init').and.callThrough();

--- a/src/angular/datepicker/calendar/calendar.ts
+++ b/src/angular/datepicker/calendar/calendar.ts
@@ -281,7 +281,7 @@ export class SbbCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   ngOnChanges(changes: SimpleChanges) {
     // Ignore date changes that are at a different time on the same day. This fixes issues where
     // the calendar re-renders when there is no meaningful change to [minDate] or [maxDate]
-    // (#24435).
+    // (angular/components#24435).
     const minDateChange: SimpleChange | undefined =
       changes['minDate'] &&
       !this._dateAdapter.sameDate(changes['minDate'].previousValue, changes['minDate'].currentValue)

--- a/src/angular/datepicker/calendar/calendar.ts
+++ b/src/angular/datepicker/calendar/calendar.ts
@@ -16,6 +16,7 @@ import {
   OnDestroy,
   Optional,
   Output,
+  SimpleChange,
   SimpleChanges,
   ViewChild,
   ViewEncapsulation,
@@ -278,7 +279,21 @@ export class SbbCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    const change = changes.minDate || changes.maxDate || changes.dateFilter;
+    // Ignore date changes that are at a different time on the same day. This fixes issues where
+    // the calendar re-renders when there is no meaningful change to [minDate] or [maxDate]
+    // (#24435).
+    const minDateChange: SimpleChange | undefined =
+      changes['minDate'] &&
+      !this._dateAdapter.sameDate(changes['minDate'].previousValue, changes['minDate'].currentValue)
+        ? changes['minDate']
+        : undefined;
+    const maxDateChange: SimpleChange | undefined =
+      changes['maxDate'] &&
+      !this._dateAdapter.sameDate(changes['maxDate'].previousValue, changes['maxDate'].currentValue)
+        ? changes['maxDate']
+        : undefined;
+
+    const change = minDateChange || maxDateChange || changes['dateFilter'];
 
     if (change && !change.firstChange) {
       const view = this._getCurrentViewComponent();


### PR DESCRIPTION
Avoid re-rendering when the [minDate] or [maxDate]
Input change to a different time on the same day.

In ngOnChanges, do not call init if the previous and current value for
minDate/maxDate are on the same day.