### PR TITLE
fix(angular/table): resolve local compilation issues

### DIFF
--- a/src/angular/table/table/row.ts
+++ b/src/angular/table/table/row.ts
@@ -5,9 +5,11 @@ import {
   CdkHeaderRowDef,
   CdkRow,
   CdkRowDef,
-  CDK_ROW_TEMPLATE,
 } from '@angular/cdk/table';
 import { ChangeDetectionStrategy, Component, Directive, ViewEncapsulation } from '@angular/core';
+
+// We can't reuse `CDK_ROW_TEMPLATE` because it's incompatible with local compilation mode.
+const ROW_TEMPLATE = `<ng-container cdkCellOutlet></ng-container>`;
 
 /**
  * Header row definition for the sbb-table.
@@ -46,7 +48,7 @@ export class SbbRowDef<T> extends CdkRowDef<T> {}
 /** Header template container that contains the cell outlet. Adds the right class and role. */
 @Component({
   selector: 'sbb-header-row, tr[sbb-header-row]',
-  template: CDK_ROW_TEMPLATE,
+  template: ROW_TEMPLATE,
   host: {
     class: 'sbb-header-row',
     role: 'row',
@@ -63,7 +65,7 @@ export class SbbHeaderRow extends CdkHeaderRow {}
 /** Footer template container that contains the cell outlet. Adds the right class and role. */
 @Component({
   selector: 'sbb-footer-row, tr[sbb-footer-row]',
-  template: CDK_ROW_TEMPLATE,
+  template: ROW_TEMPLATE,
   host: {
     class: 'sbb-footer-row',
     role: 'row',
@@ -80,7 +82,7 @@ export class SbbFooterRow extends CdkFooterRow {}
 /** Data row template container that contains the cell outlet. Adds the right class and role. */
 @Component({
   selector: 'sbb-row, tr[sbb-row]',
-  template: CDK_ROW_TEMPLATE,
+  template: ROW_TEMPLATE,
   host: {
     class: 'sbb-row',
     role: 'row',

--- a/src/angular/table/table/table.ts
+++ b/src/angular/table/table/table.ts
@@ -10,7 +10,6 @@ import { ViewportRuler } from '@angular/cdk/scrolling';
 import {
   CdkTable,
   CDK_TABLE,
-  CDK_TABLE_TEMPLATE,
   RenderRow,
   RowContext,
   StickyPositioningListener,
@@ -54,7 +53,17 @@ export class SbbRecycleRows {}
 @Component({
   selector: 'sbb-table, table[sbb-table]',
   exportAs: 'sbbTable',
-  template: CDK_TABLE_TEMPLATE,
+  // Note that according to MDN, the `caption` element has to be projected as the **first**
+  // element in the table. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
+  // We can't reuse `CDK_TABLE_TEMPLATE` because it's incompatible with local compilation mode.
+  template: `
+    <ng-content select="caption"></ng-content>
+    <ng-content select="colgroup, col"></ng-content>
+    <ng-container headerRowOutlet></ng-container>
+    <ng-container rowOutlet></ng-container>
+    <ng-container noDataRowOutlet></ng-container>
+    <ng-container footerRowOutlet></ng-container>
+  `,
   host: {
     class: 'sbb-table',
     '[class.sbb-table-fixed-layout]': 'fixedLayout',


### PR DESCRIPTION
The SBB Angular table had a few places where it was importing a component's template as a string. This is incompatible with the upcoming local compilation mode in the compiler. These changes inline the templates instead.