### PR TITLE
fix(angular/tooltip): stop event propagation on trigger click

### DIFF
--- a/src/angular/tooltip/tooltip.spec.ts
+++ b/src/angular/tooltip/tooltip.spec.ts
@@ -64,6 +64,7 @@ describe('SbbTooltip', () => {
         TooltipOnDraggableElement,
         DataBoundAriaLabelTooltip,
         TriggerConfigurableTooltip,
+        TooltipTriggerBubble,
       ],
       providers: [
         {
@@ -1251,6 +1252,19 @@ describe('SbbTooltip', () => {
       expect(document.querySelector('.sbb-tooltip-close-button')).toBeFalsy();
     }));
   });
+
+  describe('click bubbling', () => {
+    it('should stop propagation on trigger click', fakeAsync(() => {
+      const fixture = TestBed.createComponent(TooltipTriggerBubble);
+      const outerClickSpy = spyOn(fixture.componentInstance, 'outerDivClick');
+      fixture.detectChanges();
+
+      fixture.nativeElement.querySelector('button').click();
+      tick();
+
+      expect(outerClickSpy).not.toHaveBeenCalled();
+    }));
+  });
 });
 
 @Component({
@@ -1379,6 +1393,19 @@ class TooltipDemoWithoutPositionBinding {
   message: any = initialTooltipMessage;
   @ViewChild(SbbTooltip) tooltip: SbbTooltip;
   @ViewChild('button') button: ElementRef<HTMLButtonElement>;
+}
+
+@Component({
+  template: `
+    <div (click)="outerDivClick()">
+      <button [sbbTooltip]="'content'" sbbTooltipTrigger="click">Show tooltip</button>
+    </div>
+  `,
+})
+class TooltipTriggerBubble {
+  @ViewChild(SbbTooltip) tooltip: SbbTooltip;
+
+  outerDivClick() {}
 }
 
 /** Asserts whether a tooltip directive has a tooltip instance. */

--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -31,6 +31,7 @@ import {
   Directive,
   ElementRef,
   EventEmitter,
+  HostListener,
   Inject,
   InjectionToken,
   Input,
@@ -335,6 +336,11 @@ export abstract class _SbbTooltipBase<T extends _TooltipComponentBase>
     if (_defaultOptions?.touchGestures) {
       this.touchGestures = _defaultOptions.touchGestures;
     }
+  }
+
+  @HostListener('click', ['$event'])
+  _preventClickBubbling(event: Event) {
+    event.stopPropagation();
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
Closes #1554