### PR TITLE
fix(angular/datepicker): no weekday in standalone date input

### DIFF
--- a/src/angular/core/datetime/date-formats.ts
+++ b/src/angular/core/datetime/date-formats.ts
@@ -2,6 +2,11 @@ import { InjectionToken } from '@angular/core';
 
 export interface SbbDateFormats {
   dateInput: any;
+  /**
+   * Parameter `dateInputPure` will become required.
+   * @breaking-change 15.0.0
+   */
+  dateInputPure?: any;
   dateA11yLabel: any;
 }
 

--- a/src/angular/core/datetime/date-pipe-date-formats.ts
+++ b/src/angular/core/datetime/date-pipe-date-formats.ts
@@ -2,5 +2,6 @@ import { SbbDateFormats } from './date-formats';
 
 export const SBB_DATE_PIPE_DATE_FORMATS: SbbDateFormats = {
   dateInput: 'EEEEEE, dd.MM.yyyy',
+  dateInputPure: 'dd.MM.yyyy',
   dateA11yLabel: 'dd MM yyyy',
 };

--- a/src/angular/datepicker/date-input/date-input.directive.ts
+++ b/src/angular/datepicker/date-input/date-input.directive.ts
@@ -369,8 +369,11 @@ export class SbbDateInput<D> implements ControlValueAccessor, Validator, OnInit,
 
   /** Formats a value and sets it on the input element. */
   private _formatValue(value: D | null) {
+    const displayFormat = this._datepicker
+      ? this._dateFormats.dateInput
+      : this._dateFormats.dateInputPure ?? this._dateFormats.dateInput;
     this._elementRef.nativeElement.value =
-      value != null ? this._dateAdapter.format(value, this._dateFormats.dateInput) : '';
+      value != null ? this._dateAdapter.format(value, displayFormat) : '';
   }
 
   /**

--- a/src/angular/datepicker/datepicker/datepicker.spec.ts
+++ b/src/angular/datepicker/datepicker/datepicker.spec.ts
@@ -908,7 +908,6 @@ describe('SbbDatepicker', () => {
       testComponent.date.setValue(new Date(2022, JAN, 1));
       fixture.detectChanges();
 
-      // When clicking toggle
       const dateInput = fixture.debugElement.query(By.css('.sbb-date-input'));
       expect(dateInput.nativeElement.value).toBe('01.01.2022');
     });

--- a/src/angular/datepicker/datepicker/datepicker.spec.ts
+++ b/src/angular/datepicker/datepicker/datepicker.spec.ts
@@ -892,6 +892,27 @@ describe('SbbDatepicker', () => {
       expect(toggle).toBeTruthy();
     });
   });
+
+  describe('standalone date input', () => {
+    let fixture: ComponentFixture<StandaloneDateInputComponent>;
+    let testComponent: StandaloneDateInputComponent;
+
+    beforeEach(fakeAsync(() => {
+      fixture = createComponent(StandaloneDateInputComponent);
+      fixture.detectChanges();
+
+      testComponent = fixture.componentInstance;
+    }));
+
+    it('should show the date without the name of the week day', () => {
+      testComponent.date.setValue(new Date(2022, JAN, 1));
+      fixture.detectChanges();
+
+      // When clicking toggle
+      const dateInput = fixture.debugElement.query(By.css('.sbb-date-input'));
+      expect(dateInput.nativeElement.value).toBe('01.01.2022');
+    });
+  });
 });
 
 @Component({
@@ -1086,4 +1107,11 @@ class DatepickerWithNoToggleComponent {
   @ViewChild('d') datepicker: SbbDatepicker<Date>;
   @ViewChild(SbbDateInput) input: SbbDateInput<Date>;
   notoggle: boolean = true;
+}
+
+@Component({
+  template: ` <input sbbDateInput sbbInput [formControl]="date" /> `,
+})
+class StandaloneDateInputComponent {
+  date = new FormControl<Date | null>(null);
 }


### PR DESCRIPTION
Don't display the name of the weekday if `SbbDateInput` is used without `SbbDatePicker`.

Closes #1610