### PR TITLE
fix: remove global $localize usage

### DIFF
--- a/src/angular/dialog/dialog-content-directives.ts
+++ b/src/angular/dialog/dialog-content-directives.ts
@@ -21,8 +21,6 @@ import { SbbDialogRef, _closeDialogVia } from './dialog-ref';
 /** Counter used to generate unique IDs for dialog elements. */
 let dialogElementUid = 0;
 
-const closeAriaLabel = $localize`:Aria label to close a dialog@@sbbDialogCloseDialog:Close dialog`;
-
 /**
  * Button that will close the current dialog.
  */
@@ -36,7 +34,8 @@ const closeAriaLabel = $localize`:Aria label to close a dialog@@sbbDialogCloseDi
 })
 export class SbbDialogClose implements OnInit, OnChanges {
   /** Screenreader label for the button. */
-  @Input('aria-label') ariaLabel: string = closeAriaLabel;
+  @Input('aria-label')
+  ariaLabel: string = $localize`:Aria label to close a dialog@@sbbDialogCloseDialog:Close dialog`;
 
   /** Default to "button" to prevents accidental form submits. */
   @Input() type: 'submit' | 'button' | 'reset' = 'button';
@@ -107,7 +106,8 @@ export class _SbbDialogTitleBase implements OnInit {
   @Input() id: string = `sbb-dialog-title-${dialogElementUid++}`;
 
   /** Arial label for the close button. */
-  @Input() closeAriaLabel: string = closeAriaLabel;
+  @Input()
+  closeAriaLabel: string = $localize`:Aria label to close a dialog@@sbbDialogCloseDialog:Close dialog`;
 
   /** Whether the close button is enabled for the dialog. */
   _closeEnabled: boolean = true;

--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -78,7 +78,11 @@
         <source>Close dialog</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/dialog/dialog-content-directives.ts</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular/dialog/dialog-content-directives.ts</context>
+          <context context-type="linenumber">110</context>
         </context-group>
         <note priority="1" from="description">Aria label to close a dialog</note>
       </trans-unit>
@@ -126,7 +130,11 @@
         <source>Close lightbox</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/lightbox/lightbox-content-directives.ts</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../../../../../src/angular/lightbox/lightbox-content-directives.ts</context>
+          <context context-type="linenumber">101</context>
         </context-group>
         <note priority="1" from="description">Aria label to close a dialog</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -84,7 +84,8 @@
     </unit>
     <unit id="sbbDialogCloseDialog">
       <notes>
-        <note category="location">../../../../../../src/angular/dialog/dialog-content-directives.ts:24</note>
+        <note category="location">../../../../../../src/angular/dialog/dialog-content-directives.ts:38</note>
+        <note category="location">../../../../../../src/angular/dialog/dialog-content-directives.ts:110</note>
         <note category="description">Aria label to close a dialog</note>
       </notes>
       <segment>
@@ -138,7 +139,8 @@
     </unit>
     <unit id="sbbLightboxCloseLightbox">
       <notes>
-        <note category="location">../../../../../../src/angular/lightbox/lightbox-content-directives.ts:25</note>
+        <note category="location">../../../../../../src/angular/lightbox/lightbox-content-directives.ts:39</note>
+        <note category="location">../../../../../../src/angular/lightbox/lightbox-content-directives.ts:101</note>
         <note category="description">Aria label to close a dialog</note>
       </notes>
       <segment>

--- a/src/angular/lightbox/lightbox-content-directives.ts
+++ b/src/angular/lightbox/lightbox-content-directives.ts
@@ -22,8 +22,6 @@ import { SbbLightboxRef } from './lightbox-ref';
 /** Counter used to generate unique IDs for dialog elements. */
 let dialogElementUid = 0;
 
-const closeAriaLabel = $localize`:Aria label to close a dialog@@sbbLightboxCloseLightbox:Close lightbox`;
-
 /**
  * Button that will close the current lightbox.
  */
@@ -37,7 +35,8 @@ const closeAriaLabel = $localize`:Aria label to close a dialog@@sbbLightboxClose
 })
 export class SbbLightboxClose extends SbbDialogClose implements OnInit, OnChanges {
   /** Aria label for the close button. */
-  @Input('aria-label') override ariaLabel: string = closeAriaLabel;
+  @Input('aria-label')
+  override ariaLabel: string = $localize`:Aria label to close a dialog@@sbbLightboxCloseLightbox:Close lightbox`;
 
   /** Lightbox close input. */
   @Input('sbb-lightbox-close')
@@ -98,7 +97,8 @@ export class SbbLightboxTitle extends _SbbDialogTitleBase implements OnInit {
   @ViewChild(SbbLightboxClose, { static: true }) _lightBoxClose: SbbLightboxClose;
 
   /** Arial label for the close button. */
-  @Input() override closeAriaLabel: string = closeAriaLabel;
+  @Input()
+  override closeAriaLabel: string = $localize`:Aria label to close a dialog@@sbbLightboxCloseLightbox:Close lightbox`;
 
   constructor(
     // The lightbox title directive is always used in combination with a `SbbDialogRef`.


### PR DESCRIPTION
Global $localize usage would be called before our $localize monkey
patch. Inlining the $localize call causes a slight duplication, but this
should be acceptable at this scale.