### PR TITLE
fix(angular/dialog): aria-modal not being set

### DIFF
--- a/src/angular/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog-config.ts
@@ -90,6 +90,9 @@ export class SbbDialogConfig<D = any> {
   /** Aria label to assign to the dialog element. */
   ariaLabel?: string | null = null;
 
+  /** Whether this is a modal dialog. Used to set the `aria-modal` attribute. */
+  ariaModal?: boolean = true;
+
   /** Whether the dialog should focus the first focusable element on open. */
   autoFocus?: boolean = true;
 

--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -113,9 +113,9 @@ export abstract class _SbbDialogContainerBase extends CdkDialogContainer<SbbDial
   host: {
     class: 'sbb-dialog-container',
     tabindex: '-1',
-    'aria-modal': 'true',
     '[id]': '_config.id',
     '[attr.role]': '_config.role',
+    '[attr.aria-modal]': '_config.ariaModal',
     '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledBy',
     '[attr.aria-label]': '_config.ariaLabel',
     '[attr.aria-describedby]': '_config.ariaDescribedBy || null',

--- a/src/angular/dialog/dialog.spec.ts
+++ b/src/angular/dialog/dialog.spec.ts
@@ -120,6 +120,7 @@ describe('SbbDialog', () => {
     viewContainerFixture.detectChanges();
     const dialogContainerElement = overlayContainerElement.querySelector('sbb-dialog-container')!;
     expect(dialogContainerElement.getAttribute('role')).toBe('dialog');
+    expect(dialogContainerElement.getAttribute('aria-modal')).toBe('true');
   });
 
   it('should open a dialog with a template', () => {
@@ -140,6 +141,7 @@ describe('SbbDialog', () => {
 
     const dialogContainerElement = overlayContainerElement.querySelector('sbb-dialog-container')!;
     expect(dialogContainerElement.getAttribute('role')).toBe('dialog');
+    expect(dialogContainerElement.getAttribute('aria-modal')).toBe('true');
 
     dialogRef.close();
   });

--- a/src/angular/lightbox/lightbox-config.ts
+++ b/src/angular/lightbox/lightbox-config.ts
@@ -46,6 +46,9 @@ export class SbbLightboxConfig<D = any> {
   /** Aria label to assign to the dialog element. */
   ariaLabel?: string | null = null;
 
+  /** Whether this is a modal dialog. Used to set the `aria-modal` attribute. */
+  ariaModal?: boolean = true;
+
   /** Whether the dialog should focus the first focusable element on open. */
   autoFocus?: boolean = true;
 

--- a/src/angular/lightbox/lightbox-container.ts
+++ b/src/angular/lightbox/lightbox-container.ts
@@ -35,9 +35,9 @@ import { sbbLightboxAnimations } from './lightbox-animations';
   host: {
     class: 'sbb-lightbox-container',
     tabindex: '-1',
-    'aria-modal': 'true',
     '[id]': '_config.id',
     '[attr.role]': '_config.role',
+    '[attr.aria-modal]': '_config.ariaModal',
     '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledBy',
     '[attr.aria-label]': '_config.ariaLabel',
     '[attr.aria-describedby]': '_config.ariaDescribedBy || null',

--- a/src/angular/lightbox/lightbox.spec.ts
+++ b/src/angular/lightbox/lightbox.spec.ts
@@ -121,6 +121,7 @@ describe('SbbLightbox', () => {
     const lightboxContainerElement =
       overlayContainerElement.querySelector('sbb-lightbox-container')!;
     expect(lightboxContainerElement.getAttribute('role')).toBe('dialog');
+    expect(lightboxContainerElement.getAttribute('aria-modal')).toBe('true');
   });
 
   it('should open a lightbox with a template', () => {
@@ -142,6 +143,7 @@ describe('SbbLightbox', () => {
     const lightboxContainerElement =
       overlayContainerElement.querySelector('sbb-lightbox-container')!;
     expect(lightboxContainerElement.getAttribute('role')).toBe('dialog');
+    expect(lightboxContainerElement.getAttribute('aria-modal')).toBe('true');
 
     lightboxRef.close();
   });


### PR DESCRIPTION
Fixes that `aria-modal` wasn't being set on the dialog container. This likely got broken when the dialog was changed to be based on top of the CDK dialog.

The `ariaModal` option is added to the config to avoid that it's overridden by the CDK dialog (see [cdk/dialog/dialog-container.ts#L62](https://github.com/angular/components/blob/main/src/cdk/dialog/dialog-container.ts#L62))