### PR TITLE
fix(oauth): parse token correctly to be able to parse unicode characters

### DIFF
--- a/src/angular/oauth/resource-access.spec.ts
+++ b/src/angular/oauth/resource-access.spec.ts
@@ -6,6 +6,13 @@ const accessTokenWithResourceAccess =
   'jp7ImV4YW1wbGUtY2xpZW50Ijp7InJvbGVzIjpbInNlcnZpY2Utb3duZXIiLCJ0ZXN0MSJdfSwiYWNjb3VudCI6eyJyb2' +
   'xlcyI6WyJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIGVtYWlsIn0.xiQfMkFrkr_lx0LHtg6' +
   'XKvIOhvtb6qYpDc5Ve__-9w8';
+const accessTokenWithSpecialCharAndResourceAccess =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiZXhhbXBsZS1jbGllbnQiLCJhY2NvdW50Il0sInR5cCI6' +
+  'IkJlYXJlciIsImFsbG93ZWQtb3JpZ2lucyI6WyJodHRwOi8vbG9jYWxob3N0OjQyMDAiXSwicmVzb3VyY2VfYWNjZXNzI' +
+  'jp7ImV4YW1wbGUtY2xpZW50Ijp7InJvbGVzIjpbInNlcnZpY2Utb3duZXLDryIsInRlc3QxIl19LCJhY2NvdW50Ijp7In' +
+  'JvbGVzIjpbInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwiLCJuYW1lIjoiVGVzdCB' +
+  '3aXRoIMOvIHVuaWNvZGUgbWFuIGVycm9yIiwiZnVsbF9uYW1lIjoidGhpcyDDryBpcyBhIGRlc2NyaXB0aW9uIHRvIGdl' +
+  'bmVyYXRlIGEgbG9uZ2VyIGFjY2Vzcy10b2tlbiDhuLQifQ.NZlHyDkYE4RUVoeSEqRD_2GZl47PjqpH8RpLtAoD0w0';
 const accessTokenWithoutResourceAccess =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiZXhhbXBsZS1jbGllbnQiLCJhY2NvdW50Il0sInR5cCI6' +
   'IkJlYXJlciIsImFsbG93ZWQtb3JpZ2lucyI6WyJodHRwOi8vbG9jYWxob3N0OjQyMDAiXSwic2NvcGUiOiJvcGVuaWQgc' +
@@ -41,6 +48,18 @@ describe('resourceAccess', () => {
     expect(data).toEqual({
       'example-client': {
         roles: ['service-owner', 'test1'],
+      },
+      account: {
+        roles: ['view-profile'],
+      },
+    });
+  });
+
+  it('should parse resouce_access with valid access token but including a special char', () => {
+    const data = resourceAccess(accessTokenWithSpecialCharAndResourceAccess);
+    expect(data).toEqual({
+      'example-client': {
+        roles: ['service-ownerï', 'test1'],
       },
       account: {
         roles: ['view-profile'],

--- a/src/angular/oauth/resource-access.ts
+++ b/src/angular/oauth/resource-access.ts
@@ -15,12 +15,19 @@ export function resourceAccess(
 ): null | { [resource: string]: { roles: string[] } } {
   accessToken =
     !accessToken || typeof accessToken === 'string' ? accessToken : accessToken.getAccessToken();
+
   if (!accessToken || typeof accessToken !== 'string') {
     return null;
   }
 
-  const payload = base64Decode(accessToken.split('.')[1]);
-  const parsedAccessToken = JSON.parse(payload);
+  const processedAccessToken = accessToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+  const payload = base64Decode(processedAccessToken);
+  const processedPayload = payload
+    .split('')
+    .map((char) => '%' + ('00' + char.charCodeAt(0).toString(16)).slice(-2))
+    .join('');
+  const parsedAccessToken = JSON.parse(decodeURIComponent(processedPayload));
+
   if (!('resource_access' in parsedAccessToken) || !parsedAccessToken.resource_access) {
     return null;
   }


### PR DESCRIPTION
Hello

Currently, the parsing of access tokens does not quite work. Unicode characters can generate problems.
Even so far to produce an error when calling `atob` which leads to the token not being able to be parsed at all.

This PR will address that. The logic to do that is mainly taken from https://stackoverflow.com/a/38552302 

Thanks