### PR TITLE
fix(angular/datepicker): avoid calendar being cut off on small screens

### DIFF
--- a/src/angular/datepicker/datepicker-content/datepicker-content.scss
+++ b/src/angular/datepicker/datepicker-content/datepicker-content.scss
@@ -4,6 +4,8 @@
   position: relative;
   top: var(--sbb-datepicker-content-offset);
   font-size: var(--sbb-font-size);
+  height: var(--sbb-datepicker-calendar-height);
+  width: var(--sbb-datepicker-calendar-width);
 
   .sbb-datepicker-panel-above & {
     top: auto;
@@ -45,6 +47,11 @@
       box-shadow: var(--sbb-box-shadow-arrow-width) var(--sbb-box-shadow-arrow-width) 0
         var(--sbb-box-shadow-arrow-width) var(--sbb-box-shadow-color);
     }
+  }
+
+  // Hide arrow if panel is vertically centered
+  .sbb-datepicker-panel-centered &::after {
+    display: none;
   }
 
   .sbb-calendar {

--- a/src/angular/datepicker/datepicker-content/datepicker-content.scss
+++ b/src/angular/datepicker/datepicker-content/datepicker-content.scss
@@ -47,11 +47,11 @@
       box-shadow: var(--sbb-box-shadow-arrow-width) var(--sbb-box-shadow-arrow-width) 0
         var(--sbb-box-shadow-arrow-width) var(--sbb-box-shadow-color);
     }
-  }
 
-  // Hide arrow if panel is vertically centered
-  .sbb-datepicker-panel-centered &::after {
-    display: none;
+    // Hide arrow if panel is vertically centered
+    .sbb-datepicker-panel-centered & {
+      display: none;
+    }
   }
 
   .sbb-calendar {

--- a/src/angular/datepicker/datepicker/datepicker.ts
+++ b/src/angular/datepicker/datepicker/datepicker.ts
@@ -506,7 +506,6 @@ export class SbbDatepicker<D> implements OnDestroy {
       .withTransformOriginOn('.sbb-datepicker-content')
       .withFlexibleDimensions(false)
       .withViewportMargin(8)
-      .withPush(false)
       .withPositions([
         {
           originX: 'start',
@@ -531,6 +530,20 @@ export class SbbDatepicker<D> implements OnDestroy {
           originY: 'top',
           overlayX: 'end',
           overlayY: 'bottom',
+        },
+        {
+          originX: 'start',
+          originY: 'center',
+          overlayX: 'start',
+          overlayY: 'center',
+          panelClass: 'sbb-datepicker-panel-centered',
+        },
+        {
+          originX: 'end',
+          originY: 'center',
+          overlayX: 'end',
+          overlayY: 'center',
+          panelClass: 'sbb-datepicker-panel-centered',
         },
       ]);
 


### PR DESCRIPTION
If the screen is too small to show the calendar above or below the date input, display it centered and remove the arrow pointing to the input.

Closes #1819