### PR TITLE
fix(angular/autocomplete): outside click in Angular zone

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -349,7 +349,12 @@ export class SbbAutocompleteTrigger
 
     if (this.panelOpen) {
       // Only emit if the panel was visible.
-      this.autocomplete.closed.emit();
+      // The `NgZone.onStable` always emits outside of the Angular zone,
+      // so all the subscriptions from `_subscribeToClosingActions()` are also outside of the Angular zone.
+      // We should manually run in Angular zone to update UI after panel closing.
+      this._zone.run(() => {
+        this.autocomplete.closed.emit();
+      });
     }
 
     this.autocomplete._isOpen = this._overlayAttached = false;

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -3781,6 +3781,31 @@ describe('SbbAutocomplete', () => {
     expect(fixture.componentInstance.trigger.panelOpen).toBe(true);
   });
 
+  it('should emit from `autocomplete.closed` after click outside inside the NgZone', fakeAsync(() => {
+    const inZoneSpy = jasmine.createSpy('in zone spy');
+
+    const fixture = createComponent(SimpleAutocomplete, [
+      { provide: NgZone, useFactory: () => new NgZone({ enableLongStackTrace: false }) },
+    ]);
+    const ngZone = TestBed.inject(NgZone);
+    fixture.detectChanges();
+
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    flush();
+
+    const subscription = fixture.componentInstance.trigger.autocomplete.closed.subscribe(() =>
+      inZoneSpy(NgZone.isInAngularZone())
+    );
+    ngZone.onStable.emit(null);
+
+    dispatchFakeEvent(document, 'click');
+
+    expect(inZoneSpy).toHaveBeenCalledWith(true);
+
+    subscription.unsubscribe();
+  }));
+
   describe('highlighting', () => {
     let fixture: ComponentFixture<AutocompleteLocaleNormalizer>;
     let input: HTMLInputElement;


### PR DESCRIPTION
Fixes a bug in `autocomplete` when outside click doesn't trigger `changeDetection`.