### PR TITLE
feat(angular/header-lean): add directive to display icon buttons in header

### DIFF
--- a/src/angular/header-lean/header-directives.ts
+++ b/src/angular/header-lean/header-directives.ts
@@ -58,3 +58,23 @@ export class SbbHeaderEnvironment implements OnDestroy {
     this._destroyed.complete();
   }
 }
+
+/**
+ * Optional component to display icon buttons next to the `<sbb-usermenu>` or the `[brand]`.
+ *
+ * e.g.:
+ * ```
+ * <sbb-header-icon-actions>
+ *   <button sbb-frameless-button><sbb-icon svgIcon="magnifying-glass-small"></sbb-icon></button>
+ *   <button sbb-frameless-button><sbb-icon svgIcon="bell-small"></sbb-icon></button>
+ * </sbb-header-icon-actions>
+ * ```
+ */
+@Directive({
+  selector: 'sbb-header-icon-actions',
+  exportAs: 'sbbHeaderIconActions',
+  host: {
+    class: 'sbb-header-icon-actions',
+  },
+})
+export class SbbHeaderIconActions {}

--- a/src/angular/header-lean/header-lean.md
+++ b/src/angular/header-lean/header-lean.md
@@ -1,8 +1,8 @@
 The header will appear at the top of the screen in a fixed position, and provide a container
 for navigation, usermenu and the logo.
-It supports `<a>` and `<button>` tags for navigation. Optionally a `<sbb-usermenu>` can be
-provided, as well as any element with a `[brand]` attribute or `.brand` class, for replacing
-the standard logo.
+It supports `<a>` and `<button>` tags for navigation. Optionally a `<sbb-header-icon-actions>`
+element and a `<sbb-usermenu>` can be provided, as well as any element with a `[brand]` attribute or
+`.brand` class, for replacing the standard logo.
 
 ```html
 <sbb-header-lean [label]="Title" [subtitle]="Subtitle">
@@ -15,7 +15,12 @@ the standard logo.
     <a sbbHeaderMenuItem routerLink="/nav1/section1" routerLinkActive="sbb-active">Section 1</a>
     <a sbbHeaderMenuItem routerLink="/nav1/section2" routerLinkActive="sbb-active">Section 2</a>
   </sbb-header-menu>
+  <!-- Optional icon buttons to be displayed on the right side of the header -->
+  <sbb-header-icon-actions>
+    <button sbb-frameless-button><sbb-icon svgIcon="magnifying-glass-small"></sbb-icon></button>
+  </sbb-header-icon-actions>
   <sbb-usermenu ...><!-- Optional --></sbb-usermenu>
+
   <svg brand><!-- Optional --></svg>
 </sbb-header-lean>
 ```

--- a/src/angular/header-lean/header.html
+++ b/src/angular/header-lean/header.html
@@ -27,7 +27,9 @@
 
 <div class="sbb-header-lean-container-end">
   <div class="sbb-header-lean-additional-content">
-    <ng-content select=".additional-header-content"></ng-content>
+    <ng-content
+      select=".additional-header-content,sbb-header-icon-actions,.sbb-header-icon-actions"
+    ></ng-content>
   </div>
   <div class="sbb-header-lean-usermenu">
     <ng-content select="sbb-usermenu,.sbb-usermenu"></ng-content>

--- a/src/angular/header-lean/header.module.ts
+++ b/src/angular/header-lean/header.module.ts
@@ -8,7 +8,7 @@ import { SbbIconModule } from '@sbb-esta/angular/icon';
 
 import { SbbAppChooserSection } from './app-chooser-section';
 import { SbbHeaderLean } from './header';
-import { SbbHeaderEnvironment } from './header-directives';
+import { SbbHeaderEnvironment, SbbHeaderIconActions } from './header-directives';
 import { SbbHeaderMenu } from './header-menu';
 import { SbbHeaderMenuItem } from './header-menu-item';
 import {
@@ -29,6 +29,7 @@ import {
     SbbHeaderLean,
     SbbAppChooserSection,
     SbbHeaderEnvironment,
+    SbbHeaderIconActions,
     SbbHeaderMenuItem,
     SbbHeaderMenuTrigger,
     SbbHeaderMenu,
@@ -37,6 +38,7 @@ import {
     SbbHeaderLean,
     SbbAppChooserSection,
     SbbHeaderEnvironment,
+    SbbHeaderIconActions,
     SbbHeaderMenuItem,
     SbbHeaderMenuTrigger,
     SbbHeaderMenu,

--- a/src/angular/header-lean/header.scss
+++ b/src/angular/header-lean/header.scss
@@ -32,6 +32,14 @@
   }
 }
 
+.sbb-header-icon-actions {
+  white-space: nowrap;
+
+  .sbb-frameless-button:not(:last-child) {
+    margin-right: calc(#{sbb.pxToRem(15)} * var(--sbb-scaling-factor));
+  }
+}
+
 /** Header environment styles. */
 .sbb-header-environment {
   z-index: 1;

--- a/src/angular/header-lean/header.scss
+++ b/src/angular/header-lean/header.scss
@@ -33,11 +33,8 @@
 }
 
 .sbb-header-icon-actions {
-  white-space: nowrap;
-
-  .sbb-frameless-button:not(:last-child) {
-    margin-right: calc(#{sbb.pxToRem(15)} * var(--sbb-scaling-factor));
-  }
+  display: flex;
+  gap: calc(#{sbb.pxToRem(15)} * var(--sbb-scaling-factor));
 }
 
 /** Header environment styles. */

--- a/src/angular/header-lean/header.spec.ts
+++ b/src/angular/header-lean/header.spec.ts
@@ -5,7 +5,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Breakpoints } from '@sbb-esta/angular/core';
 import { FakeMediaMatcher } from '@sbb-esta/angular/core/testing';
-import { SbbIcon } from '@sbb-esta/angular/icon';
+import { SbbIcon, SbbIconModule } from '@sbb-esta/angular/icon';
 import { SbbIconTestingModule } from '@sbb-esta/angular/icon/testing';
 
 import { SbbHeaderLeanModule } from './index';
@@ -15,7 +15,7 @@ describe('SbbHeaderLean', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, SbbHeaderLeanModule, SbbIconTestingModule],
+      imports: [NoopAnimationsModule, SbbHeaderLeanModule, SbbIconModule, SbbIconTestingModule],
       declarations: [SimpleHeaderLean, HeaderLeanWithAppChooser],
       providers: [
         {
@@ -94,6 +94,11 @@ describe('SbbHeaderLean', () => {
       ) as HTMLElement;
       expect(homeElementInSide).toBeDefined();
     }));
+
+    it('should display `<sbb-header-icon-actions />`', () => {
+      const button = fixture.debugElement.nativeElement.querySelectorAll('.sbb-frameless-button');
+      expect(button).toBeDefined();
+    });
   });
 
   describe('with app chooser', () => {
@@ -122,6 +127,9 @@ describe('SbbHeaderLean', () => {
   template: `
     <sbb-header-lean [label]="label" [subtitle]="subtitle">
       <sbb-header-environment>dev</sbb-header-environment>
+      <sbb-header-icon-actions>
+        <button sbb-frameless-button><sbb-icon svgIcon="magnifying-glass-small"></sbb-icon></button>
+      </sbb-header-icon-actions>
       <a routerLink="/" class="home-link">Home</a>
     </sbb-header-lean>
   `,

--- a/src/angular/schematics/ng-update/migrations/sbb-angular-symbols.json
+++ b/src/angular/schematics/ng-update/migrations/sbb-angular-symbols.json
@@ -243,6 +243,7 @@
   "sbbHeaderAnimations": "header-lean",
   "SbbHeaderCollapseBreakpoint": "header-lean",
   "SbbHeaderEnvironment": "header-lean",
+  "SbbHeaderIconActions": "header-lean",
   "SbbHeaderLean": "header-lean",
   "SbbHeaderLeanModule": "header-lean",
   "SbbHeaderMenu": "header-lean",


### PR DESCRIPTION
Adds the `<sbb-header-icon-actions />` directive for displaying icon buttons on the right side of the header, left to the `<sbb-usermenu>` and the `[brand]` element.

Closes #902