### PR TITLE
fix(angular/datepicker): add ability to have numeric zero value in input

### DIFF
--- a/src/angular/datepicker/date-input/date-input.directive.ts
+++ b/src/angular/datepicker/date-input/date-input.directive.ts
@@ -369,9 +369,8 @@ export class SbbDateInput<D> implements ControlValueAccessor, Validator, OnInit,
 
   /** Formats a value and sets it on the input element. */
   private _formatValue(value: D | null) {
-    this._elementRef.nativeElement.value = value
-      ? this._dateAdapter.format(value, this._dateFormats.dateInput)
-      : '';
+    this._elementRef.nativeElement.value =
+      value != null ? this._dateAdapter.format(value, this._dateFormats.dateInput) : '';
   }
 
   /**


### PR DESCRIPTION
Shows valid formatted value for 'falsy' values (exp 0)
Custom DateAdapter (exp TimestampDateAdapter) can have valid numeric 0 value (for timestamp it is 1/1/1970), but datepicker input doesn't show formatted value