### PR TITLE
fix(angular/chips): prevent default behavior on remove button

### DIFF
--- a/src/angular/chips/chip-remove.spec.ts
+++ b/src/angular/chips/chip-remove.spec.ts
@@ -1,6 +1,7 @@
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { dispatchMouseEvent } from '@sbb-esta/angular/core/testing';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
 import { SbbIconTestingModule } from '@sbb-esta/angular/icon/testing';
 
@@ -77,6 +78,14 @@ describe('Chip Remove', () => {
       fixture.detectChanges();
 
       expect(testChip.didRemove).not.toHaveBeenCalled();
+    });
+
+    it('should prevent the default click action', () => {
+      const buttonElement = chipNativeElement.querySelector('button')!;
+      const event = dispatchMouseEvent(buttonElement, 'click');
+      fixture.detectChanges();
+
+      expect(event.defaultPrevented).toBe(true);
     });
   });
 

--- a/src/angular/chips/chip.ts
+++ b/src/angular/chips/chip.ts
@@ -319,5 +319,6 @@ export class SbbChipRemove {
     // the parent click listener of the `SbbChip` would prevent propagation, but it can happen
     // that the chip is being removed before the event bubbles up.
     event.stopPropagation();
+    event.preventDefault();
   }
 }

--- a/src/angular/input/BUILD.bazel
+++ b/src/angular/input/BUILD.bazel
@@ -21,6 +21,7 @@ ng_module(
         "@npm//@angular/cdk",
         "@npm//@angular/core",
         "@npm//@angular/forms",
+        "@npm//rxjs",
     ],
 )
 


### PR DESCRIPTION
Adds a `preventDefault` call to the `click` handlers of the chip remove icon in order to avoid things like form submissions and link navigations.