### PR TITLE
refactor: remove various deprecations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@ This document describes how to create a new release of SBB Angular.
 - Update Angular packages to align with new angular major version.
 - Update ng-update schematics.
 - Update stackblitz assets.
-- Check TODOs, @breaking-change annotations and @deprecation annotations.
+- Check TODOs, @breaking-change annotations and @deprecated annotations.
 - Check angular components commits to be considered for next major release in the [sync issue](https://github.com/sbb-design-systems/sbb-angular/issues/1047).
 - Create new route for previous release (e.g. angular-v13.app.sbb.ch) and deploy corresponding version.
 - Github maintenance workflow

--- a/src/angular/button/button.ts
+++ b/src/angular/button/button.ts
@@ -185,8 +185,7 @@ export class SbbAnchor extends SbbButton implements AfterViewInit, OnDestroy {
     focusMonitor: FocusMonitor,
     elementRef: ElementRef,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode: string,
-    /** @breaking-change 14.0.0 _ngZone will be required. */
-    @Optional() private _ngZone?: NgZone
+    private _ngZone: NgZone
   ) {
     super(elementRef, focusMonitor, animationMode);
   }
@@ -194,14 +193,9 @@ export class SbbAnchor extends SbbButton implements AfterViewInit, OnDestroy {
   override ngAfterViewInit(): void {
     super.ngAfterViewInit();
 
-    /** @breaking-change 14.0.0 _ngZone will be required. */
-    if (this._ngZone) {
-      this._ngZone.runOutsideAngular(() => {
-        this._elementRef.nativeElement.addEventListener('click', this._haltDisabledEvents);
-      });
-    } else {
+    this._ngZone.runOutsideAngular(() => {
       this._elementRef.nativeElement.addEventListener('click', this._haltDisabledEvents);
-    }
+    });
   }
 
   override ngOnDestroy(): void {

--- a/src/angular/datepicker/datepicker/datepicker.ts
+++ b/src/angular/datepicker/datepicker/datepicker.ts
@@ -12,7 +12,6 @@ import {
 } from '@angular/cdk/overlay';
 import { _getFocusedElementPierceShadowDom } from '@angular/cdk/platform';
 import { ComponentPortal, ComponentType } from '@angular/cdk/portal';
-import { DOCUMENT } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -277,8 +276,6 @@ export class SbbDatepicker<D> implements OnDestroy {
     private _changeDetectorRef: ChangeDetectorRef,
     @Inject(SBB_DATEPICKER_SCROLL_STRATEGY) private _scrollStrategy: any,
     @Optional() private _dateAdapter: SbbDateAdapter<D>,
-    /** @breaking-change 14.0.0 remove document as parameter **/
-    @Optional() @Inject(DOCUMENT) _document: any,
     @Inject(LOCALE_ID) public readonly locale: string
   ) {
     if (!this._dateAdapter) {

--- a/src/angular/loading/loading-indicator.ts
+++ b/src/angular/loading/loading-indicator.ts
@@ -26,7 +26,7 @@ export type SbbLoadingIndicatorMode =
     '[class.sbb-loading-indicator-small]': `this.mode === 'small'`,
     '[class.sbb-loading-indicator-medium]': `this.mode === 'medium'`,
     '[class.sbb-loading-indicator-big]': `this.mode === 'big'`,
-    // TODO: @deprecated mode fullscreen will be removed with next major version
+    // TODO: @deprecated mode fullscreen will be removed with next major version (v15)
     '[class.sbb-loading-indicator-fullscreen]': `this.mode === 'fullscreen'`,
     '[class.sbb-loading-indicator-fullbox]': `this.mode === 'fullbox'`,
     '[class.sbb-loading-indicator-inline]': `this.mode === 'inline'`,

--- a/src/angular/schematics/ng-update/data/constructor-checks.ts
+++ b/src/angular/schematics/ng-update/data/constructor-checks.ts
@@ -15,5 +15,13 @@ export const constructorChecks: VersionChanges<ConstructorChecksUpgradeData> = {
       pr: '',
       changes: ['SbbMenuItem'],
     },
+    {
+      pr: '',
+      changes: ['SbbAnchor'],
+    },
+    {
+      pr: '',
+      changes: ['SbbDatepicker'],
+    },
   ],
 };


### PR DESCRIPTION
BREAKING CHANGE:
 - SbbAnchor: Constructor parameter `ngZone` has become required.
 - SbbDatepicker: Remove unused constructor parameter `document`.