### PR TITLE
fix(angular/lightbox): fix height calculation on mobile

### DIFF
--- a/src/angular/lightbox/lightbox-container.ts
+++ b/src/angular/lightbox/lightbox-container.ts
@@ -10,6 +10,7 @@ import {
   HostListener,
   Inject,
   NgZone,
+  OnInit,
   Optional,
   ViewEncapsulation,
 } from '@angular/core';
@@ -40,9 +41,10 @@ import { sbbLightboxAnimations } from './lightbox-animations';
     '[attr.aria-label]': '_config.ariaLabel',
     '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
     '[@lightboxContainer]': `_getAnimationState()`,
+    '[style.height.px]': '_innerHeight',
   },
 })
-export class SbbLightboxContainer extends _SbbDialogContainerBase {
+export class SbbLightboxContainer extends _SbbDialogContainerBase implements OnInit {
   /** Callback, invoked whenever an animation on the host completes. */
   @HostListener('@lightboxContainer.done', ['$event'])
   _onAnimationDone({ toState, totalTime }: AnimationEvent) {
@@ -64,6 +66,11 @@ export class SbbLightboxContainer extends _SbbDialogContainerBase {
     }
   }
 
+  @HostListener('window:resize', ['$event'])
+  onResize() {
+    this._innerHeight = window.innerHeight;
+  }
+
   /** Starts the dialog exit animation. */
   _startExitAnimation(): void {
     this._state = 'exit';
@@ -72,6 +79,8 @@ export class SbbLightboxContainer extends _SbbDialogContainerBase {
     // view container is using OnPush change detection.
     this._changeDetectorRef.markForCheck();
   }
+
+  _innerHeight: number;
 
   constructor(
     elementRef: ElementRef,
@@ -94,5 +103,9 @@ export class SbbLightboxContainer extends _SbbDialogContainerBase {
       overlayRef,
       focusMonitor
     );
+  }
+
+  ngOnInit(): void {
+    this._innerHeight = window.innerHeight;
   }
 }

--- a/src/angular/lightbox/lightbox-container.ts
+++ b/src/angular/lightbox/lightbox-container.ts
@@ -67,7 +67,7 @@ export class SbbLightboxContainer extends _SbbDialogContainerBase implements OnI
   }
 
   @HostListener('window:resize', ['$event'])
-  onResize() {
+  _handleResize() {
     this._innerHeight = window.innerHeight;
   }
 

--- a/src/angular/lightbox/lightbox-container.ts
+++ b/src/angular/lightbox/lightbox-container.ts
@@ -10,7 +10,6 @@ import {
   HostListener,
   Inject,
   NgZone,
-  OnInit,
   Optional,
   ViewEncapsulation,
 } from '@angular/core';
@@ -44,7 +43,7 @@ import { sbbLightboxAnimations } from './lightbox-animations';
     '[style.height.px]': '_innerHeight',
   },
 })
-export class SbbLightboxContainer extends _SbbDialogContainerBase implements OnInit {
+export class SbbLightboxContainer extends _SbbDialogContainerBase {
   /** Callback, invoked whenever an animation on the host completes. */
   @HostListener('@lightboxContainer.done', ['$event'])
   _onAnimationDone({ toState, totalTime }: AnimationEvent) {
@@ -103,9 +102,16 @@ export class SbbLightboxContainer extends _SbbDialogContainerBase implements OnI
       overlayRef,
       focusMonitor
     );
+
+    const window = this._getWindow();
+
+    if (typeof window !== 'undefined') {
+      this._innerHeight = window.innerHeight;
+    }
   }
 
-  ngOnInit(): void {
-    this._innerHeight = window.innerHeight;
+  /** Use defaultView of injected document if available or fallback to global window reference */
+  private _getWindow(): Window {
+    return this._document?.defaultView || window;
   }
 }

--- a/src/angular/lightbox/lightbox.scss
+++ b/src/angular/lightbox/lightbox.scss
@@ -14,9 +14,11 @@
   outline: 0;
   background-color: var(--sbb-color-background);
 
-  // The dialog container should completely fill its parent overlay element.
+  // The dialog container width should completely fill its parent overlay element.
   width: 100%;
-  height: 100%;
+
+  // Fallback if viewport height cannot be calculated by the component.
+  height: 100vh;
 
   @include cdk.high-contrast(active, off) {
     outline: solid sbb.pxToRem(1);

--- a/src/angular/lightbox/lightbox.scss
+++ b/src/angular/lightbox/lightbox.scss
@@ -18,10 +18,6 @@
   width: 100%;
   height: 100%;
 
-  // The lightbox should always cover the entire viewbox.
-  min-height: 100vh;
-  max-height: 100vw;
-
   @include cdk.high-contrast(active, off) {
     outline: solid sbb.pxToRem(1);
   }

--- a/src/angular/lightbox/lightbox.spec.ts
+++ b/src/angular/lightbox/lightbox.spec.ts
@@ -1629,11 +1629,11 @@ describe('SbbLightbox with default options', () => {
 
     const overlayPane = overlayContainerElement.querySelector('.cdk-overlay-pane') as HTMLElement;
     expect(overlayPane.style.width).toBe('100vw');
-    expect(overlayPane.style.height).toBe('100vh');
+    expect(overlayPane.style.height).toBe('auto');
     expect(overlayPane.style.minWidth).toBe('100vw');
-    expect(overlayPane.style.minHeight).toBe('100vh');
+    expect(overlayPane.style.minHeight).toBe('auto');
     expect(overlayPane.style.maxWidth).toBe('100vw');
-    expect(overlayPane.style.maxHeight).toBe('100vh');
+    expect(overlayPane.style.maxHeight).toBe('none');
   });
 
   it('should be overridable by open() options', fakeAsync(() => {

--- a/src/angular/lightbox/lightbox.ts
+++ b/src/angular/lightbox/lightbox.ts
@@ -102,9 +102,9 @@ export class SbbLightbox extends _SbbDialogBase<SbbLightboxContainer, SbbLightbo
       width: '100vw',
       minWidth: '100vw',
       maxWidth: '100vw',
-      height: '100vh',
-      minHeight: '100vh',
-      maxHeight: '100vh',
+      height: 'auto',
+      minHeight: 'auto',
+      maxHeight: 'none',
     };
     dialogConfig.id = dialogConfig.id || `${this._idPrefix}${uniqueId++}`;
     return super.open(componentOrTemplateRef, dialogConfig) as any;


### PR DESCRIPTION
Use `window.innerHeight` instead of `100vh` to calculate the height of the `SbbLightBox`.  This is necessary because on mobile Chrome and Safari, `100vh` includes the address bar and is therefore taller than the actual viewport (see e.g. [this explanation](https://bugs.webkit.org/show_bug.cgi?id=141832#c5)). This led to cut off buttons in the lightbox.

Closes #1586