### PR TITLE
fix(multipe): don't use div containers inside labels

### DIFF
--- a/src/angular/checkbox-panel/checkbox-panel.html
+++ b/src/angular/checkbox-panel/checkbox-panel.html
@@ -18,7 +18,7 @@
     (click)="_onInputClick($event)"
   />
 
-  <div class="sbb-selection-container">
+  <span class="sbb-selection-container">
     <span class="sbb-selection-container-checked">
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -36,16 +36,16 @@
         />
       </svg>
     </span>
-  </div>
+  </span>
 
-  <div class="sbb-selection-content">
-    <div class="sbb-selection-inner-content">
+  <span class="sbb-selection-content">
+    <span class="sbb-selection-inner-content">
       <!-- Add an invisible span so JAWS can read the label -->
       <span style="display: none">&nbsp;</span>
       <span><ng-content></ng-content></span>
       <ng-content select="sbb-checkbox-panel-subtitle"></ng-content>
-    </div>
+    </span>
     <ng-content select="sbb-checkbox-panel-warning"></ng-content>
     <ng-content select="sbb-checkbox-panel-note"></ng-content>
-  </div>
+  </span>
 </label>

--- a/src/angular/checkbox-panel/checkbox-panel.md
+++ b/src/angular/checkbox-panel/checkbox-panel.md
@@ -95,4 +95,7 @@ This internal checkbox receives focus and is automatically labelled by the text 
 Checkboxes without text or labels should be given a meaningful label via `aria-label` or
 `aria-labelledby`.
 
+Internally, the component is wrapped in a `<label>` tag. For HTML standard conformity, please only
+use inline elements like `<span>` and `<strong>` and avoid block elements like `<div>`.
+
 The checkbox panels are essentially large checkboxes, with more content options.

--- a/src/angular/checkbox-panel/checkbox-panel.spec.ts
+++ b/src/angular/checkbox-panel/checkbox-panel.spec.ts
@@ -183,6 +183,11 @@ describe('SbbCheckboxPanel', () => {
       fixture.detectChanges();
       expect(element.classList.contains('sbb-selection-checked')).toBeTrue();
     });
+
+    it('should not contain a div inside the label', () => {
+      const element = fixture.debugElement.nativeElement as HTMLElement;
+      expect(element.querySelectorAll('label div').length).toBe(0);
+    });
   });
 
   describe('note with icon', () => {

--- a/src/angular/radio-button-panel/radio-button-panel.html
+++ b/src/angular/radio-button-panel/radio-button-panel.html
@@ -17,18 +17,18 @@
     (click)="_onInputClick($event)"
   />
 
-  <div class="sbb-selection-container">
-    <div class="sbb-selection-container-checked"></div>
-  </div>
+  <span class="sbb-selection-container">
+    <span class="sbb-selection-container-checked"></span>
+  </span>
 
-  <div class="sbb-selection-content">
-    <div class="sbb-selection-inner-content">
+  <span class="sbb-selection-content">
+    <span class="sbb-selection-inner-content">
       <!-- Add an invisible span so JAWS can read the label -->
       <span style="display: none">&nbsp;</span>
       <span><ng-content></ng-content></span>
       <ng-content select="sbb-radio-button-panel-subtitle"></ng-content>
-    </div>
+    </span>
     <ng-content select="sbb-radio-button-panel-warning"></ng-content>
     <ng-content select="sbb-radio-button-panel-note"></ng-content>
-  </div>
+  </span>
 </label>

--- a/src/angular/radio-button-panel/radio-button-panel.md
+++ b/src/angular/radio-button-panel/radio-button-panel.md
@@ -129,3 +129,6 @@ radio buttons because groups are easier to use exclusively with a keyboard.
 
 You should provide an accessible label for all `<sbb-radio-group>` elements via `aria-label` or
 `aria-labelledby`.
+
+Internally, the component is wrapped in a `<label>` tag. For HTML standard conformity, please only
+use inline elements like `<span>` and `<strong>` and avoid block elements like `<div>`.

--- a/src/angular/radio-button-panel/radio-button-panel.spec.ts
+++ b/src/angular/radio-button-panel/radio-button-panel.spec.ts
@@ -177,6 +177,11 @@ describe('SbbRadioButtonPanel', () => {
       fixture.detectChanges();
       expect(element.classList.contains('sbb-selection-checked')).toBeTrue();
     });
+
+    it('should not contain a div inside the label', () => {
+      const element = fixture.debugElement.nativeElement as HTMLElement;
+      expect(element.querySelectorAll('label div').length).toBe(0);
+    });
   });
 
   describe('note with icon', () => {


### PR DESCRIPTION
According to the specification, div containers are not allowed inside labels.

Closes #1619 