### PR TITLE
fix(angular/select): changed after checked error if option label changes

### DIFF
--- a/src/angular/core/option/option.ts
+++ b/src/angular/core/option/option.ts
@@ -246,8 +246,11 @@ export class SbbOption<T = any>
       const viewValue = this.viewValue;
 
       if (viewValue !== this._mostRecentViewValue) {
+        if (this._mostRecentViewValue) {
+          this._stateChanges.next();
+        }
+
         this._mostRecentViewValue = viewValue;
-        this._stateChanges.next();
       }
     }
   }

--- a/src/angular/select/select.spec.ts
+++ b/src/angular/select/select.spec.ts
@@ -87,7 +87,7 @@ import { SbbSelectModule } from './select.module';
         [typeaheadDebounceInterval]="typeaheadDebounceInterval"
       >
         <sbb-option *ngFor="let food of foods" [value]="food.value" [disabled]="food.disabled">
-          {{ food.viewValue }}
+          {{ capitalize ? food.viewValue.toUpperCase() : food.viewValue }}
         </sbb-option>
       </sbb-select>
     </sbb-form-field>
@@ -116,6 +116,7 @@ class BasicSelect {
   panelClass = ['custom-one', 'custom-two'];
   typeaheadDebounceInterval: number;
   label? = 'Label';
+  capitalize = false;
 
   @ViewChild(SbbSelect, { static: true }) select: SbbSelect;
   @ViewChildren(SbbOption) options: QueryList<SbbOption>;
@@ -2678,6 +2679,19 @@ describe('SbbSelect', () => {
 
         // tslint:disable-next-line:no-non-null-assertion
         expect(select.textContent!.trim()).toBe('Calzone');
+      }));
+
+      it('should update the trigger value if the text as a result of an expression change', fakeAsync(() => {
+        fixture.componentInstance.control.setValue('pizza-1');
+        fixture.detectChanges();
+
+        expect(select.textContent!.trim()).toBe('Pizza');
+
+        fixture.componentInstance.capitalize = true;
+        fixture.detectChanges();
+        fixture.checkNoChanges();
+
+        expect(select.textContent!.trim()).toBe('PIZZA');
       }));
 
       it('should not select disabled options', fakeAsync(() => {

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -1025,7 +1025,10 @@ export class SbbSelect
     merge(...this.options.map((option) => option._stateChanges))
       .pipe(takeUntil(changedOrDestroyed))
       .subscribe(() => {
-        this._changeDetectorRef.markForCheck();
+        // `_stateChanges` can fire as a result of a change in the label's DOM value which may
+        // be the result of an expression changing. We have to use `detectChanges` in order
+        // to avoid "changed after checked" errors (see #14793).
+        this._changeDetectorRef.detectChanges();
         this.stateChanges.next();
       });
   }


### PR DESCRIPTION
Fixes a "changed after checked" error that is thrown if the label of a selected option changes dynamically.