### PR TITLE
fix(angular/autocomplete):  requireSelection incorrectly resetting va…

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -140,8 +140,8 @@ export class SbbAutocompleteTrigger
   /** Old value of the native input. Used to work around issues with the `input` event on IE. */
   private _previousValue: string | number | null;
 
-  /** Value of the input element when the panel was opened. */
-  private _valueOnOpen: string | number | null;
+  /** Value of the input element when the panel was attached (even if there are no options). */
+  private _valueOnAttach: string | number | null;
 
   /** Strategy that is used to position the panel. */
   private _positionStrategy: FlexibleConnectedPositionStrategy;
@@ -648,6 +648,7 @@ export class SbbAutocompleteTrigger
                 //   of the available options,
                 // - if a valid string is entered after an invalid one.
                 if (this.panelOpen) {
+                  this._captureValueOnAttach();
                   this._emitOpened();
                 } else {
                   this.autocomplete.closed.emit();
@@ -670,8 +671,12 @@ export class SbbAutocompleteTrigger
    * the state of the trigger right before the opening sequence was finished.
    */
   private _emitOpened() {
-    this._valueOnOpen = this._element.nativeElement.value;
     this.autocomplete.opened.emit();
+  }
+
+  /** Intended to be called when the panel is attached. Captures the current value of the input. */
+  private _captureValueOnAttach() {
+    this._valueOnAttach = this._element.nativeElement.value;
   }
 
   /** Destroys the autocomplete suggestion panel. */
@@ -722,7 +727,10 @@ export class SbbAutocompleteTrigger
       this._onChange(toSelect.value);
       panel._emitSelectEvent(toSelect);
       this._element.nativeElement.focus();
-    } else if (panel.requireSelection && this._element.nativeElement.value !== this._valueOnOpen) {
+    } else if (
+      panel.requireSelection &&
+      this._element.nativeElement.value !== this._valueOnAttach
+    ) {
       this._clearPreviousSelectedOption(null);
       this._assignOptionValue(null);
       this._onChange(null);
@@ -802,6 +810,7 @@ export class SbbAutocompleteTrigger
 
     this.autocomplete._isOpen = this._overlayAttached = true;
     this._updatePanelState();
+    this._captureValueOnAttach();
 
     // We need to do an extra `panelOpen` check in here, because the
     // autocomplete won't be shown if there are no options.

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -3042,6 +3042,37 @@ describe('SbbAutocomplete', () => {
       expect(spy).not.toHaveBeenCalled();
       subscription.unsubscribe();
     }));
+
+    it('should preserve the value if a selection is required, and there are no options', fakeAsync(() => {
+      const input = fixture.nativeElement.querySelector('input');
+      const { numberCtrl, trigger, numbers } = fixture.componentInstance;
+      fixture.componentInstance.requireSelection = true;
+      numberCtrl.setValue(numbers[1]);
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Zwei');
+      expect(numberCtrl.value).toEqual({ code: '2', name: 'Zwei', height: 48 });
+
+      fixture.componentInstance.numbers = fixture.componentInstance.filteredNumbers = [];
+      fixture.detectChanges();
+
+      trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const spy = jasmine.createSpy('optionSelected spy');
+      const subscription = trigger.optionSelections.subscribe(spy);
+
+      dispatchFakeEvent(document, 'click');
+      fixture.detectChanges();
+      tick();
+
+      expect(input.value).toBe('Zwei');
+      expect(numberCtrl.value).toEqual({ code: '2', name: 'Zwei', height: 48 });
+      expect(spy).not.toHaveBeenCalled();
+      subscription.unsubscribe();
+    }));
   });
 
   describe('panel closing', () => {


### PR DESCRIPTION
…lue when there are no options

The autocomplete has a check not to reset the value if the user didn't interact with the input. The problem was that we only accounted for it when there are options, because while technically an autocomplete is _attached_ when the user focuses, we don't consider it _open_ until it shows some options.