### PR TITLE
fix(angular/autocomplete): prevent outside clicks from going to other overlays

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -939,5 +939,10 @@ export class SbbAutocompleteTrigger
         event.preventDefault();
       }
     });
+
+    // Subscribe to the pointer events stream so that it doesn't get picked up by other overlays.
+    // TODO(crisbeto): we should switch `_getOutsideClickStream` eventually to use this stream,
+    // but the behvior isn't exactly the same and it ends up breaking some internal tests.
+    overlayRef.outsidePointerEvents().subscribe();
   }
 }


### PR DESCRIPTION
Adds a subscription to the outside click stream of the autocomplete overlay so that the events don't propagate to other overlays which may close the autocomplete prematurely.