### PR TITLE
fix(angular/processflow): accept AbstractControl in isErrorState

### DIFF
--- a/src/angular/core/common-behaviors/error-state.ts
+++ b/src/angular/core/common-behaviors/error-state.ts
@@ -1,4 +1,4 @@
-import { FormControl, FormGroupDirective, NgControl, NgForm } from '@angular/forms';
+import { AbstractControl, FormGroupDirective, NgControl, NgForm } from '@angular/forms';
 import { Subject } from 'rxjs';
 
 import { SbbErrorStateMatcher } from '../error/error-options';
@@ -53,7 +53,7 @@ export function mixinErrorState<T extends Constructor<HasErrorState>>(
       const oldState = this.errorState;
       const parent = this._parentFormGroup || this._parentForm;
       const matcher = this.errorStateMatcher || this._defaultErrorStateMatcher;
-      const control = this.ngControl ? (this.ngControl.control as FormControl) : null;
+      const control = this.ngControl ? (this.ngControl.control as AbstractControl) : null;
       const newState = matcher.isErrorState(control, parent);
 
       if (newState !== oldState) {

--- a/src/angular/processflow/processflow.ts
+++ b/src/angular/processflow/processflow.ts
@@ -29,7 +29,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { FormControl, FormGroupDirective, NgForm } from '@angular/forms';
+import { AbstractControl, FormGroupDirective, NgForm } from '@angular/forms';
 import { SbbErrorStateMatcher } from '@sbb-esta/angular/core';
 import { Subject, Subscription } from 'rxjs';
 import { distinctUntilChanged, map, startWith, switchMap, takeUntil } from 'rxjs/operators';
@@ -93,7 +93,7 @@ export class SbbStep extends CdkStep implements SbbErrorStateMatcher, AfterConte
   }
 
   /** Custom error state matcher that additionally checks for validity of interacted form. */
-  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+  isErrorState(control: AbstractControl | null, form: FormGroupDirective | NgForm | null): boolean {
     const originalErrorState = this._errorStateMatcher.isErrorState(control, form);
 
     // Custom error state checks for the validity of form that is not submitted or touched


### PR DESCRIPTION
Accept AbstractControl instead of FormControl to avoid compiler errors when strict typing is enabled