### PR TITLE
fix(angular/radio): radio not preselected with static value and an ngIf

### DIFF
--- a/src/angular/radio-button/BUILD.bazel
+++ b/src/angular/radio-button/BUILD.bazel
@@ -32,6 +32,7 @@ ng_test_library(
     deps = [
         ":radio-button",
         "//src/angular/core/testing",
+        "@npm//@angular/common",
         "@npm//@angular/forms",
         "@npm//@angular/platform-browser",
     ],

--- a/src/angular/radio-button/radio-button.ts
+++ b/src/angular/radio-button/radio-button.ts
@@ -449,12 +449,6 @@ export class _SbbRadioButtonBase
     if (tabIndex) {
       this.tabIndex = coerceNumberProperty(tabIndex, 0);
     }
-
-    this._removeUniqueSelectionListener = _radioDispatcher.listen((id: string, name: string) => {
-      if (id !== this.id && name === this.name) {
-        this.checked = false;
-      }
-    });
   }
 
   /** Focuses the radio button. */
@@ -490,6 +484,12 @@ export class _SbbRadioButtonBase
       // Copy name from parent radio group
       this.name = this.radioGroup.name;
     }
+
+    this._removeUniqueSelectionListener = this._radioDispatcher.listen((id, name) => {
+      if (id !== this.id && name === this.name) {
+        this.checked = false;
+      }
+    });
   }
 
   ngDoCheck(): void {


### PR DESCRIPTION
Fixes that radio buttons weren't being preselected correctly when they have an `ngIf` and a static `value`. It appears that the issue was because we were subscribing to the `UniqueSelectionDispatcher` before the name of the radio button is assigned.