### PR TITLE
fix(angular/accordion): content visible when placed inside a hidden parent

### DIFF
--- a/src/angular/accordion/accordion-animations.ts
+++ b/src/angular/accordion/accordion-animations.ts
@@ -49,7 +49,10 @@ export const sbbExpansionAnimations: {
   /** Animation that expands and collapses the panel content. */
   bodyExpansion: trigger('bodyExpansion', [
     state('collapsed, void', style({ height: '0px', visibility: 'hidden' })),
-    state('expanded', style({ height: '*', visibility: 'visible' })),
+    // Clear the `visibility` while open, otherwise the content will be visible when placed in
+    // a parent that's `visibility: hidden`, because `visibility` doesn't apply to descendants
+    // that have a `visibility` of their own (see #27436).
+    state('expanded', style({ height: '*', visibility: '' })),
     transition(
       'expanded <=> collapsed, void => collapsed',
       animate(SBB_EXPANSION_PANEL_ANIMATION_TIMING),


### PR DESCRIPTION
The accordion was setting `visibility: visible` on the content which meant that it would be visible when placed inside of a parent that is `visibility: hidden`.

These changes resolve the issue by clear the `visibility` instead.