### PR TITLE
fix(angular/tabs): nav bar not navigating on enter presses

### DIFF
--- a/src/angular/tabs/tab-nav-bar.spec.ts
+++ b/src/angular/tabs/tab-nav-bar.spec.ts
@@ -1,5 +1,5 @@
 import { Direction, Directionality } from '@angular/cdk/bidi';
-import { SPACE } from '@angular/cdk/keycodes';
+import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { Component, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -319,6 +319,18 @@ describe('SbbTabNavBar', () => {
       expect(tabLinks[1].classList.contains('sbb-tab-label-active')).toBe(false);
 
       dispatchKeyboardEvent(tabLinks[1], 'keydown', SPACE);
+      fixture.detectChanges();
+
+      expect(tabLinks[1].classList.contains('sbb-tab-label-active')).toBe(true);
+    });
+
+    it('should activate a link when enter is pressed', () => {
+      fixture.detectChanges();
+
+      const tabLinks = fixture.nativeElement.querySelectorAll('.sbb-tab-link');
+      expect(tabLinks[1].classList.contains('sbb-tab-label-active')).toBe(false);
+
+      dispatchKeyboardEvent(tabLinks[1], 'keydown', ENTER);
       fixture.detectChanges();
 
       expect(tabLinks[1].classList.contains('sbb-tab-label-active')).toBe(true);

--- a/src/angular/tabs/tab-nav-bar.ts
+++ b/src/angular/tabs/tab-nav-bar.ts
@@ -1,6 +1,6 @@
 import { FocusableOption, FocusMonitor } from '@angular/cdk/a11y';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
-import { SPACE } from '@angular/cdk/keycodes';
+import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { Platform } from '@angular/cdk/platform';
 import { ViewportRuler } from '@angular/cdk/scrolling';
 import {
@@ -208,7 +208,7 @@ export class _SbbTabLinkBase
   }
 
   _handleKeydown(event: KeyboardEvent) {
-    if (this._tabNavBar.tabPanel && event.keyCode === SPACE) {
+    if (this._tabNavBar.tabPanel && (event.keyCode === SPACE || event.keyCode === ENTER)) {
       this.elementRef.nativeElement.click();
     }
   }


### PR DESCRIPTION
Fixes that the tab nav bar wasn't navigating when pressing the enter key.