### PR TITLE
build: ship schematics as es2020 similar to rest of the APF

### DIFF
--- a/src/angular-experimental/schematics/BUILD.bazel
+++ b/src/angular-experimental/schematics/BUILD.bazel
@@ -25,9 +25,7 @@ ts_library(
     # Schematics do not need to run in browsers and can use `commonjs`
     # as format instead the default `umd` format.
     devmode_module = "commonjs",
-    devmode_target = "es2015",
     prodmode_module = "commonjs",
-    prodmode_target = "es2015",
     tsconfig = ":tsconfig.json",
     deps = [
         "@npm//@angular/cdk",

--- a/src/angular/schematics/BUILD.bazel
+++ b/src/angular/schematics/BUILD.bazel
@@ -26,9 +26,7 @@ ts_library(
     # Schematics do not need to run in browsers and can use `commonjs`
     # as format instead the default `umd` format.
     devmode_module = "commonjs",
-    devmode_target = "es2015",
     prodmode_module = "commonjs",
-    prodmode_target = "es2015",
     tsconfig = ":tsconfig.json",
     deps = [
         "@npm//@angular/cdk",


### PR DESCRIPTION
As part of v13, we manually added the prodmode/devmode target to schematic
build targets and set it to `es2015`. This was done since we still supported
NodeJS v12. This is no longer the case with v14 and we already removed the
NodeJS v12 integration test, so we can also remove the target override.