### PR TITLE
fix(multiple): fix VoiceOver confused by Select/Autocomplete's ARIA semantics

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "schematics": "./tools/schematics/collection.json",
   "dependencies": {
     "@angular/animations": "16.0.2",
-    "@angular/cdk": "16.0.1",
+    "@angular/cdk": "16.1.0-next.0",
     "@angular/common": "16.0.2",
     "@angular/core": "16.0.2",
     "@angular/elements": "16.0.2",

--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -1,3 +1,4 @@
+import { addAriaReferencedId, removeAriaReferencedId } from '@angular/cdk/a11y';
 import { BooleanInput, coerceBooleanProperty, coerceStringArray } from '@angular/cdk/coercion';
 import { DOWN_ARROW, ENTER, ESCAPE, hasModifierKey, TAB, UP_ARROW } from '@angular/cdk/keycodes';
 import {
@@ -114,7 +115,7 @@ export function getSbbAutocompleteMissingPanelError(): Error {
     '[attr.aria-autocomplete]': 'autocompleteDisabled ? null : "list"',
     '[attr.aria-activedescendant]': '(panelOpen && activeOption) ? activeOption.id : null',
     '[attr.aria-expanded]': 'autocompleteDisabled ? null : panelOpen.toString()',
-    '[attr.aria-owns]': '(autocompleteDisabled || !panelOpen) ? null : autocomplete?.id',
+    '[attr.aria-controls]': '(autocompleteDisabled || !panelOpen) ? null : autocomplete?.id',
     '[attr.aria-haspopup]': 'autocompleteDisabled ? null : "listbox"',
     '[class.sbb-focused]': 'panelOpen',
     // Note: we use `focusin`, as opposed to `focus`, in order to open the panel
@@ -328,6 +329,7 @@ export class SbbAutocompleteTrigger
     this._componentDestroyed = true;
     this._destroyPanel();
     this._closeKeyEventStream.complete();
+    this._clearFromModal();
   }
 
   /** Whether or not the autocomplete panel is open. */
@@ -770,6 +772,8 @@ export class SbbAutocompleteTrigger
     this.autocomplete._setVisibility();
     this.autocomplete._isOpen = this._overlayAttached = true;
 
+    this._applyModalPanelOwnership();
+
     // We need to do an extra `panelOpen` check in here, because the
     // autocomplete won't be shown if there are no options.
     if (this.panelOpen && wasOpen !== this.panelOpen) {
@@ -944,5 +948,67 @@ export class SbbAutocompleteTrigger
     // TODO(crisbeto): we should switch `_getOutsideClickStream` eventually to use this stream,
     // but the behvior isn't exactly the same and it ends up breaking some internal tests.
     overlayRef.outsidePointerEvents().subscribe();
+  }
+
+  /**
+   * Track which modal we have modified the `aria-owns` attribute of. When the combobox trigger is
+   * inside an aria-modal, we apply aria-owns to the parent modal with the `id` of the options
+   * panel. Track the modal we have changed so we can undo the changes on destroy.
+   */
+  private _trackedModal: Element | null = null;
+
+  /**
+   * If the autocomplete trigger is inside of an `aria-modal` element, connect
+   * that modal to the options panel with `aria-owns`.
+   *
+   * For some browser + screen reader combinations, when navigation is inside
+   * of an `aria-modal` element, the screen reader treats everything outside
+   * of that modal as hidden or invisible.
+   *
+   * This causes a problem when the combobox trigger is _inside_ of a modal, because the
+   * options panel is rendered _outside_ of that modal, preventing screen reader navigation
+   * from reaching the panel.
+   *
+   * We can work around this issue by applying `aria-owns` to the modal with the `id` of
+   * the options panel. This effectively communicates to assistive technology that the
+   * options panel is part of the same interaction as the modal.
+   *
+   * At time of this writing, this issue is present in VoiceOver.
+   * See https://github.com/angular/components/issues/20694
+   */
+  private _applyModalPanelOwnership() {
+    // TODO(http://github.com/angular/components/issues/26853): consider de-duplicating this with
+    // the `LiveAnnouncer` and any other usages.
+    //
+    // Note that the selector here is limited to CDK overlays at the moment in order to reduce the
+    // section of the DOM we need to look through. This should cover all the cases we support, but
+    // the selector can be expanded if it turns out to be too narrow.
+    const modal = this._element.nativeElement.closest(
+      'body > .cdk-overlay-container [aria-modal="true"]'
+    );
+
+    if (!modal) {
+      // Most commonly, the autocomplete trigger is not inside a modal.
+      return;
+    }
+
+    const panelId = this.autocomplete.id;
+
+    if (this._trackedModal) {
+      removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+    }
+
+    addAriaReferencedId(modal, 'aria-owns', panelId);
+    this._trackedModal = modal;
+  }
+
+  /** Clears the references to the listbox overlay element from the modal it was added to. */
+  private _clearFromModal() {
+    if (this._trackedModal) {
+      const panelId = this.autocomplete.id;
+
+      removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+      this._trackedModal = null;
+    }
   }
 }

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -1,4 +1,9 @@
-import { ActiveDescendantKeyManager, LiveAnnouncer } from '@angular/cdk/a11y';
+import {
+  ActiveDescendantKeyManager,
+  addAriaReferencedId,
+  LiveAnnouncer,
+  removeAriaReferencedId,
+} from '@angular/cdk/a11y';
 import {
   BooleanInput,
   coerceBooleanProperty,
@@ -635,6 +640,7 @@ export class SbbSelect
     this._destroy.complete();
     this.stateChanges.complete();
     this._keyManager?.destroy();
+    this._clearFromModal();
   }
 
   /** Toggles the overlay panel open or closed. */
@@ -646,6 +652,8 @@ export class SbbSelect
   /** Opens the overlay panel. */
   open(): void {
     if (this._canOpen()) {
+      this._applyModalPanelOwnership();
+
       this._panelOpen = true;
       this._keyManager.withHorizontalOrientation(null);
       this._highlightCorrectOption();
@@ -671,6 +679,71 @@ export class SbbSelect
         this._calculateOverlayPosition();
       });
     }
+  }
+
+  /**
+   * Track which modal we have modified the `aria-owns` attribute of. When the combobox trigger is
+   * inside an aria-modal, we apply aria-owns to the parent modal with the `id` of the options
+   * panel. Track the modal we have changed so we can undo the changes on destroy.
+   */
+  private _trackedModal: Element | null = null;
+
+  /**
+   * If the autocomplete trigger is inside of an `aria-modal` element, connect
+   * that modal to the options panel with `aria-owns`.
+   *
+   * For some browser + screen reader combinations, when navigation is inside
+   * of an `aria-modal` element, the screen reader treats everything outside
+   * of that modal as hidden or invisible.
+   *
+   * This causes a problem when the combobox trigger is _inside_ of a modal, because the
+   * options panel is rendered _outside_ of that modal, preventing screen reader navigation
+   * from reaching the panel.
+   *
+   * We can work around this issue by applying `aria-owns` to the modal with the `id` of
+   * the options panel. This effectively communicates to assistive technology that the
+   * options panel is part of the same interaction as the modal.
+   *
+   * At time of this writing, this issue is present in VoiceOver.
+   * See https://github.com/angular/components/issues/20694
+   */
+  private _applyModalPanelOwnership() {
+    // TODO(http://github.com/angular/components/issues/26853): consider de-duplicating this with
+    // the `LiveAnnouncer` and any other usages.
+    //
+    // Note that the selector here is limited to CDK overlays at the moment in order to reduce the
+    // section of the DOM we need to look through. This should cover all the cases we support, but
+    // the selector can be expanded if it turns out to be too narrow.
+    const modal = this._elementRef.nativeElement.closest(
+      'body > .cdk-overlay-container [aria-modal="true"]'
+    );
+
+    if (!modal) {
+      // Most commonly, the autocomplete trigger is not inside a modal.
+      return;
+    }
+
+    const panelId = `${this.id}-panel`;
+
+    if (this._trackedModal) {
+      removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+    }
+
+    addAriaReferencedId(modal, 'aria-owns', panelId);
+    this._trackedModal = modal;
+  }
+
+  /** Clears the reference to the listbox overlay element from the modal it was added to. */
+  private _clearFromModal() {
+    if (!this._trackedModal) {
+      // Most commonly, the autocomplete trigger is not used inside a modal.
+      return;
+    }
+
+    const panelId = `${this.id}-panel`;
+
+    removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+    this._trackedModal = null;
   }
 
   /** Closes the overlay panel and focuses the host element. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,10 +344,10 @@
     uuid "^9.0.0"
     yargs "^17.0.0"
 
-"@angular/cdk@16.0.1":
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-16.0.1.tgz#3b81f7980bee04831fdcddedd6a833f26ef742ab"
-  integrity sha512-GupYss6x84RWEoy3JTYu4Igr2SxHuV6whVKMScQG2/Gm+winOsOn7YWm0IZQuFnjSWIF2Va5B0Tp0IjFHWxTvA==
+"@angular/cdk@16.1.0-next.0":
+  version "16.1.0-next.0"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-16.1.0-next.0.tgz#bea73f5e2a70d3ccaa95944e209671a4cde44382"
+  integrity sha512-LRVGV1Whvh5zAwnVPuodXiqjIHBRY6X7lsTOJjaeHNprzuxXTQaoXwVS7EQ/AwPDMH4rOlpnDsCQInxr28UMDg==
   dependencies:
     tslib "^2.3.0"
   optionalDependencies:


### PR DESCRIPTION
For Select and Autocomplete components, fix issues where VoiceOver was confused by the ARIA semantics of the combobox. Fix multiple behaviors:

 - Fix VoiceOver focus ring stuck on the combobox while navigating options.
 - Fix VoiceOver would sometimes reading option as a TextNode and not communicating the selected state and position in set.
 - Fix VoiceOver "flickering" behavior where VoiceOver would display one announcement then quickly change to another announcement.

Fix the same issues for both Select and Autocomplete component.

Implement fix by correcting the combobox element and also individual options.

First, move the aria-owns reference to the overlay from the child of the combobox to the parent modal of the comobobx. Having an aria-owns reference inside the combobox element seemed to confuse VoiceOver.

Second, apply `aria-hidden="true"` to the ripple element and pseudo checkboxes on sbb-option. These DOM nodes are only used for visual purposes, so it is most appropriate to remove them from the accessibility tree. This seemed to make VoiceOver's behavior more consistent.