### PR TITLE
fix(angular/radio): clear selected radio button from group

### DIFF
--- a/src/angular/radio-button/BUILD.bazel
+++ b/src/angular/radio-button/BUILD.bazel
@@ -20,6 +20,7 @@ ng_module(
         "@npm//@angular/cdk",
         "@npm//@angular/core",
         "@npm//@angular/forms",
+        "@npm//rxjs",
     ],
 )
 

--- a/src/angular/radio-button/radio-button.spec.ts
+++ b/src/angular/radio-button/radio-button.spec.ts
@@ -16,7 +16,9 @@ import { SbbRadioButtonModule } from './radio-button.module';
       [value]="groupValue"
       name="test-name"
     >
-      <sbb-radio-button value="fire" [disabled]="isFirstDisabled"> Charmander </sbb-radio-button>
+      <sbb-radio-button value="fire" [disabled]="isFirstDisabled" *ngIf="isFirstShown">
+        Charmander
+      </sbb-radio-button>
       <sbb-radio-button value="water"> Squirtle </sbb-radio-button>
       <sbb-radio-button value="leaf"> Bulbasaur </sbb-radio-button>
     </sbb-radio-group>
@@ -27,6 +29,7 @@ class RadiosInsideRadioGroup {
   isGroupDisabled = false;
   isGroupRequired = false;
   groupValue: string | null = null;
+  isFirstShown = true;
 }
 
 @Component({
@@ -507,6 +510,19 @@ describe('RadioButton', () => {
           return radio.getAttribute('tabindex');
         }),
       ).toEqual(['-1', '-1', '0']);
+    });
+
+    it('should clear the selected radio button but preserve the value on destroy', () => {
+      radioLabelElements[0].click();
+      fixture.detectChanges();
+      expect(groupInstance.selected).toBe(radioInstances[0]);
+      expect(groupInstance.value).toBe('fire');
+
+      fixture.componentInstance.isFirstShown = false;
+      fixture.detectChanges();
+
+      expect(groupInstance.selected).toBe(null);
+      expect(groupInstance.value).toBe('fire');
     });
   });
 

--- a/src/angular/toggle/toggle.ts
+++ b/src/angular/toggle/toggle.ts
@@ -91,7 +91,8 @@ export class SbbToggle
     });
   }
 
-  ngOnDestroy(): void {
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
     this._destroyed.next();
     this._destroyed.complete();
   }


### PR DESCRIPTION
In  a previous commit the radio group was changed so that deselected buttons receive `tabindex="-1"` when there's a selected button. The problem is that we weren't clearing the reference to the selected button so it gets removed, the deselected buttons become unfocusable using the keyboard.

These changes clear the selected radio button on destroy.