### PR TITLE
fix(angular/button): add correct class if icon is not a direct descendant

### DIFF
--- a/src/angular/button/button.spec.ts
+++ b/src/angular/button/button.spec.ts
@@ -489,7 +489,7 @@ describe('SbbButton', () => {
         )!;
 
         expect(nonIconButtonElements.length).toEqual(10);
-        expect(iconButtonElements.length).toEqual(8);
+        expect(iconButtonElements.length).toEqual(9);
 
         expect(
           nonIconButtonElements.every(
@@ -684,6 +684,9 @@ class ButtonIconTest extends ButtonTestBase {}
       <a sbb-alt-button type="button"><sbb-icon svgIcon="example"></sbb-icon></a>
       <a sbb-secondary-button type="button"><sbb-icon svgIcon="example"></sbb-icon></a>
       <a sbb-ghost-button type="button"><sbb-icon svgIcon="example"></sbb-icon></a>
+      <button sbb-button type="button">
+        <a href="#"><sbb-icon svgIcon="example"></sbb-icon></a>
+      </button>
       <button sbb-button type="button"><sbb-icon svgIcon="example"></sbb-icon></button>
       <button sbb-alt-button type="button"><sbb-icon svgIcon="example"></sbb-icon></button>
       <button sbb-secondary-button type="button"><sbb-icon svgIcon="example"></sbb-icon></button>

--- a/src/angular/button/button.spec.ts
+++ b/src/angular/button/button.spec.ts
@@ -684,13 +684,13 @@ class ButtonIconTest extends ButtonTestBase {}
       <a sbb-alt-button type="button"><sbb-icon svgIcon="example"></sbb-icon></a>
       <a sbb-secondary-button type="button"><sbb-icon svgIcon="example"></sbb-icon></a>
       <a sbb-ghost-button type="button"><sbb-icon svgIcon="example"></sbb-icon></a>
-      <button sbb-button type="button">
+      <button sbb-button>
         <a href="#"><sbb-icon svgIcon="example"></sbb-icon></a>
       </button>
-      <button sbb-button type="button"><sbb-icon svgIcon="example"></sbb-icon></button>
-      <button sbb-alt-button type="button"><sbb-icon svgIcon="example"></sbb-icon></button>
-      <button sbb-secondary-button type="button"><sbb-icon svgIcon="example"></sbb-icon></button>
-      <button sbb-ghost-button type="button"><sbb-icon svgIcon="example"></sbb-icon></button>
+      <button sbb-button><sbb-icon svgIcon="example"></sbb-icon></button>
+      <button sbb-alt-button><sbb-icon svgIcon="example"></sbb-icon></button>
+      <button sbb-secondary-button><sbb-icon svgIcon="example"></sbb-icon></button>
+      <button sbb-ghost-button><sbb-icon svgIcon="example"></sbb-icon></button>
     </p>
 
     <p class="non-icon-buttons">

--- a/src/angular/button/button.ts
+++ b/src/angular/button/button.ts
@@ -106,8 +106,8 @@ export class SbbButton
    */
   @Input() svgIcon: string;
 
-  @ContentChildren(SbbIcon, { read: ElementRef }) _iconRefs: QueryList<ElementRef> =
-    new QueryList<ElementRef>();
+  @ContentChildren(SbbIcon, { read: ElementRef, descendants: true })
+  _iconRefs: QueryList<ElementRef> = new QueryList<ElementRef>();
 
   constructor(
     elementRef: ElementRef,


### PR DESCRIPTION
The `sbb-icon-button` class was not added if the icon is not a direct descendant, e.g. because it's wrapped in a link. This PR fixes this bug.