### PR TITLE
ci: fix renovate by setting `skipInstalls` to `false`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,7 @@
     "yarn",
     "zone.js"
   ],
+  "skipInstalls": false,
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance", "bump"],


### PR DESCRIPTION
`psstUpgradeTasks` using `yarn` stopped working if `skipInstalls` is set to `true`.

Maybe caused by https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/npm/post-update/lerna.ts#L63