### PR TITLE
feat(multiple): provide the complete set of the SBBWeb font

### DIFF
--- a/src/angular/BUILD.bazel
+++ b/src/angular/BUILD.bazel
@@ -32,6 +32,11 @@ sass_binary(
     deps = ["//src/angular/styles:scss_lib"],
 )
 
+sass_binary(
+    name = "fullfont",
+    src = "fullfont.scss",
+)
+
 sass_library(
     name = "scss_lib",
     srcs = glob(["**/_*.scss"]),
@@ -53,6 +58,7 @@ ng_package(
     name = "npm_package",
     srcs = [
         "package.json",
+        ":fullfont",
         ":scss_lib",
         ":typography",
         "//src/angular/i18n:xlf",

--- a/src/angular/fullfont.scss
+++ b/src/angular/fullfont.scss
@@ -1,0 +1,1 @@
+@import './styles/fullfont';

--- a/src/angular/getting-started.md
+++ b/src/angular/getting-started.md
@@ -67,6 +67,14 @@ or editing your `angular.json`:
   ...
 ```
 
+The `typography.css` file only contains a subset of the `SBBWeb` fonts that does not contain all characters (e.g. the French "œ").
+For including the full fontset, we provide the `fullfont.css` file which can be added after the `typography.css` file.
+
+```css
+@import '@sbb-esta/angular/typography.css';
+@import '@sbb-esta/angular/fullfont.css';
+```
+
 If you need more details about what the typography offers to you, you can go to [typography](/angular/introduction/typography).
 
 #### Step 1.3: Configure animations

--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -19,6 +19,9 @@
     },
     "./typography.css": {
       "style": "./typography.css"
+    },
+    "./fullfont.css": {
+      "style": "./fullfont.css"
     }
   },
   "peerDependencies": {

--- a/src/angular/styles/_fullfont.scss
+++ b/src/angular/styles/_fullfont.scss
@@ -1,0 +1,38 @@
+// ----------------------------------------------------------------------------------------------------
+// Full Webfonts
+// ----------------------------------------------------------------------------------------------------
+
+@font-face {
+  font-family: 'SBBWeb Bold';
+  src: url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-Bold.woff2') format('woff2'),
+    url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-Bold.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'SBBWeb Light';
+  src: url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-Light.woff2') format('woff2'),
+    url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-Light.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'SBBWeb Roman';
+  src: url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-Roman.woff2') format('woff2'),
+    url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-Roman.woff') format('woff');
+  font-display: fallback;
+}
+
+@font-face {
+  font-family: 'SBBWeb Thin';
+  src: url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-Thin.woff2') format('woff2'),
+    url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-Thin.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'SBBWeb Ultralight';
+  src: url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-UltraLight.woff2') format('woff2'),
+    url('https://cdn.app.sbb.ch/fonts/v1/SBBWeb-UltraLight.woff') format('woff');
+  font-display: swap;
+}

--- a/tools/schematics/bazel/files/ngPackage/BUILD.bazel.template
+++ b/tools/schematics/bazel/files/ngPackage/BUILD.bazel.template
@@ -12,7 +12,7 @@ load(
     "ng_module",
     "ng_package",<% if (hasTests) { %>
     "ng_test_library",
-    "ng_web_test_suite",<% } %><% if (hasTypography || stylesheets.length) { %>
+    "ng_web_test_suite",<% } %><% if (hasTypography || hasFullFont || stylesheets.length) { %>
     "sass_binary",<% } %><% if (hasSassLibrary) { %>
     "sass_library",<% } %>
 )
@@ -55,6 +55,11 @@ sass_binary(
     name = "typography",
     src = "typography.scss",
     deps = ["//src/angular/styles:scss_lib"],
+)<% } %><% if (hasFullFont) { %>
+
+sass_binary(
+    name = "fullfont",
+    src = "fullfont.scss",
 )<% } %><% if (hasSassLibrary) { %>
 
 sass_library(
@@ -104,7 +109,8 @@ ng_package(
     srcs = [
         "package.json",<% if (hasSassLibrary) { %>
         ":scss_lib",<% } %><% if (hasTypography) { %>
-        ":typography",<% } %><% if (name === 'angular') { %>
+        ":typography",<% } %><% if (hasFullFont) { %>
+        ":fullfont",<% } %><% if (name === 'angular') { %>
         "//src/angular/i18n:xlf",<% } %>
     ],<% if (hasSchematics) { %>
     nested_packages = ["//src/<%= name %>/schematics:npm_package"],<% } %><% if (name === 'journey-maps') { %>

--- a/tools/schematics/bazel/index.js
+++ b/tools/schematics/bazel/index.js
@@ -230,6 +230,11 @@ var NgPackage = class extends NgModule {
       this.sassBinaries = this.sassBinaries.filter((s) => !s.path.includes("typography.scss"));
       this.stylesheets = this.stylesheets.filter((s) => !s.includes("typography.css"));
     }
+    this.hasFullFont = dir.subfiles.includes((0, import_core4.fragment)("fullfont.scss"));
+    if (this.hasFullFont) {
+      this.sassBinaries = this.sassBinaries.filter((s) => !s.path.includes("fullfont.scss"));
+      this.stylesheets = this.stylesheets.filter((s) => !s.includes("fullfont.css"));
+    }
     this.markdownModules = ngModules.filter((m) => m.hasMarkdown).map((m) => this._resolvePath(m));
     if (this.name === "journey-maps") {
       this.markdownModules.push("web-component");

--- a/tools/schematics/bazel/ng-package.ts
+++ b/tools/schematics/bazel/ng-package.ts
@@ -11,6 +11,7 @@ export class NgPackage extends NgModule {
   hasSchematics: boolean;
   hasSrcFiles: boolean;
   hasTypography: boolean;
+  hasFullFont: boolean;
   markdownModules: string[];
 
   protected _templateUrl = './files/ngPackage';
@@ -27,6 +28,11 @@ export class NgPackage extends NgModule {
     if (this.hasTypography) {
       this.sassBinaries = this.sassBinaries.filter((s) => !s.path.includes('typography.scss'));
       this.stylesheets = this.stylesheets.filter((s) => !s.includes('typography.css'));
+    }
+    this.hasFullFont = dir.subfiles.includes(fragment('fullfont.scss'));
+    if (this.hasFullFont) {
+      this.sassBinaries = this.sassBinaries.filter((s) => !s.path.includes('fullfont.scss'));
+      this.stylesheets = this.stylesheets.filter((s) => !s.includes('fullfont.css'));
     }
     this.markdownModules = ngModules.filter((m) => m.hasMarkdown).map((m) => this._resolvePath(m));
     if (this.name === 'journey-maps') {


### PR DESCRIPTION
The `typography.css` file only contains a subset of the `SBBWeb` fonts that does not contain all characters (e.g. the French "œ").

For including the full fontset, we provide the `fullfont.css` file which can be added after the `typography.css` file.

```css
@import '@sbb-esta/angular/typography.css';
@import '@sbb-esta/angular/fullfont.css';
```

Closes #1564