### PR TITLE
build: limit max memory of the bazel java process

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,12 @@
+##################
+# Startup config #
+##################
+
+# The memory usage of the java process are skyrocketing with journey-maps build (bazel bug?).
+# Limit it to 2g make the build very fast and without error.
+# It's related with https://github.com/angular/angular/issues/46965
+startup --host_jvm_args=-Xmx2g
+
 ###############################
 # Filesystem interactions     #
 ###############################

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,8 @@
-#########
-# Tests #
-#########
-
+##############
+# RAM Issues #
+##############
+# To prevent 'Worker process did not return a WorkResponse' maybe caused by a high memory consumption
+# the recommandation on https://bazel.build/docs/memory-saving-mode is tested
 build --discard_analysis_cache
 
 ###############################

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,8 @@
 # It's related with https://github.com/angular/angular/issues/46965
 startup --host_jvm_args=-Xmx2g
 
+build --discard_analysis_cache
+
 ###############################
 # Filesystem interactions     #
 ###############################

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,8 +1,8 @@
 ##############
 # RAM Issues #
 ##############
-# To prevent 'Worker process did not return a WorkResponse' maybe caused by a high memory consumption
-# the recommandation on https://bazel.build/docs/memory-saving-mode is tested
+# To prevent 'Worker process did not return a WorkResponse' maybe caused by a high memory
+# consumption the recommandation on https://bazel.build/docs/memory-saving-mode is tested
 build --discard_analysis_cache
 
 ###############################

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,11 +1,6 @@
-##################
-# Startup config #
-##################
-
-# The memory usage of the java process are skyrocketing with journey-maps build (bazel bug?).
-# Limit it to 2g make the build very fast and without error.
-# It's related with https://github.com/angular/angular/issues/46965
-startup --host_jvm_args=-Xmx2g
+#########
+# Tests #
+#########
 
 build --discard_analysis_cache
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -36,7 +36,7 @@ build --incompatible_strict_action_env
 # Use BundlingTypes strategy to avoid the `Worker process did not return a WorkResponse` error
 # being caused when Microsoft API extractor prints to stdout and conflicts with the Bazel worker 
 # IPC also using stdout. See https://github.com/angular/angular/issues/46965
-build --strategy=BundlingTypes=remote,sandboxed,local
+# build --strategy=BundlingTypes=remote,sandboxed,local
 
 ###############################
 # Output control              #


### PR DESCRIPTION
The problem 'Worker process did not return a WorkResponse' seems to come over a skyrocketing memory usage of the java bazel process. With this limit goes the build faster and make no errors.

Refs: https://github.com/angular/angular/issues/46965