### PR TITLE
build: account for new dev-infra packages @angular/ng-dev and `@angular/build-tooling`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -115,7 +115,7 @@ sass_repositories(
 
 # Setup repositories for browsers provided by the shared dev-infra package.
 load(
-    "@npm//@angular/dev-infra-private/bazel/browsers:browser_repositories.bzl",
+    "@npm//@angular/build-tooling/bazel/browsers:browser_repositories.bzl",
     _dev_infra_browser_repositories = "browser_repositories",
 )
 

--- a/angular-tsconfig.json
+++ b/angular-tsconfig.json
@@ -25,7 +25,8 @@
     "node_modules/@angular/bazel/**",
     "node_modules/@angular/common/upgrade*",
     "node_modules/@angular/compiler-cli/**",
-    "node_modules/@angular/dev-infra-private/**",
+    "node_modules/@angular/build-tooling/**",
+    "node_modules/@angular/ng-dev/**",
     "node_modules/@angular/router/upgrade*"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -74,12 +74,13 @@
     "@angular-devkit/schematics": "14.2.7",
     "@angular-devkit/schematics-cli": "14.2.7",
     "@angular/bazel": "14.2.8",
+    "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#1addc303bef0b6acc0dca0961e9e642629f3a5cd",
     "@angular/cli": "14.2.7",
     "@angular/compiler": "14.2.8",
     "@angular/compiler-cli": "14.2.8",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#6d9c069f7ba8bedd07d376444d65472154026ce8",
     "@angular/language-service": "14.2.8",
     "@angular/localize": "14.2.8",
+    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#865c7687cdca2bd512040330e1677eecaa26e46a",
     "@babel/core": "7.19.6",
     "@babel/traverse": "7.19.6",
     "@bazel/bazelisk": "1.12.1",
@@ -170,7 +171,8 @@
     "yargs": "17.6.0"
   },
   "resolutions": {
-    "@angular/dev-infra-private/typescript": "4.8.2",
+    "@angular/build-tooling/typescript": "4.8.2",
+    "@angular/ng-dev/typescript": "4.8.2",
     "browser-sync-client": "2.26.13",
     "dgeni-packages/typescript": "4.8.2"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -94,7 +94,7 @@
       "extends": ["schedule:monthly"]
     },
     {
-      "matchPackageNames": ["@angular/dev-infra-private", "angular/dev-infra"],
+      "matchPackageNames": ["@angular/build-tooling", "angular/dev-infra", "@angular/ng-dev"],
       "groupName": "angular shared dev-infra code",
       "schedule": ["before 5am on wednesday"]
     }

--- a/tools/angular/BUILD.bazel
+++ b/tools/angular/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/esbuild:index.bzl", "esbuild_config")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", "esbuild_config")
 load(":index.bzl", "create_angular_bundle_targets")
 
 package(default_visibility = ["//visibility:public"])
@@ -7,7 +7,7 @@ esbuild_config(
     name = "esbuild_config",
     config_file = "esbuild.config.mjs",
     deps = [
-        "@npm//@angular/dev-infra-private/shared-scripts/angular-linker:js_lib",
+        "@npm//@angular/build-tooling/shared-scripts/angular-linker:js_lib",
     ],
 )
 

--- a/tools/angular/esbuild.config.mjs
+++ b/tools/angular/esbuild.config.mjs
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { createLinkerEsbuildPlugin } from '@angular/dev-infra-private/shared-scripts/angular-linker/esbuild-plugin.mjs';
+import { createLinkerEsbuildPlugin } from '@angular/build-tooling/shared-scripts/angular-linker/esbuild-plugin.mjs';
 
 export default {
   // Note: We support `.mjs` here as this is the extension used by Angular APF packages.

--- a/tools/angular/index.bzl
+++ b/tools/angular/index.bzl
@@ -9,7 +9,7 @@
 """
 
 load("//:packages.bzl", "ANGULAR_PACKAGES")
-load("@npm//@angular/dev-infra-private/bazel/esbuild:index.bzl", "esbuild")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", "esbuild")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "LinkerPackageMappingInfo")
 load("@build_bazel_rules_nodejs//:providers.bzl", "ExternalNpmPackageInfo", "JSModuleInfo")
 

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -6,12 +6,12 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", _pkg_npm = "pkg_npm")
 load("@io_bazel_rules_sass//:defs.bzl", _sass_binary = "sass_binary", _sass_library = "sass_library")
 load("@npm//@angular/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
-load("@npm//@angular/dev-infra-private/bazel/karma:index.bzl", _karma_web_test_suite = "karma_web_test_suite")
-load("@npm//@angular/dev-infra-private/bazel/esbuild:index.bzl", _esbuild = "esbuild", _esbuild_config = "esbuild_config")
-load("@npm//@angular/dev-infra-private/bazel/spec-bundling:index.bzl", _spec_bundle = "spec_bundle")
-load("@npm//@angular/dev-infra-private/bazel/http-server:index.bzl", _http_server = "http_server")
-load("@npm//@angular/dev-infra-private/bazel:extract_js_module_output.bzl", "extract_js_module_output")
-load("@npm//@angular/dev-infra-private/bazel/app-bundling:index.bzl", _app_bundle = "app_bundle")
+load("@npm//@angular/build-tooling/bazel/karma:index.bzl", _karma_web_test_suite = "karma_web_test_suite")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", _esbuild = "esbuild", _esbuild_config = "esbuild_config")
+load("@npm//@angular/build-tooling/bazel/spec-bundling:index.bzl", _spec_bundle = "spec_bundle")
+load("@npm//@angular/build-tooling/bazel/http-server:index.bzl", _http_server = "http_server")
+load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")
+load("@npm//@angular/build-tooling/bazel/app-bundling:index.bzl", _app_bundle = "app_bundle")
 load("@npm//@bazel/jasmine:index.bzl", _jasmine_node_test = "jasmine_node_test")
 load("@npm//@bazel/protractor:index.bzl", _protractor_web_test_suite = "protractor_web_test_suite")
 load("@npm//@bazel/concatjs:index.bzl", _ts_library = "ts_library")
@@ -289,8 +289,8 @@ def karma_web_test_suite(name, **kwargs):
         kwargs["browsers"] = [
             # Note: when changing the browser names here, also update the "yarn test"
             # script to reflect the new browser names.
-            "@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium",
-            "@npm//@angular/dev-infra-private/bazel/browsers/firefox:firefox",
+            "@npm//@angular/build-tooling/bazel/browsers/chromium:chromium",
+            "@npm//@angular/build-tooling/bazel/browsers/firefox:firefox",
         ]
 
     # Default test suite with all configured browsers, and the debug target being
@@ -310,7 +310,7 @@ def protractor_web_test_suite(name, deps, **kwargs):
 
     _protractor_web_test_suite(
         name = name,
-        browsers = ["@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium"],
+        browsers = ["@npm//@angular/build-tooling/bazel/browsers/chromium:chromium"],
         deps = ["%s_bundle" % name],
         **kwargs
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,6 +313,42 @@
     "@angular/core" "^13.0.0 || ^14.0.0-0"
     reflect-metadata "^0.1.13"
 
+"@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#1addc303bef0b6acc0dca0961e9e642629f3a5cd":
+  version "0.0.0-fa61d03a603e04af2b66f3598f1af01da1e1cfb1"
+  resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#1addc303bef0b6acc0dca0961e9e642629f3a5cd"
+  dependencies:
+    "@angular-devkit/build-angular" "14.1.0-rc.3"
+    "@angular/benchpress" "0.3.0"
+    "@babel/core" "^7.16.0"
+    "@bazel/buildifier" "5.1.0"
+    "@bazel/concatjs" "5.5.2"
+    "@bazel/esbuild" "5.5.2"
+    "@bazel/protractor" "5.5.2"
+    "@bazel/runfiles" "5.5.2"
+    "@bazel/terser" "5.5.2"
+    "@bazel/typescript" "5.5.2"
+    "@microsoft/api-extractor" "7.28.4"
+    "@types/browser-sync" "^2.26.3"
+    "@types/node" "16.10.9"
+    "@types/selenium-webdriver" "^4.0.18"
+    "@types/send" "^0.17.1"
+    "@types/tmp" "^0.2.1"
+    "@types/uuid" "^8.3.1"
+    "@types/yargs" "^17.0.0"
+    browser-sync "^2.27.7"
+    clang-format "1.8.0"
+    prettier "2.7.1"
+    protractor "^7.0.0"
+    selenium-webdriver "4.3.1"
+    send "^0.18.0"
+    source-map "^0.7.4"
+    tmp "^0.2.1"
+    "true-case-path" "^2.2.1"
+    tslib "^2.3.0"
+    typescript "~4.7.3"
+    uuid "^8.3.2"
+    yargs "^17.0.0"
+
 "@angular/cdk@14.2.6":
   version "14.2.6"
   resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-14.2.6.tgz#5d78f7eebd228b1d71910e9e3703e02bee84ddcf"
@@ -395,43 +431,6 @@
   resolved "https://registry.yarnpkg.com/@angular/core/-/core-9.0.0.tgz#227dc53e1ac81824f998c6e76000b7efc522641e"
   integrity sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#6d9c069f7ba8bedd07d376444d65472154026ce8":
-  version "0.0.0-e5a5a4c9edf515bcafb9b72a90fe2ad3e811df1d"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#6d9c069f7ba8bedd07d376444d65472154026ce8"
-  dependencies:
-    "@angular-devkit/build-angular" "14.1.0-rc.3"
-    "@angular/benchpress" "0.3.0"
-    "@babel/core" "^7.16.0"
-    "@bazel/buildifier" "5.1.0"
-    "@bazel/concatjs" "5.5.2"
-    "@bazel/esbuild" "5.5.2"
-    "@bazel/protractor" "5.5.2"
-    "@bazel/runfiles" "5.5.2"
-    "@bazel/terser" "5.5.2"
-    "@bazel/typescript" "5.5.2"
-    "@microsoft/api-extractor" "7.28.4"
-    "@types/browser-sync" "^2.26.3"
-    "@types/node" "16.10.9"
-    "@types/selenium-webdriver" "^4.0.18"
-    "@types/send" "^0.17.1"
-    "@types/tmp" "^0.2.1"
-    "@types/uuid" "^8.3.1"
-    "@types/yargs" "^17.0.0"
-    "@yarnpkg/lockfile" "^1.1.0"
-    browser-sync "^2.27.7"
-    clang-format "1.8.0"
-    prettier "2.7.1"
-    protractor "^7.0.0"
-    selenium-webdriver "4.3.1"
-    send "^0.18.0"
-    source-map "^0.7.4"
-    tmp "^0.2.1"
-    "true-case-path" "^2.2.1"
-    tslib "^2.3.0"
-    typescript "~4.7.3"
-    uuid "^8.3.2"
-    yargs "^17.0.0"
-
 "@angular/elements@14.2.8":
   version "14.2.8"
   resolved "https://registry.yarnpkg.com/@angular/elements/-/elements-14.2.8.tgz#3e52b3443bec049636098fbd9391deca1cfdf0da"
@@ -459,6 +458,13 @@
     "@babel/core" "7.18.9"
     glob "8.0.3"
     yargs "^17.2.1"
+
+"@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#865c7687cdca2bd512040330e1677eecaa26e46a":
+  version "0.0.0-fa61d03a603e04af2b66f3598f1af01da1e1cfb1"
+  resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#865c7687cdca2bd512040330e1677eecaa26e46a"
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    typescript "~4.7.3"
 
 "@angular/platform-browser-dynamic@14.2.8":
   version "14.2.8"
@@ -16765,7 +16771,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.8.2, typescript@~4.5.4, typescript@~4.7.3:
+typescript@4.8.2, typescript@~4.5.4:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
   integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
@@ -16779,6 +16785,11 @@ typescript@~4.6.3:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+typescript@~4.7.3:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 ua-parser-js@0.7.12:
   version "0.7.12"


### PR DESCRIPTION
The dev-infra-private packages were split to decouple the ng-dev tool from the build tooling. This allows to easily update ng-dev e.g. in LTS branches without needing to update Bazel.

It is important that ng-dev can be updated as much as possible in all branches to ensure the release IPC reliably works.