### PR TITLE
docs(angular/loading-indicator): add accessibility section

### DIFF
--- a/src/angular/loading-indicator/loading-indicator.md
+++ b/src/angular/loading-indicator/loading-indicator.md
@@ -1,9 +1,21 @@
 The loading component is used as a progress bar to indicate progress and activity, as shown below
 
 ```html
-<sbb-loading-indicator mode="medium" aria-valuetext="Loading, please wait"></sbb-loading-indicator>
+<sbb-loading-indicator mode="medium" aria-label="Loading, please wait"></sbb-loading-indicator>
 ```
 
 The loading indicator supports four modes (tiny, small, medium (default), big),
 a mode for covering the parent element (fullbox),
 and a text inline mode, which allows to use the loading indicator within a text and adjust the size to the font size.
+
+### Accessibility
+
+If the loading state should be announced by screen readers, wrap the `sbb-loading-indicator` in an
+element with `aria-live` and add an `aria-label` attribute to the loading indicator.
+
+```html
+<div aria-live="polite">
+  <sbb-loading-indicator *ngIf="isLoading" mode="medium" aria-label="Loading, please wait">
+  </sbb-loading-indicator>
+</div>
+```

--- a/src/components-examples/angular/loading-indicator/loading-indicator-fullbox/loading-indicator-fullbox-example.html
+++ b/src/components-examples/angular/loading-indicator/loading-indicator-fullbox/loading-indicator-fullbox-example.html
@@ -1,7 +1,9 @@
-<sbb-loading-indicator
-  *ngIf="showSpinner"
-  mode="fullbox"
-  aria-valuetext="Loading, please wait"
-></sbb-loading-indicator>
+<div aria-live="polite">
+  <sbb-loading-indicator
+    *ngIf="showSpinner"
+    mode="fullbox"
+    aria-label="Loading, please wait"
+  ></sbb-loading-indicator>
+</div>
 <p>Covers the parent element.</p>
 <button type="button" sbb-button (click)="activateSpinner()">Activate Fullbox Spinner</button>

--- a/src/components-examples/angular/loading-indicator/loading-indicator-inline/loading-indicator-inline-example.html
+++ b/src/components-examples/angular/loading-indicator/loading-indicator-inline/loading-indicator-inline-example.html
@@ -1,5 +1,2 @@
 I am an inline loading indicator:
-<sbb-loading-indicator
-  mode="inline"
-  aria-valuetext="Loading inline, please wait"
-></sbb-loading-indicator>
+<sbb-loading-indicator mode="inline"></sbb-loading-indicator>

--- a/src/components-examples/angular/loading-indicator/loading-indicator-simple/loading-indicator-simple-example.html
+++ b/src/components-examples/angular/loading-indicator/loading-indicator-simple/loading-indicator-simple-example.html
@@ -1,20 +1,11 @@
 <h4>Tiny</h4>
-<sbb-loading-indicator
-  mode="tiny"
-  aria-valuetext="Loading tiny, please wait"
-></sbb-loading-indicator>
+<sbb-loading-indicator mode="tiny"></sbb-loading-indicator>
 
 <h4>Small</h4>
-<sbb-loading-indicator
-  mode="small"
-  aria-valuetext="Loading small, please wait"
-></sbb-loading-indicator>
+<sbb-loading-indicator mode="small"></sbb-loading-indicator>
 
 <h4>Medium</h4>
-<sbb-loading-indicator
-  mode="medium"
-  aria-valuetext="Loading medium, please wait"
-></sbb-loading-indicator>
+<sbb-loading-indicator mode="medium"></sbb-loading-indicator>
 
 <h4>Big</h4>
-<sbb-loading-indicator mode="big" aria-valuetext="Loading big, please wait"></sbb-loading-indicator>
+<sbb-loading-indicator mode="big"></sbb-loading-indicator>


### PR DESCRIPTION
Add an accessibility section to the loading indicator docs. Obsolete `aria-valuetext` attributes are removed.

Closes #1634 