### PR TITLE
fix(angular/dialog): update aria-labelledby if title is swapped

### DIFF
--- a/src/angular/dialog/dialog-container.ts
+++ b/src/angular/dialog/dialog-container.ts
@@ -116,7 +116,7 @@ export abstract class _SbbDialogContainerBase extends CdkDialogContainer<SbbDial
     '[id]': '_config.id',
     '[attr.role]': '_config.role',
     '[attr.aria-modal]': '_config.ariaModal',
-    '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledBy',
+    '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledByQueue[0]',
     '[attr.aria-label]': '_config.ariaLabel',
     '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
     '[@dialogContainer]': `_getAnimationState()`,

--- a/src/angular/lightbox/lightbox-container.ts
+++ b/src/angular/lightbox/lightbox-container.ts
@@ -39,7 +39,7 @@ import { sbbLightboxAnimations } from './lightbox-animations';
     '[id]': '_config.id',
     '[attr.role]': '_config.role',
     '[attr.aria-modal]': '_config.ariaModal',
-    '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledBy',
+    '[attr.aria-labelledby]': '_config.ariaLabel ? null : _ariaLabelledByQueue[0]',
     '[attr.aria-label]': '_config.ariaLabel',
     '[attr.aria-describedby]': '_config.ariaDescribedBy || null',
     '[@lightboxContainer]': `_getAnimationState()`,


### PR DESCRIPTION
Currently the dialog assigns the ID of the title as the `aria-labelleledby` of the container, but it doesn't update it if the title is swapped out or removed.

These changes add a queue of possible IDs that the container can use as titles are being created or destroyed.
