### PR TITLE
fix(angular/autocomplete): do not reset scroll if an option is added

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -609,7 +609,18 @@ export class SbbAutocompleteTrigger
               this._changeDetectorRef.detectChanges();
 
               if (this.panelOpen) {
+                /**
+                 * Fix to avoid scrolling to the top if a new element is added.
+                 * This happens because our overlay hasa dynamic height (different from @angular/material).
+                 * When the _resetBoundingBoxStyles() function in the FlexibleConnectedPositionStrategy
+                 * is called, the element is reset to full height and scaled back afterwards.
+                 *
+                 * An alternative to this hack would be to either use a maxHeight property for our overlay
+                 * or to fix this in angular/components.
+                 */
+                const scrollTop = this.autocomplete.panel.nativeElement.scrollTop;
                 this._overlayRef!.updatePosition();
+                this.autocomplete.panel.nativeElement.scrollTop = scrollTop;
               }
 
               if (wasOpen !== this.panelOpen) {

--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -611,12 +611,13 @@ export class SbbAutocompleteTrigger
               if (this.panelOpen) {
                 /**
                  * Fix to avoid scrolling to the top if a new element is added.
-                 * This happens because our overlay hasa dynamic height (different from @angular/material).
+                 * This happens because our overlay has a dynamic height (different from @angular/material).
                  * When the _resetBoundingBoxStyles() function in the FlexibleConnectedPositionStrategy
                  * is called, the element is reset to full height and scaled back afterwards.
+                 * During this the scroll position gets lost.
                  *
-                 * An alternative to this hack would be to either use a maxHeight property for our overlay
-                 * or to fix this in angular/components.
+                 * An alternative to this hack would be to either use a maxHeight property for our
+                 * overlay or to fix this in angular/components.
                  */
                 const scrollTop = this.autocomplete.panel.nativeElement.scrollTop;
                 this._overlayRef!.updatePosition();

--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -609,16 +609,14 @@ export class SbbAutocompleteTrigger
               this._changeDetectorRef.detectChanges();
 
               if (this.panelOpen) {
-                /**
-                 * Fix to avoid scrolling to the top if a new element is added.
-                 * This happens because our overlay has a dynamic height (different from @angular/material).
-                 * When the _resetBoundingBoxStyles() function in the FlexibleConnectedPositionStrategy
-                 * is called, the element is reset to full height and scaled back afterwards.
-                 * During this the scroll position gets lost.
-                 *
-                 * An alternative to this hack would be to either use a maxHeight property for our
-                 * overlay or to fix this in angular/components.
-                 */
+                // Fix to avoid scrolling to the top if a new element is added.
+                // This happens because our overlay has a dynamic height (different from @angular/material).
+                // When the _resetBoundingBoxStyles() function in the FlexibleConnectedPositionStrategy
+                // is called, the element is reset to full height and scaled back afterwards.
+                // During this the scroll position gets lost.
+                //
+                // An alternative to this hack would be to either use a maxHeight property for our
+                // overlay or to fix this in angular/components.
                 const scrollTop = this.autocomplete.panel.nativeElement.scrollTop;
                 this._overlayRef!.updatePosition();
                 this.autocomplete.panel.nativeElement.scrollTop = scrollTop;

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -3145,6 +3145,24 @@ describe('SbbAutocomplete', () => {
 
       expect(fixture.componentInstance.selectedValue).toBe(1337);
     }));
+
+    it('should not scroll to top if a new option is added', fakeAsync(() => {
+      const fixture = createComponent(SimpleAutocomplete);
+      fixture.detectChanges();
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const scrollbar = overlayContainerElement.querySelector('.sbb-autocomplete-panel')!;
+      scrollbar.scrollTop = 5;
+
+      fixture.componentInstance.numbers.push({ code: '42', name: 'Fourty two', height: 48 });
+      flush();
+      fixture.detectChanges();
+      tick();
+
+      expect(scrollbar.scrollTop).toBe(5);
+    }));
   });
 
   it('should not focus the option when DOWN key is pressed', fakeAsync(() => {

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -3153,15 +3153,18 @@ describe('SbbAutocomplete', () => {
       fixture.detectChanges();
       zone.simulateZoneExit();
 
-      const scrollbar = overlayContainerElement.querySelector('.sbb-autocomplete-panel')!;
-      scrollbar.scrollTop = 5;
+      const scrollbar = overlayContainerElement.querySelector(
+        '.sbb-autocomplete-panel'
+      )! as HTMLElement;
+      scrollbar.style.height = '100px';
+      scrollbar.scrollTop = 10;
 
       fixture.componentInstance.numbers.push({ code: '42', name: 'Fourty two', height: 48 });
       flush();
       fixture.detectChanges();
       tick();
 
-      expect(scrollbar.scrollTop).toBe(5);
+      expect(scrollbar.scrollTop).toBe(10);
     }));
   });
 


### PR DESCRIPTION
Closes #1571

Fix to avoid scrolling to the top if a new element is added. This happens because our overlay has a dynamic height (different from @angular/material).

When the _resetBoundingBoxStyles() function in the FlexibleConnectedPositionStrategy is called, the element is reset to full height and scaled back afterwards. When scaling back the scroll position gets lost.
![image](https://user-images.githubusercontent.com/3184240/178761054-24592df0-a217-4049-a273-1e9cf9b90f2e.png)

An alternative to this hack would be to either use a maxHeight property for our overlay or to fix this in angular/components.