### PR TITLE
build: revert "build: remove `BundlingTypes` strategy to find out if …

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,14 @@ test --nolegacy_external_runfiles
 # when running bazel via `yarn bazel`.
 build --incompatible_strict_action_env
 
+############################
+# --strategy=BundlingTypes #
+############################
+# Use BundlingTypes strategy to avoid the `Worker process did not return a WorkResponse` error
+# being caused when Microsoft API extractor prints to stdout and conflicts with the Bazel worker 
+# IPC also using stdout. See https://github.com/angular/angular/issues/46965
+build --strategy=BundlingTypes=remote,sandboxed,local
+
 ###############################
 # Output control              #
 ###############################


### PR DESCRIPTION
…it's still needed (#1925)"

This reverts commit 0f1805356c84493fcb18fe24229843ce18095164.

The error occured again