### PR TITLE
refactor(angular/dialog): use embedded injector to provide ref to template dialogs

### DIFF
--- a/src/angular/dialog/dialog-content-directives.ts
+++ b/src/angular/dialog/dialog-content-directives.ts
@@ -204,6 +204,10 @@ export class SbbDialogActions {
   @Input() align?: 'start' | 'center' | 'end' = 'end';
 }
 
+// TODO(crisbeto): this utility shouldn't be necessary anymore, because the dialog ref is provided
+// both to component and template dialogs through DI. We need to keep it around, because there are
+// some internal wrappers around `SbbDialog` that happened to work by accident, because we had this
+// fallback logic in place.
 /**
  * Finds the closest SbbDialogRef to an element by looking at the DOM.
  * @param element Element relative to which to look for a dialog.

--- a/src/angular/dialog/dialog.ts
+++ b/src/angular/dialog/dialog.ts
@@ -271,6 +271,7 @@ export abstract class _SbbDialogBase<
           <any>{
             $implicit: config.data,
             dialogRef,
+            lightboxRef: dialogRef,
           },
           injector
         )

--- a/src/angular/dialog/dialog.ts
+++ b/src/angular/dialog/dialog.ts
@@ -261,17 +261,21 @@ export abstract class _SbbDialogBase<
     // Create a reference to the dialog we're creating in order to give the user a handle
     // to modify and close it.
     const dialogRef = new this._dialogRefConstructor(overlayRef, dialogContainer, config.id);
+    const injector = this._createInjector<T>(config, dialogRef, dialogContainer);
 
     if (componentOrTemplateRef instanceof TemplateRef) {
       dialogContainer.attachTemplatePortal(
-        new TemplatePortal<T>(componentOrTemplateRef, null!, <any>{
-          $implicit: config.data,
-          dialogRef,
-          lightboxRef: dialogRef,
-        })
+        new TemplatePortal<T>(
+          componentOrTemplateRef,
+          null!,
+          <any>{
+            $implicit: config.data,
+            dialogRef,
+          },
+          injector
+        )
       );
     } else {
-      const injector = this._createInjector<T>(config, dialogRef, dialogContainer);
       const contentRef = dialogContainer.attachComponentPortal<T>(
         new ComponentPortal(
           componentOrTemplateRef,

--- a/src/angular/lightbox/lightbox.spec.ts
+++ b/src/angular/lightbox/lightbox.spec.ts
@@ -1963,7 +1963,7 @@ class ModuleBoundLightboxParentComponent {
   }
 }
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 class ModuleBoundLightboxService {
   name = 'Pasta';
 }


### PR DESCRIPTION
Previously we had to walk the DOM in order to figure out which dialog ref belonged to a specific template dialog. We no longer need to do that if we provide an injector to the template portal.