### PR TITLE
build: lint BUILD.bazel files

### DIFF
--- a/src/journey-maps/web-component/BUILD.bazel
+++ b/src/journey-maps/web-component/BUILD.bazel
@@ -36,8 +36,8 @@ html_insert_assets(
         "--scripts --module showcase.js",
     ],
     data = [
-        ":showcase.template.html",
         ":showcase.js",
+        ":showcase.template.html",
     ] + _DEV_SERVER_ASSETS,
 )
 

--- a/src/showcase/BUILD.bazel
+++ b/src/showcase/BUILD.bazel
@@ -98,8 +98,8 @@ html_insert_assets(
         "--scripts --module dev-bundles/main.dev.js",
     ],
     data = [
-        ":index.template.html",
         ":dev-bundles",
+        ":index.template.html",
     ] + _ASSETS,
 )
 
@@ -188,8 +188,8 @@ html_insert_assets(
 pkg_web(
     name = "prodapp",
     srcs = _ASSETS + [
-        ":prod-bundles",
         ":index_html_prod",
+        ":prod-bundles",
         "//src/showcase/assets",
     ],
     # In production mode we serve some polyfills with script tags that have hard-coded paths in the index.html


### PR DESCRIPTION
This is necessary to avoid linting errors when updating bazel to v6.1.0.