### PR TITLE
fix(angular/autocomplete): clear selected option if input is cleared

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -547,6 +547,10 @@ export class SbbAutocompleteTrigger
       this._onChange(value);
       this._inputValue.next(target.value);
 
+      if (!value) {
+        this._clearPreviousSelectedOption(null, false);
+      }
+
       if (this._canOpen() && this._document.activeElement === event.target) {
         this.openPanel();
       }
@@ -701,12 +705,14 @@ export class SbbAutocompleteTrigger
   }
 
   /** Clear any previous selected option and emit a selection change event for this option */
-  private _clearPreviousSelectedOption(skip: SbbOption) {
-    this.autocomplete.options.forEach((option) => {
-      if (option !== skip && option.selected) {
-        option.deselect();
-      }
-    });
+  private _clearPreviousSelectedOption(skip: SbbOption | null, emitEvent?: boolean) {
+    if (this.autocomplete && this.autocomplete.options) {
+      this.autocomplete.options.forEach((option) => {
+        if (option !== skip && option.selected) {
+          option.deselect(emitEvent);
+        }
+      });
+    }
   }
 
   private _attachOverlay(): void {

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -2851,6 +2851,36 @@ describe('SbbAutocomplete', () => {
         .withContext(`Expected panel switch to the above position if the options no longer fit.`)
         .toBe(Math.floor(panelBottom - 1));
     }));
+
+    it('should clear the selected option when the input value is cleared', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const input = fixture.nativeElement.querySelector('input');
+      const option = overlayContainerElement.querySelector('sbb-option') as HTMLElement;
+      const optionInstance = fixture.componentInstance.options.first;
+      const spy = jasmine.createSpy('selectionChange spy');
+
+      option.click();
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Eins');
+      expect(optionInstance.selected).toBe(true);
+
+      const subscription = optionInstance.onSelectionChange.subscribe(spy);
+
+      clearElement(input);
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('');
+      expect(optionInstance.selected).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    }));
   });
 
   describe('panel closing', () => {

--- a/src/angular/core/option/option.ts
+++ b/src/angular/core/option/option.ts
@@ -144,11 +144,14 @@ export class SbbOption<T = any>
   }
 
   /** Deselects the option. */
-  deselect(): void {
+  deselect(emitEvent = true): void {
     if (this._selected) {
       this._selected = false;
       this._changeDetectorRef.markForCheck();
-      this._emitSelectionChangeEvent();
+
+      if (emitEvent) {
+        this._emitSelectionChangeEvent();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes that the selected state was lingering on the selected option even after the input value is cleared.