### PR TITLE
feat(angular/autocomplete): add input to require selection from the panel

### DIFF
--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -71,6 +71,7 @@ const SIMPLE_AUTOCOMPLETE_TEMPLATE = `
     [class]="panelClass"
     #auto="sbbAutocomplete"
     [displayWith]="displayFn"
+    [requireSelection]="requireSelection"
     [aria-label]="ariaLabel"
     [aria-labelledby]="ariaLabelledby"
     (opened)="openedSpy()"
@@ -89,7 +90,7 @@ const SIMPLE_AUTOCOMPLETE_TEMPLATE = `
   template: SIMPLE_AUTOCOMPLETE_TEMPLATE,
 })
 class SimpleAutocomplete implements OnDestroy {
-  numberCtrl = new FormControl<{ name: string; code: string; height: number } | string | null>(
+  numberCtrl = new FormControl<{ name: string; code: string; height?: number } | string | null>(
     null,
   );
   filteredNumbers: any[];
@@ -98,6 +99,7 @@ class SimpleAutocomplete implements OnDestroy {
   width: number;
   autocompleteDisabled = false;
   hasLabel = true;
+  requireSelection = false;
   ariaLabel: string;
   ariaLabelledby: string;
   panelClass = 'class-one class-two';
@@ -2879,6 +2881,165 @@ describe('SbbAutocomplete', () => {
       expect(optionInstance.selected).toBe(false);
       expect(spy).not.toHaveBeenCalled();
 
+      subscription.unsubscribe();
+    }));
+
+    it('should accept the user selection if they click on an option while selection is required', fakeAsync(() => {
+      const input = fixture.nativeElement.querySelector('input');
+      const { numberCtrl, trigger, numbers } = fixture.componentInstance;
+      fixture.componentInstance.requireSelection = true;
+      numberCtrl.setValue(numbers[1]);
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Zwei');
+      expect(numberCtrl.value).toEqual({ code: '2', name: 'Zwei', height: 48 });
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const options = overlayContainerElement.querySelectorAll(
+        'sbb-option',
+      ) as NodeListOf<HTMLElement>;
+      const spy = jasmine.createSpy('optionSelected spy');
+      const subscription = trigger.optionSelections.subscribe(spy);
+
+      options[5].click();
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Sieben');
+      expect(numberCtrl.value).toEqual({ code: '7', name: 'Sieben', height: 48 });
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      subscription.unsubscribe();
+    }));
+
+    it('should accept the user selection if they press enter on an option while selection is required', fakeAsync(() => {
+      const input = fixture.nativeElement.querySelector('input');
+      const { numberCtrl, trigger, numbers } = fixture.componentInstance;
+      fixture.componentInstance.requireSelection = true;
+      numberCtrl.setValue(numbers[1]);
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Zwei');
+      expect(numberCtrl.value).toEqual({ code: '2', name: 'Zwei', height: 48 });
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const options = overlayContainerElement.querySelectorAll(
+        'sbb-option',
+      ) as NodeListOf<HTMLElement>;
+      const spy = jasmine.createSpy('optionSelected spy');
+      const subscription = trigger.optionSelections.subscribe(spy);
+
+      dispatchKeyboardEvent(options[5], 'keydown', ENTER);
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Sieben');
+      expect(numberCtrl.value).toEqual({ code: '7', name: 'Sieben', height: 48 });
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      subscription.unsubscribe();
+    }));
+
+    it('should accept the user selection if autoSelectActiveOption is enabled', fakeAsync(() => {
+      const input = fixture.nativeElement.querySelector('input');
+      const { numberCtrl, trigger, numbers } = fixture.componentInstance;
+      fixture.componentInstance.requireSelection = true;
+      trigger.autocomplete.autoSelectActiveOption = true;
+      numberCtrl.setValue(numbers[1]);
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Zwei');
+      expect(numberCtrl.value).toEqual({ code: '2', name: 'Zwei', height: 48 });
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      for (let i = 0; i < 5; i++) {
+        dispatchKeyboardEvent(input, 'keydown', DOWN_ARROW);
+        fixture.detectChanges();
+      }
+
+      dispatchFakeEvent(document, 'click');
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Sechs');
+      expect(numberCtrl.value).toEqual({ code: '6', name: 'Sechs', height: 48 });
+    }));
+
+    it('should clear the value if selection is required and the user interacted with the panel without selecting anything', fakeAsync(() => {
+      const input = fixture.nativeElement.querySelector('input');
+      const { numberCtrl, trigger, numbers } = fixture.componentInstance;
+      fixture.componentInstance.requireSelection = true;
+      numberCtrl.setValue(numbers[1]);
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Zwei');
+      expect(numberCtrl.value).toEqual({ code: '2', name: 'Zwei', height: 48 });
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const spy = jasmine.createSpy('optionSelected spy');
+      const subscription = trigger.optionSelections.subscribe(spy);
+
+      input.value = 'Zw';
+      dispatchKeyboardEvent(input, 'input');
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Zw');
+      expect(numberCtrl.value).toBe('Zw');
+      expect(spy).not.toHaveBeenCalled();
+
+      dispatchFakeEvent(document, 'click');
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('');
+      expect(numberCtrl.value).toBe(null);
+      expect(spy).not.toHaveBeenCalled();
+
+      subscription.unsubscribe();
+    }));
+
+    it('should preserve the value if a selection is required, but the user opened and closed the panel without interacting with it', fakeAsync(() => {
+      const input = fixture.nativeElement.querySelector('input');
+      const { numberCtrl, trigger, numbers } = fixture.componentInstance;
+      fixture.componentInstance.requireSelection = true;
+      numberCtrl.setValue(numbers[1]);
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Zwei');
+      expect(numberCtrl.value).toEqual({ code: '2', name: 'Zwei', height: 48 });
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const spy = jasmine.createSpy('optionSelected spy');
+      const subscription = trigger.optionSelections.subscribe(spy);
+
+      dispatchFakeEvent(document, 'click');
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Zwei');
+      expect(numberCtrl.value).toEqual({ code: '2', name: 'Zwei', height: 48 });
+      expect(spy).not.toHaveBeenCalled();
       subscription.unsubscribe();
     }));
   });

--- a/src/angular/autocomplete/autocomplete.ts
+++ b/src/angular/autocomplete/autocomplete.ts
@@ -59,6 +59,9 @@ export interface SbbAutocompleteDefaultOptions {
   /** Whether the active option should be selected as the user is navigating. */
   autoSelectActiveOption?: boolean;
 
+  /** Whether the user is required to make a selection when they're interacting with the autocomplete. */
+  requireSelection?: boolean;
+
   /** Class or list of classes to be applied to the autocomplete's overlay panel. */
   overlayPanelClass?: string | string[];
 }
@@ -74,7 +77,7 @@ export const SBB_AUTOCOMPLETE_DEFAULT_OPTIONS = new InjectionToken<SbbAutocomple
 
 /** @docs-private */
 export function SBB_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY(): SbbAutocompleteDefaultOptions {
-  return { autoActiveFirstOption: false, autoSelectActiveOption: false };
+  return { autoActiveFirstOption: false, autoSelectActiveOption: false, requireSelection: false };
 }
 
 @Component({
@@ -180,6 +183,21 @@ export class SbbAutocomplete implements AfterContentInit, OnDestroy {
   private _autoSelectActiveOption: boolean;
 
   /**
+   * Whether the user is required to make a selection when they're interacting with the
+   * autocomplete. If the user moves away from the autcomplete without selecting an option from
+   * the list, the value will be reset. If the user opens the panel and closes it without
+   * interacting or selecting a value, the initial value will be kept.
+   */
+  @Input()
+  get requireSelection(): boolean {
+    return this._requireSelection;
+  }
+  set requireSelection(value: BooleanInput) {
+    this._requireSelection = coerceBooleanProperty(value);
+  }
+  private _requireSelection: boolean;
+
+  /**
    * Specify the width of the autocomplete panel.  Can be any CSS sizing value, otherwise it will
    * match the width of its host.
    */
@@ -256,6 +274,7 @@ export class SbbAutocomplete implements AfterContentInit, OnDestroy {
     this.inertGroups = platform?.SAFARI || false;
     this._autoActiveFirstOption = !!defaults.autoActiveFirstOption;
     this._autoSelectActiveOption = !!defaults.autoSelectActiveOption;
+    this._requireSelection = !!defaults.requireSelection;
   }
 
   ngAfterContentInit() {

--- a/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.html
+++ b/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.html
@@ -1,0 +1,24 @@
+<form class="example-form">
+  <sbb-form-field class="example-full-width">
+    <sbb-label>Number</sbb-label>
+    <input
+      type="text"
+      placeholder="Pick one"
+      aria-label="Number"
+      sbbInput
+      [formControl]="myControl"
+      [sbbAutocomplete]="auto"
+    />
+    <sbb-autocomplete requireSelection #auto="sbbAutocomplete">
+      <sbb-option *ngFor="let option of filteredOptions | async" [value]="option">
+        {{option}}
+      </sbb-option>
+    </sbb-autocomplete>
+  </sbb-form-field>
+</form>
+
+<pre>{{ myControl.value | json }}</pre>
+<p>
+  Enter something in the autocomplete (e.g. "B") and leave the field without selecting a value. With
+  `requiredSelection = true` the value will be reset to `null` (otherwise it would be "B").
+</p>

--- a/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
@@ -1,0 +1,56 @@
+import { AsyncPipe, JsonPipe, NgFor } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SbbAutocompleteModule } from '@sbb-esta/angular/autocomplete';
+import { SbbFormFieldModule } from '@sbb-esta/angular/form-field';
+import { SbbInputModule } from '@sbb-esta/angular/input';
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
+
+/**
+ * @title Require an autocomplete option to be selected
+ * @order 70
+ */
+@Component({
+  selector: 'sbb-autocomplete-require-selection-example',
+  templateUrl: 'autocomplete-require-selection-example.html',
+  standalone: true,
+  imports: [
+    FormsModule,
+    SbbFormFieldModule,
+    SbbInputModule,
+    SbbAutocompleteModule,
+    ReactiveFormsModule,
+    NgFor,
+    AsyncPipe,
+    JsonPipe,
+  ],
+})
+export class AutocompleteRequireSelectionExample implements OnInit {
+  myControl = new FormControl('');
+  options: string[] = [
+    'Zürich',
+    'Bern',
+    'St. Gallen',
+    'Luzern',
+    'Basel',
+    'Genf',
+    'Biel/Bienne',
+    'Lausanne',
+    'Winterthur',
+  ];
+  filteredOptions: Observable<string[]>;
+
+  ngOnInit() {
+    this.filteredOptions = this.myControl.valueChanges.pipe(
+      startWith(''),
+      map((value) => this._filter(value || '')),
+    );
+  }
+
+  private _filter(value: string): string[] {
+    const filterValue = value.toLowerCase();
+
+    return this.options.filter((option) => option.toLowerCase().includes(filterValue));
+  }
+}

--- a/src/components-examples/angular/autocomplete/index.ts
+++ b/src/components-examples/angular/autocomplete/index.ts
@@ -4,3 +4,4 @@ export { AutocompleteHintExample } from './autocomplete-hint/autocomplete-hint-e
 export { AutocompleteLocaleNormalizerExample } from './autocomplete-locale-normalizer/autocomplete-locale-normalizer-example';
 export { AutocompleteOptionGroupExample } from './autocomplete-option-group/autocomplete-option-group-example';
 export { AutocompleteReactiveFormsExample } from './autocomplete-reactive-forms/autocomplete-reactive-forms-example';
+export { AutocompleteRequireSelectionExample } from './autocomplete-require-selection/autocomplete-require-selection-example';


### PR DESCRIPTION
Adds the `requireSelection` input to the autocomplete, which when enabled will clear the input value if the user doesn't select an option from the list.