### PR TITLE
fix(angular/dialog): scrollable content if no dialog height is defined

### DIFF
--- a/src/angular/dialog/dialog.scss
+++ b/src/angular/dialog/dialog.scss
@@ -37,6 +37,10 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+
+  // Flexbox uses `min-height: auto` by default.
+  // To make the content scrollable, we set it to `0`.
+  min-height: 0;
 }
 
 .sbb-dialog-content {


### PR DESCRIPTION
If no dialog height is specified, the  content was not scrollable and the dialog footer sometimes was not visible. This is because flexbox uses `min-height: auto` by default. To make the dialog content scrollable again, the `min-height` is set to zero.

Closes #1803