### PR TITLE
docs(angular/chips): use correct terminology

### DIFF
--- a/src/angular/chips/chip-list.ts
+++ b/src/angular/chips/chip-list.ts
@@ -282,7 +282,7 @@ export class SbbChipList
    */
   @Output() readonly valueChange = new EventEmitter<any>();
 
-  /** The chip components contained within this chip list. */
+  /** The chips contained within this chip list. */
   @ContentChildren(SBB_CHIP, {
     // We need to use `descendants: true`, because Ivy will no longer match
     // indirect descendants if it's left as false.

--- a/src/angular/chips/chip.ts
+++ b/src/angular/chips/chip.ts
@@ -71,9 +71,7 @@ const _SbbChipMixinBase = mixinTabIndex(SbbChipBase, -1);
 })
 export class SbbChipTrailingIcon {}
 
-/**
- * Design styled Chip component. Used inside the SbbChipList component.
- */
+/** SBB Design styled chip directive. Used inside the MatChipList component. */
 @Component({
   selector: `sbb-basic-chip, [sbb-basic-chip], sbb-chip, [sbb-chip]`,
   inputs: ['tabIndex'],


### PR DESCRIPTION
Fixes that we were referring to `SbbChip` as a component even though it's a directive.