### PR TITLE
ci: allow renovate to update @types/geojson and rxjs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,6 @@
   "allowedPostUpgradeCommands": ["^yarn"],
   "ignoreDeps": [
     "@arcgis/core",
-    "@types/geojson",
     "@types/marked",
     "browser-sync",
     "browser-sync-client",
@@ -23,7 +22,6 @@
     "dgeni-packages",
     "highlight.js",
     "marked",
-    "rxjs",
     "typescript",
     "yarn"
   ],


### PR DESCRIPTION
Ignoring them was done due to a build bug (see #1609). However, it turned out they're not responsible for this bug.