### PR TITLE
fix(angular/menu): explicitly set aria-expanded to true/false

### DIFF
--- a/src/angular/menu/menu-trigger.ts
+++ b/src/angular/menu/menu-trigger.ts
@@ -110,7 +110,7 @@ const _SbbMenuTriggerMixinBase = mixinVariant(class {});
   host: {
     class: 'sbb-menu-trigger sbb-icon-fit',
     '[attr.aria-haspopup]': 'menu ? "menu" : null',
-    '[attr.aria-expanded]': 'menuOpen || null',
+    '[attr.aria-expanded]': 'menuOpen',
     '[attr.aria-controls]': 'menuOpen ? menu.panelId : null',
     '[class.sbb-menu-trigger-root]': '!_parentSbbMenu',
     '[class.sbb-menu-trigger-menu-open]': 'menuOpen',

--- a/src/angular/menu/menu.spec.ts
+++ b/src/angular/menu/menu.spec.ts
@@ -811,7 +811,7 @@ describe('SbbMenu', () => {
     fixture.detectChanges();
     const triggerEl = fixture.componentInstance.triggerEl.nativeElement;
 
-    expect(triggerEl.hasAttribute('aria-expanded')).toBe(false);
+    expect(triggerEl.getAttribute('aria-expanded')).toBe('false');
 
     fixture.componentInstance.trigger.openMenu();
     fixture.detectChanges();
@@ -823,7 +823,7 @@ describe('SbbMenu', () => {
     fixture.detectChanges();
     tick(500);
 
-    expect(triggerEl.hasAttribute('aria-expanded')).toBe(false);
+    expect(triggerEl.getAttribute('aria-expanded')).toBe('false');
   }));
 
   it('should throw if assigning a menu that contains the trigger', fakeAsync(() => {


### PR DESCRIPTION
In the context of a submenu trigger it is useful for a screen reader user to know whether a submenu is open or closed. By specifying the `aria-expanded` attribute as either true or false it provides an additional "collapsed" announcement to the user informing them of the state of the menu trigger when closed.