### PR TITLE
feat(angular/autocomplete): don't assign to model value while typing …

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -551,7 +551,13 @@ export class SbbAutocompleteTrigger
     if (this._previousValue !== value) {
       this._previousValue = value;
       this._pendingAutoselectedOption = null;
-      this._onChange(value);
+
+      // If selection is required we don't write to the CVA while the user is typing.
+      // At the end of the selection either the user will have picked something
+      // or we'll reset the value back to null.
+      if (!this.autocomplete || !this.autocomplete.requireSelection) {
+        this._onChange(value);
+      }
       this._inputValue.next(target.value);
 
       if (!value) {

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -3001,7 +3001,7 @@ describe('SbbAutocomplete', () => {
       tick();
 
       expect(input.value).toBe('Zw');
-      expect(numberCtrl.value).toBe('Zw');
+      expect(numberCtrl.value).toEqual({ code: '2', name: 'Zwei', height: 48 });
       expect(spy).not.toHaveBeenCalled();
 
       dispatchFakeEvent(document, 'click');

--- a/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.html
+++ b/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.html
@@ -2,17 +2,18 @@
   <sbb-form-field class="example-full-width">
     <sbb-label>Number</sbb-label>
     <input
+      #input
       type="text"
       placeholder="Pick one"
       aria-label="Number"
       sbbInput
       [formControl]="myControl"
       [sbbAutocomplete]="auto"
+      (input)="filter()"
+      (focus)="filter()"
     />
     <sbb-autocomplete requireSelection #auto="sbbAutocomplete">
-      <sbb-option *ngFor="let option of filteredOptions | async" [value]="option">
-        {{option}}
-      </sbb-option>
+      <sbb-option *ngFor="let option of filteredOptions" [value]="option"> {{option}} </sbb-option>
     </sbb-autocomplete>
   </sbb-form-field>
 </form>

--- a/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
@@ -1,11 +1,9 @@
 import { AsyncPipe, JsonPipe, NgFor } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SbbAutocompleteModule } from '@sbb-esta/angular/autocomplete';
 import { SbbFormFieldModule } from '@sbb-esta/angular/form-field';
 import { SbbInputModule } from '@sbb-esta/angular/input';
-import { Observable } from 'rxjs';
-import { map, startWith } from 'rxjs/operators';
 
 /**
  * @title Require an autocomplete option to be selected
@@ -26,7 +24,8 @@ import { map, startWith } from 'rxjs/operators';
     JsonPipe,
   ],
 })
-export class AutocompleteRequireSelectionExample implements OnInit {
+export class AutocompleteRequireSelectionExample {
+  @ViewChild('input') input: ElementRef<HTMLInputElement>;
   myControl = new FormControl('');
   options: string[] = [
     'Zürich',
@@ -39,18 +38,14 @@ export class AutocompleteRequireSelectionExample implements OnInit {
     'Lausanne',
     'Winterthur',
   ];
-  filteredOptions: Observable<string[]>;
+  filteredOptions: string[];
 
-  ngOnInit() {
-    this.filteredOptions = this.myControl.valueChanges.pipe(
-      startWith(''),
-      map((value) => this._filter(value || '')),
-    );
+  constructor() {
+    this.filteredOptions = this.options.slice();
   }
 
-  private _filter(value: string): string[] {
-    const filterValue = value.toLowerCase();
-
-    return this.options.filter((option) => option.toLowerCase().includes(filterValue));
+  filter(): void {
+    const filterValue = this.input.nativeElement.value.toLowerCase();
+    this.filteredOptions = this.options.filter((o) => o.toLowerCase().includes(filterValue));
   }
 }


### PR DESCRIPTION
…when requireSelection is enabled

Follow-up to #1952. Usually `sbb-autocomplete` assigns to the model as the user is typing which may not be desired when `requireSelection` is enabled, because at the end of the selection either an option value will set or it'll be reset.

These changes add a condition so that the value isn't assigned while typing and `requireSelection` is enabled. 1952