### PR TITLE
fix(angular/processflow): remove obsolete aria-expanded attribute

### DIFF
--- a/src/angular/processflow/processflow.html
+++ b/src/angular/processflow/processflow.html
@@ -35,7 +35,6 @@
     (@stepTransition.done)="_animationDone.next($event)"
     [id]="_getStepContentId(i)"
     [attr.aria-labelledby]="_getStepLabelId(i)"
-    [attr.aria-expanded]="selectedIndex === i"
   >
     <ng-container [ngTemplateOutlet]="step.content"></ng-container>
   </div>

--- a/src/angular/processflow/processflow.spec.ts
+++ b/src/angular/processflow/processflow.spec.ts
@@ -124,22 +124,6 @@ describe('SbbProcessflow', () => {
       expect(processflowEl.getAttribute('role')).toBe('tablist');
     });
 
-    it('should set aria-expanded of content correctly', () => {
-      const stepContents = fixture.debugElement.queryAll(By.css(`.sbb-processflow-content`));
-      const processflowComponent = fixture.debugElement.query(
-        By.directive(SbbProcessflow)
-      )!.componentInstance;
-      const firstStepContentEl = stepContents[0].nativeElement;
-      expect(firstStepContentEl.getAttribute('aria-expanded')).toBe('true');
-
-      processflowComponent.selectedIndex = 1;
-      fixture.detectChanges();
-
-      expect(firstStepContentEl.getAttribute('aria-expanded')).toBe('false');
-      const secondStepContentEl = stepContents[1].nativeElement;
-      expect(secondStepContentEl.getAttribute('aria-expanded')).toBe('true');
-    });
-
     it('should display the correct label', () => {
       const processflowComponent = fixture.debugElement.query(
         By.directive(SbbProcessflow)


### PR DESCRIPTION
The `aria-expanded` attribute is not valid for the `tabpanel` role (see e.g. [here](https://www.w3.org/TR/wai-aria-1.2/#tabpanel)). It can be simply removed because selecting the tab with `aria-selected` in combination with an `aria-controls` pointing to the `tabpanel` is already enough.

Closes #1613 