### PR TITLE
feat(sbb-header-environment): add 'inte' as a recognized environment

### DIFF
--- a/src/angular/header-lean/header.scss
+++ b/src/angular/header-lean/header.scss
@@ -61,7 +61,7 @@
 .sbb-header-environment-edu {
   background-color: var(--sbb-color-green);
 }
-.sbb-header-environment-int {
+.sbb-header-environment-int, .sbb-header-environment-inte {
   background-color: var(--sbb-color-granite);
 }
 

--- a/src/angular/header-lean/header.scss
+++ b/src/angular/header-lean/header.scss
@@ -61,7 +61,8 @@
 .sbb-header-environment-edu {
   background-color: var(--sbb-color-green);
 }
-.sbb-header-environment-int, .sbb-header-environment-inte {
+.sbb-header-environment-int,
+.sbb-header-environment-inte {
   background-color: var(--sbb-color-granite);
 }
 


### PR DESCRIPTION
Some INT environments are called "inte" instead of "int"; add a corresponding style class.