### PR TITLE
Revert "fix(angular/tooltip): avoid problem when triggers hide animation for not visible tooltip"

### DIFF
--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -1042,22 +1042,8 @@ export abstract class _TooltipComponentBase implements OnDestroy {
     const tooltip = this._tooltip.nativeElement;
     const showClass = this._showAnimation;
     const hideClass = this._hideAnimation;
-
-    if (isVisible) {
-      tooltip.classList.remove(hideClass);
-      tooltip.classList.add(showClass);
-    }
-
-    if (!isVisible) {
-      // It's avoids the problem when `mat-tooltip-hide` triggers the animation of
-      // a tooltip that has not been shown yet.
-      if (tooltip.classList.contains(showClass)) {
-        tooltip.classList.add(hideClass);
-      }
-
-      tooltip.classList.remove(showClass);
-    }
-
+    tooltip.classList.remove(isVisible ? hideClass : showClass);
+    tooltip.classList.add(isVisible ? showClass : hideClass);
     this._isVisible = isVisible;
 
     // It's common for internal apps to disable animations using `* { animation: none !important }`


### PR DESCRIPTION
This reverts commit 603726eb804c56033ffab3ea9787f8048903884e.

This introduced a race condition which caused tooltips to get stuck in the DOM in an invisible state.