### PR TITLE
ci: fix maintenance workflow

### DIFF
--- a/.github/workflows/maintenance-changelog.yml
+++ b/.github/workflows/maintenance-changelog.yml
@@ -3,7 +3,6 @@ name: cherry-pick changelog from release branch into default branch
 on:
   push:
     tags: ['*.*']
-    branches: ["*.x"]
 
 permissions:
   actions: write


### PR DESCRIPTION
Remove `branch` workflow event. Otherwise, the workflow will trigger on every push on a release branch (workflow events are combined with `or`).