### PR TITLE
fix(angular/checkbox): disabled state not distinguishable in high contrast mode

### DIFF
--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -1778,6 +1778,10 @@ textarea {
 
 .sbb-selection-disabled {
   pointer-events: none;
+
+  @include cdk.high-contrast(active, off) {
+    opacity: 0.5;
+  }
 }
 
 :is(.sbb-checkbox-group-vertical, .sbb-radio-group-vertical) {


### PR DESCRIPTION
Adds an 0.5 opacity to disabled checkboxes and radio buttons in high contrast mode