### PR TITLE
fix(angular/tooltip): animations running when timeouts haven't elapsed

### DIFF
--- a/src/angular/tooltip/tooltip.spec.ts
+++ b/src/angular/tooltip/tooltip.spec.ts
@@ -470,7 +470,6 @@ describe('SbbTooltip', () => {
       const tooltipDelay = 1000;
       tooltipDirective.hide();
       tick(tooltipDelay); // Change the tooltip state to hidden and trigger animation start
-      finishCurrentTooltipAnimation(overlayContainerElement, false);
 
       fixture.componentInstance.showButton = false;
       fixture.detectChanges();
@@ -489,7 +488,6 @@ describe('SbbTooltip', () => {
       tooltipDirective.hide(0);
       tick(0);
       fixture.detectChanges();
-      finishCurrentTooltipAnimation(overlayContainerElement, false);
 
       expect(spy).toHaveBeenCalled();
       subscription.unsubscribe();


### PR DESCRIPTION
After the tooltips were switched to CSS animations, a regression was introduced where the opposite animation is shown even if the tooltip didn't actually reach its target state.