### PR TITLE
fix(angular/core): sbb-option sets aria-selected="false"

### DIFF
--- a/src/angular/core/option/option.ts
+++ b/src/angular/core/option/option.ts
@@ -56,15 +56,6 @@ export class SbbOptionSelectionChange<T = any> {
     '[class.sbb-option-multiple]': 'multiple',
     '[class.sbb-focused]': 'active',
     '[id]': 'id',
-    // Set aria-selected to false for non-selected items and true for selected items. Conform to
-    // [WAI ARIA Listbox authoring practices guide](
-    //  https://www.w3.org/WAI/ARIA/apg/patterns/listbox/), "If any options are selected, each
-    // selected option has either aria-selected or aria-checked set to true. All options that are
-    // selectable but not selected have either aria-selected or aria-checked set to false." Align
-    // aria-selected implementation of Chips and List components.
-    //
-    // Set `aria-selected="false"` on not-selected listbox options to fix VoiceOver announcing
-    // every option as "selected" (#21491).
     '[attr.aria-selected]': 'selected',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[class.sbb-disabled]': 'disabled',

--- a/src/angular/core/option/option.ts
+++ b/src/angular/core/option/option.ts
@@ -56,7 +56,16 @@ export class SbbOptionSelectionChange<T = any> {
     '[class.sbb-option-multiple]': 'multiple',
     '[class.sbb-focused]': 'active',
     '[id]': 'id',
-    '[attr.aria-selected]': '_getAriaSelected()',
+    // Set aria-selected to false for non-selected items and true for selected items. Conform to
+    // [WAI ARIA Listbox authoring practices guide](
+    //  https://www.w3.org/WAI/ARIA/apg/patterns/listbox/), "If any options are selected, each
+    // selected option has either aria-selected or aria-checked set to true. All options that are
+    // selectable but not selected have either aria-selected or aria-checked set to false." Align
+    // aria-selected implementation of Chips and List components.
+    //
+    // Set `aria-selected="false"` on not-selected listbox options to fix VoiceOver announcing
+    // every option as "selected" (#21491).
+    '[attr.aria-selected]': 'selected',
     '[attr.aria-disabled]': 'disabled.toString()',
     '[class.sbb-disabled]': 'disabled',
   },
@@ -214,16 +223,6 @@ export class SbbOption<T = any>
       this._changeDetectorRef.markForCheck();
       this._emitSelectionChangeEvent(true);
     }
-  }
-
-  /**
-   * Gets the `aria-selected` value for the option. We explicitly omit the `aria-selected`
-   * attribute from single-selection, unselected options. Including the `aria-selected="false"`
-   * attributes adds a significant amount of noise to screen-reader users without providing useful
-   * information.
-   */
-  _getAriaSelected(): boolean | null {
-    return this.selected || (this.multiple ? false : null);
   }
 
   /** Returns the correct tabindex for the option depending on disabled state. */

--- a/src/angular/select/select.spec.ts
+++ b/src/angular/select/select.spec.ts
@@ -1985,9 +1985,9 @@ describe('SbbSelect', () => {
         }));
 
         it('should set aria-selected on each option for single select', fakeAsync(() => {
-          expect(options.every((option) => !option.hasAttribute('aria-selected')))
+          expect(options.every((option) => option.getAttribute('aria-selected') === 'false'))
             .withContext(
-              'Expected all unselected single-select options not to have ' + 'aria-selected set.'
+              'Expected all unselected single-select options to have aria-selected="false".'
             )
             .toBe(true);
 
@@ -2002,9 +2002,9 @@ describe('SbbSelect', () => {
             .withContext('Expected selected single-select option to have aria-selected="true".')
             .toEqual('true');
           options.splice(1, 1);
-          expect(options.every((option) => !option.hasAttribute('aria-selected')))
+          expect(options.every((option) => option.getAttribute('aria-selected') === 'false'))
             .withContext(
-              'Expected all unselected single-select options not to have ' + 'aria-selected set.'
+              'Expected all unselected single-select options to have aria-selected="false".'
             )
             .toBe(true);
         }));


### PR DESCRIPTION
For sbb-option, set `aria-selected="false"` on deselected options. Confirms with [WAI ARIA Listbox authoring practices guide](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/), which says to always include aria-selected attribute on listbox options that can be selected. Fix issue where VoiceOver reads every option as "selected".