### PR TITLE
fix(multiple): clean up list key manager on destroy

### DIFF
--- a/src/angular/accordion/accordion.ts
+++ b/src/angular/accordion/accordion.ts
@@ -69,6 +69,7 @@ export class SbbAccordion extends CdkAccordion implements AfterContentInit, OnDe
 
   override ngOnDestroy() {
     super.ngOnDestroy();
+    this._keyManager?.destroy();
     this._ownHeaders.destroy();
   }
 }

--- a/src/angular/autocomplete/autocomplete.ts
+++ b/src/angular/autocomplete/autocomplete.ts
@@ -267,6 +267,7 @@ export class SbbAutocomplete implements AfterContentInit, OnDestroy {
 
   ngOnDestroy() {
     this._activeOptionChanges.unsubscribe();
+    this._keyManager?.destroy();
   }
 
   /**

--- a/src/angular/chips/chip-list.ts
+++ b/src/angular/chips/chip-list.ts
@@ -313,9 +313,7 @@ export class SbbChipList
       .withHomeAndEnd()
       .withHorizontalOrientation('ltr');
 
-    this._keyManager.tabOut.pipe(takeUntil(this._destroyed)).subscribe(() => {
-      this._allowFocusEscape();
-    });
+    this._keyManager.tabOut.subscribe(() => this._allowFocusEscape());
 
     // When the list changes, re-subscribe
     this.chips.changes.pipe(startWith(null), takeUntil(this._destroyed)).subscribe(() => {
@@ -365,10 +363,10 @@ export class SbbChipList
   }
 
   ngOnDestroy() {
+    this._keyManager?.destroy();
     this._destroyed.next();
     this._destroyed.complete();
     this.stateChanges.complete();
-
     this._dropSubscriptions();
   }
 

--- a/src/angular/header-lean/header-menu.ts
+++ b/src/angular/header-lean/header-menu.ts
@@ -23,7 +23,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { TypeRef } from '@sbb-esta/angular/core';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { map, startWith, takeUntil } from 'rxjs/operators';
 
 import type { SbbHeaderLean } from './header';
@@ -130,7 +130,6 @@ export class SbbHeaderMenu implements AfterContentInit, OnDestroy {
   _animationState: 'closed' | 'open-panel' | 'open-menu' = 'closed';
 
   /** Subscription to tab events on the menu panel */
-  private _tabSubscription = Subscription.EMPTY;
   private _destroyed = new Subject<void>();
 
   constructor(
@@ -153,11 +152,11 @@ export class SbbHeaderMenu implements AfterContentInit, OnDestroy {
       )
       .subscribe((s) => (this.showPanel = s));
     this._keyManager = new FocusKeyManager(this._items).withWrap().withTypeAhead();
-    this._tabSubscription = this._keyManager.tabOut.subscribe(() => this.closed.emit('tab'));
+    this._keyManager.tabOut.subscribe(() => this.closed.emit('tab'));
   }
 
   ngOnDestroy() {
-    this._tabSubscription.unsubscribe();
+    this._keyManager?.destroy();
     this.closed.complete();
     this._destroyed.next();
     this._destroyed.complete();

--- a/src/angular/menu/menu.ts
+++ b/src/angular/menu/menu.ts
@@ -23,7 +23,7 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { merge, Observable, Subject, Subscription } from 'rxjs';
+import { merge, Observable, Subject } from 'rxjs';
 import { startWith, switchMap, take } from 'rxjs/operators';
 
 import { sbbMenuAnimations } from './menu-animations';
@@ -116,9 +116,6 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
 
   /** Only the direct descendant menu items. */
   _directDescendantItems: QueryList<SbbMenuItem> = new QueryList<SbbMenuItem>();
-
-  /** Subscription to tab events on the menu panel */
-  private _tabSubscription = Subscription.EMPTY;
 
   /** Config object to be passed into the menu's ngClass */
   _classList: { [key: string]: boolean } = {};
@@ -273,7 +270,7 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
       .withWrap()
       .withTypeAhead()
       .withHomeAndEnd();
-    this._tabSubscription = this._keyManager.tabOut.subscribe(() => this.closed.emit('tab'));
+    this._keyManager.tabOut.subscribe(() => this.closed.emit('tab'));
 
     // If a user manually (programmatically) focuses a menu item, we need to reflect that focus
     // change back to the key manager. Note that we don't need to unsubscribe here because _focused
@@ -305,8 +302,8 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
   }
 
   ngOnDestroy() {
+    this._keyManager?.destroy();
     this._directDescendantItems.destroy();
-    this._tabSubscription.unsubscribe();
     this.closed.complete();
   }
 

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -634,6 +634,7 @@ export class SbbSelect
     this._destroy.next();
     this._destroy.complete();
     this.stateChanges.complete();
+    this._keyManager?.destroy();
   }
 
   /** Toggles the overlay panel open or closed. */
@@ -980,7 +981,7 @@ export class SbbSelect
       .withHomeAndEnd()
       .withAllowedModifierKeys(['shiftKey']);
 
-    this._keyManager.tabOut.pipe(takeUntil(this._destroy)).subscribe(() => {
+    this._keyManager.tabOut.subscribe(() => {
       if (this.panelOpen) {
         // Select the active item when tabbing away. This is consistent with how the native
         // select behaves. Note that we only want to do this in single selection mode.
@@ -995,7 +996,7 @@ export class SbbSelect
       }
     });
 
-    this._keyManager.change.pipe(takeUntil(this._destroy)).subscribe(() => {
+    this._keyManager.change.subscribe(() => {
       if (this._panelOpen && this.panel) {
         this._scrollOptionIntoView(this._keyManager.activeItemIndex || 0);
       } else if (!this._panelOpen && !this.multiple && this._keyManager.activeItem) {

--- a/src/angular/tabs/paginated-tab-header.ts
+++ b/src/angular/tabs/paginated-tab-header.ts
@@ -248,7 +248,7 @@ export abstract class SbbPaginatedTabHeader
     // If there is a change in the focus key manager we need to emit the `indexFocused`
     // event in order to provide a public event that notifies about focus changes. Also we realign
     // the tabs container by scrolling the new focused tab into the visible section.
-    this._keyManager.change.pipe(takeUntil(this._destroyed)).subscribe((newFocusIndex) => {
+    this._keyManager.change.subscribe((newFocusIndex) => {
       this.indexFocused.emit(newFocusIndex);
       this._setTabFocus(newFocusIndex);
     });
@@ -316,6 +316,7 @@ export abstract class SbbPaginatedTabHeader
   }
 
   ngOnDestroy() {
+    this._keyManager?.destroy();
     this._destroyed.next();
     this._destroyed.complete();
     this._stopScrolling.complete();


### PR DESCRIPTION
Historically we haven't needed to do any cleanup for the `ListKeyManager`, because it didn't contain any rxjs subscriptions. Over time more functionality was accumulated which now needs to be cleaned up.

These changes call the new `destroy` method in all the relevant places.