### PR TITLE
refactor: remove various deprecations

### DIFF
--- a/src/angular/button/button.ts
+++ b/src/angular/button/button.ts
@@ -113,8 +113,7 @@ export class SbbButton
     elementRef: ElementRef,
     private _focusMonitor: FocusMonitor,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) public _animationMode: string,
-    /** @breaking-change Make required with version 15. */
-    @Optional() private _contentObserver?: ContentObserver
+    private _contentObserver: ContentObserver
   ) {
     super(elementRef);
 
@@ -223,8 +222,7 @@ export class SbbAnchor extends SbbButton implements AfterViewInit, OnDestroy {
     elementRef: ElementRef,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode: string,
     private _ngZone: NgZone,
-    /** @breaking-change Make required with version 15. */
-    @Optional() contentObserver?: ContentObserver
+    contentObserver: ContentObserver
   ) {
     super(elementRef, focusMonitor, animationMode, contentObserver);
   }

--- a/src/angular/button/button.ts
+++ b/src/angular/button/button.ts
@@ -137,9 +137,7 @@ export class SbbButton
   }
 
   ngAfterContentInit() {
-    const contentChangeSource =
-      this._contentObserver?.observe(this._elementRef) ?? this._iconRefs.changes;
-    this._isIconButton = contentChangeSource?.pipe(
+    this._isIconButton = this._contentObserver.observe(this._elementRef).pipe(
       startWith([]),
       map(
         () =>

--- a/src/angular/core/datetime/date-formats.ts
+++ b/src/angular/core/datetime/date-formats.ts
@@ -2,11 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 export interface SbbDateFormats {
   dateInput: any;
-  /**
-   * Parameter `dateInputPure` will become required.
-   * @breaking-change 15.0.0
-   */
-  dateInputPure?: any;
+  dateInputPure: any;
   dateA11yLabel: any;
 }
 

--- a/src/angular/dialog/dialog.ts
+++ b/src/angular/dialog/dialog.ts
@@ -1,5 +1,5 @@
 import { Dialog, DialogConfig } from '@angular/cdk/dialog';
-import { Overlay, OverlayContainer, ScrollStrategy } from '@angular/cdk/overlay';
+import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
 import { ComponentType } from '@angular/cdk/portal';
 import {
   Inject,
@@ -102,11 +102,6 @@ export abstract class _SbbDialogBase<
     injector: Injector,
     private _defaultOptions: SbbDialogConfig | undefined,
     private _parentDialog: _SbbDialogBase<C, F> | undefined,
-    /**
-     * @deprecated No longer used. To be removed.
-     * @breaking-change 15.0.0
-     */
-    _overlayContainer: OverlayContainer,
     scrollStrategy: any,
     private _dialogRefConstructor: Type<F>,
     private _dialogContainerType: Type<C>,
@@ -228,19 +223,13 @@ export class SbbDialog extends _SbbDialogBase<SbbDialogContainer> {
     injector: Injector,
     @Optional() @Inject(SBB_DIALOG_DEFAULT_OPTIONS) defaultOptions: SbbDialogConfig,
     @Inject(SBB_DIALOG_SCROLL_STRATEGY) scrollStrategy: any,
-    @Optional() @SkipSelf() parentDialog: SbbDialog,
-    /**
-     * @deprecated No longer used. To be removed.
-     * @breaking-change 15.0.0
-     */
-    overlayContainer: OverlayContainer
+    @Optional() @SkipSelf() parentDialog: SbbDialog
   ) {
     super(
       overlay,
       injector,
       defaultOptions,
       parentDialog,
-      overlayContainer,
       scrollStrategy,
       SbbDialogRef,
       SbbDialogContainer,

--- a/src/angular/lightbox/lightbox.ts
+++ b/src/angular/lightbox/lightbox.ts
@@ -1,4 +1,4 @@
-import { Overlay, OverlayContainer, ScrollStrategy } from '@angular/cdk/overlay';
+import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
 import { ComponentType } from '@angular/cdk/portal';
 import {
   Inject,
@@ -67,19 +67,13 @@ export class SbbLightbox extends _SbbDialogBase<SbbLightboxContainer, SbbLightbo
     injector: Injector,
     @Optional() @Inject(SBB_LIGHTBOX_DEFAULT_OPTIONS) defaultOptions: SbbLightboxConfig,
     @Inject(SBB_LIGHTBOX_SCROLL_STRATEGY) scrollStrategy: any,
-    @Optional() @SkipSelf() parentDialog: SbbLightbox,
-    /**
-     * @deprecated No longer used. To be removed.
-     * @breaking-change 15.0.0
-     */
-    overlayContainer: OverlayContainer
+    @Optional() @SkipSelf() parentDialog: SbbLightbox
   ) {
     super(
       overlay,
       injector,
       defaultOptions,
       parentDialog,
-      overlayContainer,
       scrollStrategy,
       SbbLightboxRef,
       SbbLightboxContainer,

--- a/src/angular/loading-indicator/BUILD.bazel
+++ b/src/angular/loading-indicator/BUILD.bazel
@@ -17,7 +17,6 @@ ng_module(
     ),
     assets = [":loading-indicator.css"] + glob(["**/*.html"]),
     deps = [
-        "//src:dev_mode_types",
         "//src/angular/core",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/src/angular/loading-indicator/loading-indicator.scss
+++ b/src/angular/loading-indicator/loading-indicator.scss
@@ -8,8 +8,7 @@ $time: 0.23s;
 // (size, width, height, gutterWidth, perspective)
 $sizes: (tiny, 0.53333em, 0.33333em, 0.2em, 6em), (small, 1em, 0.6em, 0.2em, 8em),
   (medium, 2em, 1.2em, 0.3em, 12em), (big, 3em, 1.8em, 0.46666em, 16.66666em),
-  (fullbox, 2em, 1.2em, 0.33333em, 11.33333em), (fullscreen, 2em, 1.2em, 0.33333em, 11.33333em),
-  (inline, 0.53333em, 0.33333em, 0.2em, 6em);
+  (fullbox, 2em, 1.2em, 0.33333em, 11.33333em), (inline, 0.53333em, 0.33333em, 0.2em, 6em);
 
 $loadingRectangleOpacities: (1, 0.5, 0), (2, 1, 0.5), (3, 0.5, 1), (4, 0.25, 0.5), (5, 0, 0.25);
 
@@ -97,7 +96,7 @@ $loadingRectangleOpacities: (1, 0.5, 0), (2, 1, 0.5), (3, 0.5, 1), (4, 0.25, 0.5
   }
 }
 
-:is(.sbb-loading-indicator-fullbox, .sbb-loading-indicator-fullscreen) {
+.sbb-loading-indicator-fullbox {
   top: 0;
   left: 0;
   height: 100%;
@@ -115,10 +114,6 @@ $loadingRectangleOpacities: (1, 0.5, 0), (2, 1, 0.5), (3, 0.5, 1), (4, 0.25, 0.5
 
 .sbb-loading-indicator-fullbox {
   position: absolute;
-}
-
-.sbb-loading-indicator-fullscreen {
-  position: fixed;
 }
 
 // Animations

--- a/src/angular/loading-indicator/loading-indicator.ts
+++ b/src/angular/loading-indicator/loading-indicator.ts
@@ -1,15 +1,8 @@
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 
-const sbbAvailableModes = ['tiny', 'small', 'medium', 'big', 'fullscreen', 'fullbox', 'inline'];
+const sbbAvailableModes = ['tiny', 'small', 'medium', 'big', 'fullbox', 'inline'];
 
-export type SbbLoadingIndicatorMode =
-  | 'tiny'
-  | 'small'
-  | 'medium'
-  | 'big'
-  | 'fullscreen'
-  | 'fullbox'
-  | 'inline';
+export type SbbLoadingIndicatorMode = 'tiny' | 'small' | 'medium' | 'big' | 'fullbox' | 'inline';
 
 @Component({
   selector: 'sbb-loading-indicator',
@@ -25,8 +18,6 @@ export type SbbLoadingIndicatorMode =
     '[class.sbb-loading-indicator-small]': `this.mode === 'small'`,
     '[class.sbb-loading-indicator-medium]': `this.mode === 'medium'`,
     '[class.sbb-loading-indicator-big]': `this.mode === 'big'`,
-    // TODO: @deprecated mode fullscreen will be removed with next major version (v15)
-    '[class.sbb-loading-indicator-fullscreen]': `this.mode === 'fullscreen'`,
     '[class.sbb-loading-indicator-fullbox]': `this.mode === 'fullbox'`,
     '[class.sbb-loading-indicator-inline]': `this.mode === 'inline'`,
   },
@@ -41,10 +32,6 @@ export class SbbLoadingIndicator {
     if (!sbbAvailableModes.includes(value)) {
       this._mode = 'medium';
       return;
-    } else if (value === 'fullscreen' && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      console.warn(
-        'The mode fullscreen for the loading indicator is deprecated and will be removed with the next major version. Please consider another mode.'
-      );
     }
     this._mode = value as SbbLoadingIndicatorMode;
   }

--- a/src/angular/menu/menu-trigger.ts
+++ b/src/angular/menu/menu-trigger.ts
@@ -237,11 +237,7 @@ export class SbbMenuTrigger
     private _sanitizer: DomSanitizer,
     private _breakpointObserver: BreakpointObserver,
     private _changeDetectorRef: ChangeDetectorRef,
-    /**
-     * @deprecated `ngZone` will become a required parameter.
-     * @breaking-change 15.0.0
-     */
-    private _ngZone?: NgZone
+    private _ngZone: NgZone
   ) {
     super();
 
@@ -534,14 +530,7 @@ export class SbbMenuTrigger
         this._element.nativeElement.classList.add(`sbb-menu-trigger-${posX}`);
         this._element.nativeElement.classList.add(`sbb-menu-trigger-${posY}`);
 
-        // @breaking-change 15.0.0 Remove null check for `ngZone`.
-        // `positionChanges` fires outside of the `ngZone` and `setPositionClasses` might be
-        // updating something in the view, so we need to bring it back in.
-        if (this._ngZone) {
-          this._ngZone.run(() => menu.setPositionClasses!(posX, posY));
-        } else {
-          menu.setPositionClasses!(posX, posY);
-        }
+        this._ngZone.run(() => menu.setPositionClasses!(posX, posY));
       });
     }
   }

--- a/src/angular/menu/menu.ts
+++ b/src/angular/menu/menu.ts
@@ -256,8 +256,7 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
     private _elementRef: ElementRef<HTMLElement>,
     private _ngZone: NgZone,
     @Inject(SBB_MENU_DEFAULT_OPTIONS) private _defaultOptions: SbbMenuDefaultOptions,
-    // @breaking-change 15.0.0 `_changeDetectorRef` to become a required parameter.
-    private _changeDetectorRef?: ChangeDetectorRef
+    private _changeDetectorRef: ChangeDetectorRef
   ) {}
 
   ngOnInit() {
@@ -432,8 +431,7 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
     classes['sbb-menu-panel-above'] = posY === 'above';
     classes['sbb-menu-panel-below'] = posY === 'below';
 
-    // @breaking-change 15.0.0 Remove null check for `_changeDetectorRef`.
-    this._changeDetectorRef?.markForCheck();
+    this._changeDetectorRef.markForCheck();
   }
 
   /** Starts the enter animation. */


### PR DESCRIPTION
BREAKING CHANGE:
- SbbButton: Constructor parameter `contentObserver` becomes required.
- SbbDateFormats: `dateInputPure` becomes required.
- SbbDialog: Remove unused constructor parameter `overlayContainer`.
- SbbLightbox: Remove unused constructor parameter `overlayContainer`.
- SbbMenu: Constructor parameter `_changeDetectorRef` becomes required.
- SbbMenuTrigger: Constructor parameter `_ngZone` becomes required.
- SbbLoadingIndicator: Mode `fullscreen` is removed.