### PR TITLE
chore: remove angular-t9n from renovate ng update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,12 +69,7 @@
       "matchPackagePrefixes": ["jasmine", "@types/jasmine"]
     },
     {
-      "matchPackageNames": [
-        "@angular/cli",
-        "@angular/cdk",
-        "angular-server-side-configuration",
-        "angular-t9n"
-      ],
+      "matchPackageNames": ["@angular/cli", "@angular/cdk", "angular-server-side-configuration"],
       "postUpgradeTasks": {
         "commands": [
           "yarn install --frozen-lockfile --non-interactive",


### PR DESCRIPTION
angular-t9n does not provide update schematics and therefore `ng update` fails.