### PR TITLE
refactor: remove UpdateBuffer patching

### DIFF
--- a/src/angular/schematics/ng-update/index.ts
+++ b/src/angular/schematics/ng-update/index.ts
@@ -1,9 +1,5 @@
 import { chain, Rule, SchematicContext } from '@angular-devkit/schematics';
 import {
-  UpdateBuffer2,
-  UpdateBufferBase,
-} from '@angular-devkit/schematics/src/utility/update-buffer';
-import {
   cdkMigrations,
   createMigrationSchematicRule,
   TargetVersion,
@@ -16,7 +12,6 @@ import { sbbAngularUpgradeData } from './upgrade-data';
 
 /** Entry point for the migration schematics with target of SBB Angular v13 */
 export function updateToV13(): Rule {
-  patchUpdateBuffer();
   return chain([
     leanTestConfigurationMigration,
     createMigrationSchematicRule(TargetVersion.V13, [], sbbAngularUpgradeData, onMigrationComplete),
@@ -25,7 +20,6 @@ export function updateToV13(): Rule {
 
 /** Entry point for the migration schematics with target of Angular v14 */
 export function updateToV14(): Rule {
-  patchUpdateBuffer();
   patchClassNamesMigration();
   return createMigrationSchematicRule(
     TargetVersion.V14,
@@ -37,7 +31,6 @@ export function updateToV14(): Rule {
 
 /** Entry point for the migration schematics with target of Angular 15 */
 export function updateToV15(): Rule {
-  patchUpdateBuffer();
   patchClassNamesMigration();
   return createMigrationSchematicRule(
     TargetVersion.V15,
@@ -45,13 +38,6 @@ export function updateToV15(): Rule {
     sbbAngularUpgradeData,
     onMigrationComplete
   );
-}
-
-function patchUpdateBuffer() {
-  if (UpdateBufferBase.create) {
-    UpdateBufferBase.create = (originalContent: Buffer): UpdateBufferBase =>
-      new UpdateBuffer2(originalContent);
-  }
 }
 
 function patchClassNamesMigration() {


### PR DESCRIPTION
Upstream UpdateBuffer change has been merged (https://github.com/angular/angular-cli/pull/24035) which allows us to remove the UpdateBuffer patching.