### PR TITLE
fix(angular/tabs):  add aria-hidden to inactive tabs

### DIFF
--- a/src/angular/tabs/tab-group.html
+++ b/src/angular/tabs/tab-group.html
@@ -47,6 +47,7 @@
     *ngFor="let tab of _tabs; let i = index"
     [id]="_getTabContentId(i)"
     [attr.aria-labelledby]="_getTabLabelId(i)"
+    [attr.aria-hidden]="selectedIndex !== i"
     [class.sbb-tab-body-active]="selectedIndex == i"
     [ngClass]="tab.bodyClass"
     [content]="tab.content!"

--- a/src/angular/tabs/tab-group.spec.ts
+++ b/src/angular/tabs/tab-group.spec.ts
@@ -377,6 +377,25 @@ describe('SbbTabGroup', () => {
     });
   });
 
+  describe('aria labelling of tab panels', () => {
+    let fixture: ComponentFixture<BindedTabsTestApp>;
+    let tabPanels: HTMLElement[];
+
+    beforeEach(fakeAsync(() => {
+      fixture = TestBed.createComponent(BindedTabsTestApp);
+      fixture.detectChanges();
+      tick();
+      tabPanels = Array.from(fixture.nativeElement.querySelectorAll('.sbb-tab-body'));
+    }));
+
+    it('should set `aria-hidden="true"` on inactive tab panels', () => {
+      fixture.detectChanges();
+
+      expect(tabPanels[0].getAttribute('aria-hidden')).not.toBe('true');
+      expect(tabPanels[1].getAttribute('aria-hidden')).toBe('true');
+    });
+  });
+
   describe('disable tabs', () => {
     let fixture: ComponentFixture<DisabledTabsTestApp>;
 


### PR DESCRIPTION
Fix accessibility for tabs component. Add `aria-hidden="true"` to inactive tab panels. Fix issue where chromevox would read the names of inactive tab panels when navigating past the active tab panel. Fix this by adding `aria-hidden="true"` to inactive tab panels to exclude them from the a11y tree.