### PR TITLE
ci: pin rxjs and @types/geojson deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@types/browser-sync": "2.26.3",
     "@types/events": "3.0.0",
     "@types/fs-extra": "9.0.13",
-    "@types/geojson": "7946.0.10",
+    "@types/geojson": "7946.0.8",
     "@types/glob": "7.2.0",
     "@types/grecaptcha": "2.0.36",
     "@types/highlight.js": "10.1.0",

--- a/renovate.json
+++ b/renovate.json
@@ -15,14 +15,7 @@
   "allowedPostUpgradeCommands": ["^yarn"],
   "ignoreDeps": [
     "@arcgis/core",
-    "@bazel/buildifier",
-    "@bazel/buildozer",
-    "@bazel/concatjs",
-    "@bazel/esbuild",
-    "@bazel/jasmine",
-    "@bazel/protractor",
-    "@bazel/rollup",
-    "@bazel/runfiles",
+    "@types/geojson",
     "@types/marked",
     "browser-sync",
     "browser-sync-client",
@@ -30,6 +23,7 @@
     "dgeni-packages",
     "highlight.js",
     "marked",
+    "rxjs",
     "typescript",
     "yarn"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4204,10 +4204,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/geojson@*", "@types/geojson@7946.0.10", "@types/geojson@^7946.0.8":
+"@types/geojson@*", "@types/geojson@^7946.0.8":
   version "7946.0.10"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
   integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
+
+"@types/geojson@7946.0.8":
+  version "7946.0.8"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
+  integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
 
 "@types/glob@7.2.0":
   version "7.2.0"


### PR DESCRIPTION
This is necessary due to a mysterious build bug.