### PR TITLE
fix(angular/autocomplete): prevent clean-up from repeatedly being called

### DIFF
--- a/src/components-examples/angular/autocomplete/autocomplete-option-group/autocomplete-option-group-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-option-group/autocomplete-option-group-example.ts
@@ -24,7 +24,7 @@ export class AutocompleteOptionGroupExample implements OnInit {
       debounceTime(500),
       distinctUntilChanged(),
       map((newValue) =>
-        newValue.length <= 2
+        newValue.length < 2
           ? []
           : options.filter(
               (option) => option.toLocaleUpperCase().indexOf(newValue.toLocaleUpperCase()) > -1


### PR DESCRIPTION
Previously we called clean-up (and option highlighting) on each zone.js
onStable emit. This caused a near constant loop of the functionality
being called on large applications. We fixed this by limiting the call
to just the next onStable emit and removing it entirely for the clean-up
as it is not necessary there.