### PR TITLE
fix(angular/lightbox): update height on window resize

### DIFF
--- a/src/angular/lightbox/lightbox-container.ts
+++ b/src/angular/lightbox/lightbox-container.ts
@@ -113,6 +113,7 @@ export class SbbLightboxContainer extends _SbbDialogContainerBase implements OnD
       .pipe(takeUntil(this._destroyed), startWith(null))
       .subscribe(() => {
         this._height = this._viewportRuler!.getViewportSize().height;
+        this._changeDetectorRef.markForCheck();
       });
   }
 

--- a/src/angular/lightbox/lightbox.scss
+++ b/src/angular/lightbox/lightbox.scss
@@ -16,9 +16,7 @@
 
   // The dialog container width should completely fill its parent overlay element.
   width: 100%;
-
-  // Fallback if viewport height cannot be calculated by the component.
-  height: 100vh;
+  height: 100%;
 
   @include cdk.high-contrast(active, off) {
     outline: solid sbb.pxToRem(1);

--- a/src/angular/lightbox/lightbox.ts
+++ b/src/angular/lightbox/lightbox.ts
@@ -102,7 +102,7 @@ export class SbbLightbox extends _SbbDialogBase<SbbLightboxContainer, SbbLightbo
       width: '100vw',
       minWidth: '100vw',
       maxWidth: '100vw',
-      height: 'auto',
+      height: '100vh',
       minHeight: 'auto',
       maxHeight: 'none',
     };


### PR DESCRIPTION
For inexplicable reasons updating the height of the Lightbox using host binding did sometimes not work. This probably has to do with the change detection of the `CdkOverlay`. In this fix we therefore update the overlay size directly using `CdkOverlay.updateSize()`.

For backward compatibility and if no `ViewportRuler` is injected, we set the initial overlay height to `100vh`.

Closes #1696