### PR TITLE
fix(angular/tooltip): change tooltip icon to info

### DIFF
--- a/src/angular/tooltip/tooltip-wrapper.html
+++ b/src/angular/tooltip/tooltip-wrapper.html
@@ -11,7 +11,7 @@
   #tooltip="sbbTooltip"
   (click)="tooltip.show(0)"
 >
-  <sbb-icon [svgIcon]="svgIcon"></sbb-icon>
+  <sbb-icon [svgIcon]="(_svgIcon | async)!"></sbb-icon>
 </button>
 <ng-template #tooltipTemplate>
   <ng-content></ng-content>

--- a/src/angular/tooltip/tooltip-wrapper.spec.ts
+++ b/src/angular/tooltip/tooltip-wrapper.spec.ts
@@ -18,6 +18,7 @@ import {
   dispatchEvent,
   dispatchKeyboardEvent,
   dispatchMouseEvent,
+  switchToLean,
 } from '@sbb-esta/angular/core/testing';
 import { SbbIconTestingModule } from '@sbb-esta/angular/icon/testing';
 
@@ -209,6 +210,21 @@ describe('SbbTooltipWrapper', () => {
       expect(tooltip.classList).toContain('custom-one');
       expect(tooltip.classList).toContain('custom-two');
     }));
+
+    it('should show the correct icon in standard variant', () => {
+      const spy = jasmine.createSpy('icon subject spy');
+      component.tooltip._svgIcon.subscribe(spy);
+      expect(spy).toHaveBeenCalledWith('kom:circle-question-mark-small');
+    });
+
+    describe('lean', () => {
+      switchToLean();
+      it('should show the correct icon', () => {
+        const spy = jasmine.createSpy('icon subject spy');
+        component.tooltip._svgIcon.subscribe(spy);
+        expect(spy).toHaveBeenCalledWith('kom:circle-information-small');
+      });
+    });
   });
 
   describe('using two tooltips', () => {

--- a/src/angular/tooltip/tooltip-wrapper.ts
+++ b/src/angular/tooltip/tooltip-wrapper.ts
@@ -69,7 +69,7 @@ export class SbbTooltipWrapper extends _SbbTooltipWrapperMixinBase implements On
    *
    * e.g. svgIcon="kom:circle-question-mark-small"
    */
-  @Input() svgIcon: string = 'kom:circle-question-mark-small';
+  @Input() svgIcon: string = 'kom:circle-information-small';
 
   /** Classes to be passed to the tooltip. Supports the same syntax as `ngClass`. */
   @Input() sbbTooltipClass: string | string[] | Set<string> | { [key: string]: any };


### PR DESCRIPTION
BREAKING CHANGE: We align the default tooltip icon with the SBB style guide and replace the question mark with an info icon.

Closes #1684