### PR TITLE
fix(angular/select): don't announce selected value multiple times

### DIFF
--- a/src/angular/select/select.html
+++ b/src/angular/select/select.html
@@ -2,6 +2,7 @@
   [attr.id]="_valueId"
   [ngSwitch]="empty"
   class="sbb-select-value"
+  aria-hidden="true"
   [class.sbb-select-value-empty]="empty"
 >
   <span *ngSwitchCase="true" class="sbb-select-placeholder"


### PR DESCRIPTION
Screen readers announce the selected value multiple times. NVDA e.g. reads "Favorite food Pizza Pizza combobox Pizza collapsed".

1. First, the Screen Reader (SR) reads the value of the label (see 1st `aria-labelledby`): "Favorite food"
2. SR reads the content of the combobox: "Pizza"
3. SR reads the value of the combobox (see 2nd `aria-labelledby`): "Pizza"
4. SR reads the content of the combobox again: "Pizza"

To fix this, an `aria-hidden` attribute is added to the element containing the selected value. NVDA e.g. now reads "Favorite food Pizza combobox collapsed".

Successfully tested with NVDA, JAWS, Narrator and the _Screen Reader_ Chrome plugin.

Closes #1385