### PR TITLE
fix(angular/datepicker): update arrow keys of connected datepicker 

### DIFF
--- a/src/angular/datepicker/datepicker/datepicker.spec.ts
+++ b/src/angular/datepicker/datepicker/datepicker.spec.ts
@@ -769,6 +769,21 @@ describe('SbbDatepicker', () => {
 
         flush();
       }));
+
+      it('should update the arrow keys of the connected datepicker', () => {
+        testComponent.firstDatepicker.setValue(new Date(2023, JAN, 15));
+        testComponent.secondDatepicker.setValue(new Date(2023, JAN, 15));
+        fixture.detectChanges();
+        expect(
+          fixture.nativeElement.querySelectorAll('.sbb-datepicker-arrow-button-left').length
+        ).toBe(1);
+        testComponent.firstDatepicker.setValue(new Date(2023, JAN, 13));
+        fixture.detectChanges();
+
+        expect(
+          fixture.nativeElement.querySelectorAll('.sbb-datepicker-arrow-button-left').length
+        ).toBe(2);
+      });
     });
 
     describe('datepicker in readonly mode', () => {
@@ -1078,10 +1093,10 @@ class DatepickerOpeningOnFocusComponent {
 }
 
 @Component({
-  template: `<sbb-datepicker [connected]="second">
+  template: `<sbb-datepicker arrows [connected]="second">
       <input sbbDateInput sbbInput [formControl]="firstDatepicker" />
     </sbb-datepicker>
-    <sbb-datepicker #second>
+    <sbb-datepicker #second arrows>
       <input sbbDateInput sbbInput [formControl]="secondDatepicker" />
     </sbb-datepicker>`,
 })

--- a/src/angular/datepicker/datepicker/datepicker.ts
+++ b/src/angular/datepicker/datepicker/datepicker.ts
@@ -260,6 +260,8 @@ export class SbbDatepicker<D> implements OnDestroy {
 
   private _posStrategySubscription = Subscription.EMPTY;
 
+  private _mainDatepickerSubscription? = Subscription.EMPTY;
+
   /** The input element this datepicker is associated with. */
   datepickerInput: SbbDateInput<D>;
 
@@ -289,6 +291,7 @@ export class SbbDatepicker<D> implements OnDestroy {
     this._inputSubscription.unsubscribe();
     this._inputChangeSubscription.unsubscribe();
     this._connectedDatepickerSubscription.unsubscribe();
+    this._mainDatepickerSubscription?.unsubscribe();
     this.disabledChange.complete();
 
     if (this.popupRef) {
@@ -339,6 +342,11 @@ export class SbbDatepicker<D> implements OnDestroy {
       this.datepickerInput.disabledChange,
       this.datepickerInput.readonlyChange
     ).subscribe(() => this._changeDetectorRef.markForCheck());
+
+    // If the main datepicker date changes, we need to do a `markForCheck` to update the arrow keys.
+    this._mainDatepickerSubscription = this.main?.datepickerInput.valueChange.subscribe(() =>
+      this._changeDetectorRef.markForCheck()
+    );
 
     // The connected datepicker is only opened on the following conditions:
     // This datepicker has a connected datepicker and has been opened, a value selected, closed

--- a/src/angular/datepicker/month-view/month-view.spec.ts
+++ b/src/angular/datepicker/month-view/month-view.spec.ts
@@ -84,6 +84,7 @@ class MonthViewWithDateClassComponent {
 @Component({
   template: `<sbb-month-view
     [isWeekdaySelectable]="isWeekdaySelectable"
+    [activeDate]="date"
     showWeekNumbers="true"
     [dateClass]="dateClass"
   ></sbb-month-view>`,
@@ -91,7 +92,6 @@ class MonthViewWithDateClassComponent {
 class MonthViewComponentWithWeekNumbers {
   @ViewChild(SbbMonthView) monthView: SbbMonthView<Date>;
   date = new Date(2023, JAN, 1);
-  selected = new Date(2023, JAN, 1);
   isWeekdaySelectable = true;
   dateClass: SbbCalendarCellClassFunction<Date> = (date: Date) =>
     date.getDay() === 0 ? 'custom-date-class' : '';
@@ -420,7 +420,7 @@ describe('SbbMonthView', () => {
       fixture.detectChanges();
     });
 
-    it('whould display the correct week numbers if first day of year is a Sunday', () => {
+    it('should display the correct week numbers if first day of year is a Sunday', () => {
       expect(fixture.componentInstance.monthView._dateAdapter.getFirstDayOfWeek()).toBe(1);
       expect(fixture.componentInstance.monthView.weeksInMonth).toEqual([52, 1, 2, 3, 4, 5]);
     });


### PR DESCRIPTION
If the date of the main datepicker changes, the arrow keys of the connected datepicker need to be updated.

Closes #1852