### PR TITLE
refactor(angular/core): no longer define stateChanges in `mixinErrorState`

### DIFF
--- a/src/angular/chips/chip-list.ts
+++ b/src/angular/chips/chip-list.ts
@@ -33,11 +33,22 @@ import { SBB_CHIP, SBB_CHIP_LIST } from './chip-tokens';
 // tslint:disable-next-line:naming-convention
 const _SbbChipListBase = mixinErrorState(
   class {
+    /**
+     * Emits whenever the component state changes and should cause the parent
+     * form-field to update. Implemented as part of `SbbFormFieldControl`.
+     * @docs-private
+     */
+    readonly stateChanges = new Subject<void>();
+
     constructor(
       public _defaultErrorStateMatcher: SbbErrorStateMatcher,
       public _parentForm: NgForm,
       public _parentFormGroup: FormGroupDirective,
-      /** @docs-private */
+      /**
+       * Form control bound to the component.
+       * Implemented as part of `SbbFormFieldControl`.
+       * @docs-private
+       */
       public ngControl: NgControl
     ) {}
   }

--- a/src/angular/core/common-behaviors/error-state.ts
+++ b/src/angular/core/common-behaviors/error-state.ts
@@ -7,18 +7,28 @@ import { AbstractConstructor, Constructor } from './constructor';
 
 /** @docs-private */
 export interface CanUpdateErrorState {
-  readonly stateChanges: Subject<void>;
-  errorState: boolean;
-  errorStateMatcher: SbbErrorStateMatcher;
+  /** Updates the error state based on the provided error state matcher. */
   updateErrorState(): void;
+  /** Whether the component is in an error state. */
+  errorState: boolean;
+  /** An object used to control the error state of the component. */
+  errorStateMatcher: SbbErrorStateMatcher;
 }
+
+type CanUpdateErrorStateCtor = Constructor<CanUpdateErrorState> &
+  AbstractConstructor<CanUpdateErrorState>;
 
 /** @docs-private */
 export interface HasErrorState {
   _parentFormGroup: FormGroupDirective;
   _parentForm: NgForm;
   _defaultErrorStateMatcher: SbbErrorStateMatcher;
+
+  // These properties are defined as per the `SbbFormFieldControl` interface. Since
+  // this mixin is commonly used with custom form-field controls, we respect the
+  // properties (also with the public name they need according to `SbbFormFieldControl`).
   ngControl: NgControl;
+  stateChanges: Subject<void>;
 }
 
 /**
@@ -27,22 +37,18 @@ export interface HasErrorState {
  */
 export function mixinErrorState<T extends AbstractConstructor<HasErrorState>>(
   base: T
-): AbstractConstructor<CanUpdateErrorState> & T;
+): CanUpdateErrorStateCtor & T;
 export function mixinErrorState<T extends Constructor<HasErrorState>>(
   base: T
-): Constructor<CanUpdateErrorState> & T {
+): CanUpdateErrorStateCtor & T {
   return class extends base {
     /** Whether the component is in an error state. */
     errorState: boolean = false;
 
-    /**
-     * Stream that emits whenever the state of the input changes such that the wrapping
-     * `SbbField` needs to run change detection.
-     */
-    readonly stateChanges = new Subject<void>();
-
+    /** An object used to control the error state of the component. */
     errorStateMatcher: SbbErrorStateMatcher;
 
+    /** Updates the error state based on the provided error state matcher. */
     updateErrorState() {
       const oldState = this.errorState;
       const parent = this._parentFormGroup || this._parentForm;

--- a/src/angular/input/input.ts
+++ b/src/angular/input/input.ts
@@ -18,6 +18,7 @@ import {
 import { FormGroupDirective, NgControl, NgForm } from '@angular/forms';
 import { CanUpdateErrorState, mixinErrorState, SbbErrorStateMatcher } from '@sbb-esta/angular/core';
 import { SbbFormFieldControl } from '@sbb-esta/angular/form-field';
+import { Subject } from 'rxjs';
 
 import { getSbbInputUnsupportedTypeError } from './input-errors';
 import { SBB_INPUT_VALUE_ACCESSOR } from './input-value-accessor';
@@ -40,11 +41,22 @@ const SBB_INPUT_INVALID_TYPES = [
 // tslint:disable-next-line:naming-convention
 const _SbbInputBase = mixinErrorState(
   class {
+    /**
+     * Emits whenever the component state changes and should cause the parent
+     * form-field to update. Implemented as part of `SbbFormFieldControl`.
+     * @docs-private
+     */
+    readonly stateChanges = new Subject<void>();
+
     constructor(
       public _defaultErrorStateMatcher: SbbErrorStateMatcher,
       public _parentForm: NgForm,
       public _parentFormGroup: FormGroupDirective,
-      /** @docs-private */
+      /**
+       * Form control bound to the component.
+       * Implemented as part of `SbbFormFieldControl`.
+       * @docs-private
+       */
       public ngControl: NgControl
     ) {}
   }

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -150,10 +150,22 @@ const _SbbSelectMixinBase = mixinTabIndex(
     mixinErrorState(
       mixinVariant(
         class {
+          /**
+           * Emits whenever the component state changes and should cause the parent
+           * form-field to update. Implemented as part of `SbbFormFieldControl`.
+           * @docs-private
+           */
+          readonly stateChanges = new Subject<void>();
+
           constructor(
             public _defaultErrorStateMatcher: SbbErrorStateMatcher,
             public _parentForm: NgForm,
             public _parentFormGroup: FormGroupDirective,
+            /**
+             * Form control bound to the component.
+             * Implemented as part of `SbbFormFieldControl`.
+             * @docs-private
+             */
             public ngControl: NgControl
           ) {}
         }

--- a/src/angular/textarea/textarea/textarea.ts
+++ b/src/angular/textarea/textarea/textarea.ts
@@ -33,10 +33,22 @@ let nextId = 0;
 // tslint:disable-next-line: naming-convention
 const _SbbTextareaMixinBase = mixinErrorState(
   class {
+    /**
+     * Emits whenever the component state changes and should cause the parent
+     * form-field to update. Implemented as part of `SbbFormFieldControl`.
+     * @docs-private
+     */
+    readonly stateChanges = new Subject<void>();
+
     constructor(
       public _defaultErrorStateMatcher: SbbErrorStateMatcher,
       public _parentForm: NgForm,
       public _parentFormGroup: FormGroupDirective,
+      /**
+       * Form control bound to the component.
+       * Implemented as part of `SbbFormFieldControl`.
+       * @docs-private
+       */
       public ngControl: NgControl
     ) {}
   }


### PR DESCRIPTION
The error state mixin provided in `@sbb-esta/angular/core` currently
defines the `stateChanges` class member as part of the mixin. This
is unexpected as consumers might deal with the `stateChanges` member
differently. e.g. in some components the `stateChanges` field is
intended to show up in the docs, or the JSDoc description varies. e.g.
the observable could emit whenever form-field state changes, and it
should be updated, or it emits always when something changes (e.g.
even a component input which is not relevant for the form-field
control).

In general, we want to avoid this member being defined in the mixin
as the mixin is rather about the error state, and not defining a
subject that can emit whenever "state" changes.

BREAKING CHANGE: Previously the `mixinErrorState` mixin function defined
a class member for `stateChanges`. This is no longer the case, and consumers
need to provide the `stateChanges` class member themselves.