### PR TITLE
fix(angular/datepicker): remove div as a child of button

### DIFF
--- a/src/angular/datepicker/calendar-body/calendar-body.html
+++ b/src/angular/datepicker/calendar-body/calendar-body.html
@@ -8,10 +8,10 @@
         class="sbb-calendar-body-cell sbb-button-reset-frameless sbb-calendar-body-week"
         (click)="onWeekClicked(weeksInMonth[rowIndex])"
       >
-        <div class="sbb-calendar-body-cell-content">{{ weeksInMonth[rowIndex] }}</div>
+        <span class="sbb-calendar-body-cell-content">{{ weeksInMonth[rowIndex] }}</span>
       </button>
       <div *ngSwitchCase="false" class="sbb-calendar-body-cell sbb-calendar-body-week">
-        <div class="sbb-calendar-body-cell-content">{{ weeksInMonth[rowIndex] }}</div>
+        <span class="sbb-calendar-body-cell-content">{{ weeksInMonth[rowIndex] }}</span>
       </div>
     </ng-container>
   </td>
@@ -60,7 +60,7 @@
       (click)="cellClicked(item)"
       (focus)="_emitActiveDateChange(item, $event)"
     >
-      <div class="sbb-calendar-body-cell-content">{{ item.displayValue }}</div>
+      <span class="sbb-calendar-body-cell-content">{{ item.displayValue }}</span>
     </button>
   </td>
 </tr>


### PR DESCRIPTION
Fixes that we had divs as children of buttons which some a11y tools complain about.