### PR TITLE
refactor(angular/schematics): reuse standalone component utilities

### DIFF
--- a/src/angular/schematics/ng-add/setup-project.ts
+++ b/src/angular/schematics/ng-add/setup-project.ts
@@ -10,14 +10,16 @@ import {
 } from '@angular-devkit/schematics';
 import {
   addModuleImportToRootModule,
-  addModuleImportToStandaloneBootstrap,
   defaultTargetBuilders,
   getProjectFromWorkspace,
   getProjectMainFile,
   getProjectTargetOptions,
   hasNgModuleImport,
-  importsProvidersFrom,
 } from '@angular/cdk/schematics';
+import {
+  addModuleImportToStandaloneBootstrap,
+  importsProvidersFrom,
+} from '@schematics/angular/private/components';
 import { getAppModulePath } from '@schematics/angular/utility/ng-ast-utils';
 import { getWorkspace, updateWorkspace } from '@schematics/angular/utility/workspace';
 import { ProjectType } from '@schematics/angular/utility/workspace-models';


### PR DESCRIPTION
The standalone utilities were copied into `@schematics/angular` so that they can be reused.