### PR TITLE
fix: make stackblitz examples working again

### DIFF
--- a/src/showcase/assets/BUILD.bazel
+++ b/src/showcase/assets/BUILD.bazel
@@ -55,7 +55,6 @@ genrule(
       ./$(execpath //tools/stack-blitz-module-template:bazel-bin) \
           "$(execpath stack-blitz/src/app/sbb.module.ts)" \
           "@sbb-esta/angular" \
-          "@sbb-esta/journey-maps" \
           %s
     """ % " ".join([ep for ep in ANGULAR_ENTRYPOINTS if ep != "core" and ep != "i18n" and ep != "oauth"]),
     output_to_bindir = True,


### PR DESCRIPTION
The StackBlitz examples are not working anymore due to the journey-maps integration. Since journey-maps does not use StackBlitz, the integration is removed by this PR.