### PR TITLE
refactor: autodetect dark mode

### DIFF
--- a/src/angular/core/common-behaviors/common.module.ts
+++ b/src/angular/core/common-behaviors/common.module.ts
@@ -3,12 +3,14 @@ import { HighContrastModeDetector } from '@angular/cdk/a11y';
 import { _isTestEnvironment } from '@angular/cdk/platform';
 import { DOCUMENT } from '@angular/common';
 import { Inject, InjectionToken, NgModule, Optional } from '@angular/core';
+import { ɵvariant } from '@sbb-esta/angular/core';
+import { fromEvent, Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
 
 import { VERSION } from '../version';
 
 import { _global } from './localize/global';
 import { _$localize } from './localize/localize';
-import { ɵvariant } from './variant';
 
 /** @docs-private */
 export function SBB_SANITY_CHECKS_FACTORY(): SanityChecks {
@@ -50,15 +52,17 @@ export class SbbCommonModule {
     @Optional() @Inject(SBB_SANITY_CHECKS) private _sanityChecks: SanityChecks,
     @Inject(DOCUMENT) private _document: Document,
   ) {
+    this._isDarkMode().subscribe((isDark) => {
+      if (isDark) {
+        document.documentElement.classList.add('sbb-preferred-color-scheme-dark');
+      } else {
+        document.documentElement.classList.remove('sbb-preferred-color-scheme-dark');
+      }
+    });
     // Check variant configuration at the beginning, as this might cause components
     // to render differently.
     ɵvariant.next(
-      this._document.documentElement.classList.contains('sbb-lean') &&
-        this._document.documentElement.classList.contains('sbb-dark')
-        ? 'lean_dark'
-        : this._document.documentElement.classList.contains('sbb-lean')
-        ? 'lean'
-        : 'standard',
+      this._document.documentElement.classList.contains('sbb-lean') ? 'lean' : 'standard',
     );
 
     // While A11yModule also does this, we repeat it here to avoid importing A11yModule
@@ -97,6 +101,14 @@ export class SbbCommonModule {
     }
 
     return !!this._sanityChecks[name];
+  }
+
+  private _isDarkMode(): Observable<boolean> {
+    const query = window.matchMedia('(prefers-color-scheme: dark)');
+    return fromEvent<MediaQueryList>(query, 'change').pipe(
+      startWith(query),
+      map((event) => !!event.matches),
+    );
   }
 }
 

--- a/src/angular/core/common-behaviors/common.module.ts
+++ b/src/angular/core/common-behaviors/common.module.ts
@@ -53,11 +53,7 @@ export class SbbCommonModule {
     @Inject(DOCUMENT) private _document: Document,
   ) {
     this._isDarkMode().subscribe((isDark) => {
-      if (isDark) {
-        document.documentElement.classList.add('sbb-preferred-color-scheme-dark');
-      } else {
-        document.documentElement.classList.remove('sbb-preferred-color-scheme-dark');
-      }
+      document.documentElement.classList.toggle('sbb-preferred-color-scheme-dark', isDark);
     });
     // Check variant configuration at the beginning, as this might cause components
     // to render differently.

--- a/src/angular/core/common-behaviors/common.module.ts
+++ b/src/angular/core/common-behaviors/common.module.ts
@@ -3,7 +3,6 @@ import { HighContrastModeDetector } from '@angular/cdk/a11y';
 import { _isTestEnvironment } from '@angular/cdk/platform';
 import { DOCUMENT } from '@angular/common';
 import { Inject, InjectionToken, NgModule, Optional } from '@angular/core';
-import { ɵvariant } from '@sbb-esta/angular/core';
 import { fromEvent, Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
@@ -11,6 +10,7 @@ import { VERSION } from '../version';
 
 import { _global } from './localize/global';
 import { _$localize } from './localize/localize';
+import { ɵvariant } from './variant';
 
 /** @docs-private */
 export function SBB_SANITY_CHECKS_FACTORY(): SanityChecks {

--- a/src/angular/core/common-behaviors/variant.ts
+++ b/src/angular/core/common-behaviors/variant.ts
@@ -6,14 +6,14 @@ export const ɵvariant = new BehaviorSubject<SbbVariant>('standard');
 
 /** @docs-private */
 export interface HasVariant {
-  /** Observable holding current variant (`lean`, `lean_dark` or `standard`) which emits by change */
+  /** Observable holding current variant (`lean` or `standard`) which emits by change */
   readonly variant: Observable<SbbVariant>;
   /** Returns current active variant as a snapshot */
   readonly variantSnapshot: SbbVariant;
 }
 
 /** Possible variant values. */
-export type SbbVariant = 'standard' | 'lean' | 'lean_dark';
+export type SbbVariant = 'standard' | 'lean';
 
 /** Mixin to augment a directive with a variant property. */
 export function mixinVariant<T extends AbstractConstructor<any>>(

--- a/src/angular/notification/notification.html
+++ b/src/angular/notification/notification.html
@@ -18,7 +18,7 @@
 </div>
 
 <button
-  *ngIf="((variant | async) === 'lean' && !readonly) || ((variant | async) === 'lean_dark' && !readonly)"
+  *ngIf="(variant | async) !== 'standard' && !readonly"
   class="sbb-notification-dismiss-icon-button sbb-button-reset-frameless sbb-icon-scaled"
   type="button"
   (click)="dismiss()"

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -745,7 +745,7 @@
       --sbb-color-red-alpha40: #{rgba(sbb.$sbbColorRoyal, 0.4)};
     }
 
-    &:where(.sbb-lean.sbb-dark) {
+    &:where(.sbb-lean.sbb-dark, .sbb-lean.sbb-preferred-color-scheme-dark):not(.sbb-light) {
       // Context colors
       --sbb-color-text: var(--sbb-color-white);
       --sbb-color-background: var(--sbb-color-black);

--- a/src/angular/typography.md
+++ b/src/angular/typography.md
@@ -19,6 +19,10 @@ To activate lean design, set the css class `sbb-lean` on your `<html class="sbb-
 
 If you are uncertain which library to use, we recommend you to start with lean design.
 
+**Dark mode (lean only)**
+
+The lean design variant is available in a light and a dark mode. The mode chosen is based on the system settings. To enforce a specific mode, you can add the `sbb-light` or `sbb-dark` class to your `<html>` element.
+
 **Style for security-critical applications**
 
 We also provide a styling for applications that are critical for security.

--- a/src/showcase/app/app.component.html
+++ b/src/showcase/app/app.component.html
@@ -27,7 +27,8 @@
   >
     <sbb-option [value]="'standard'">Standard</sbb-option>
     <sbb-option [value]="'lean'">Lean</sbb-option>
-    <sbb-option [value]="'lean_dark'">Lean Dark</sbb-option>
+    <sbb-option [value]="'light'">Lean (light mode)</sbb-option>
+    <sbb-option [value]="'dark'">Lean (dark mode)</sbb-option>
   </sbb-select>
 </sbb-header-lean>
 

--- a/src/showcase/app/app.component.ts
+++ b/src/showcase/app/app.component.ts
@@ -1,6 +1,5 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { AfterContentInit, Component, isDevMode, OnDestroy } from '@angular/core';
-import { FormControl } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
 import { Breakpoints } from '@sbb-esta/angular/core';
 import { SbbIconRegistry } from '@sbb-esta/angular/icon';
@@ -35,7 +34,7 @@ export class AppComponent implements AfterContentInit, OnDestroy {
   angularVersion = angularVersion;
   showcaseVersion = libraryVersion;
   expanded: boolean = true;
-  sbbVariant: FormControl = this._variantSwitch.sbbVariant;
+  sbbVariant = this._variantSwitch.sbbVariant;
   packages = isDevMode() ? PACKAGES : DEV_PACKAGES;
   previousMajorVersions: number[] =
     window.LEGACY_VERSIONS?.split(/[ ,]+/).map(Number).filter(Number.isInteger).sort() ?? [];

--- a/src/showcase/app/variant-switch.ts
+++ b/src/showcase/app/variant-switch.ts
@@ -14,10 +14,12 @@ import { filter, map, startWith, takeUntil } from 'rxjs/operators';
 
 const variantLocalstorageKey = 'sbbAngularVariant';
 
+type SbbVariantLightDark = SbbVariant | 'light' | 'dark';
+
 @Injectable({ providedIn: 'root' })
 export class VariantSwitch implements CanActivate, OnDestroy {
-  sbbVariant: FormControl<SbbVariant> = new FormControl(
-    (localStorage.getItem(variantLocalstorageKey) as SbbVariant) || 'standard',
+  sbbVariant: FormControl<SbbVariantLightDark> = new FormControl(
+    (localStorage.getItem(variantLocalstorageKey) as SbbVariantLightDark) || 'standard',
   );
   private _destroyed = new Subject<void>();
 
@@ -34,9 +36,10 @@ export class VariantSwitch implements CanActivate, OnDestroy {
           () =>
             ({
               standard: 'lean',
-              lean: 'lean_dark',
-              lean_dark: 'standard',
-            })[this.sbbVariant.value] as SbbVariant,
+              lean: 'light',
+              light: 'dark',
+              dark: 'standard',
+            })[this.sbbVariant.value] as SbbVariantLightDark,
         ),
       )
       .subscribe((newVariant) => this.sbbVariant.setValue(newVariant));
@@ -44,17 +47,23 @@ export class VariantSwitch implements CanActivate, OnDestroy {
     this.sbbVariant.valueChanges
       .pipe(startWith(this.sbbVariant.value), takeUntil(this._destroyed))
       .subscribe((value) => {
-        document.documentElement.classList.remove('sbb-dark');
+        // switch between lean and standard variant
         if (value === 'standard') {
           document.documentElement.classList.remove('sbb-lean');
         } else {
           document.documentElement.classList.add(`sbb-lean`);
-          if (value === 'lean_dark') {
-            document.documentElement.classList.add(`sbb-dark`);
-          }
         }
-        ɵvariant.next(value);
+        ɵvariant.next(value === 'standard' ? 'lean' : 'standard');
         localStorage.setItem(variantLocalstorageKey, value);
+
+        // switch between light and dark mode
+        document.documentElement.classList.remove('sbb-dark');
+        document.documentElement.classList.remove('sbb-light');
+        if (value === 'light') {
+          document.documentElement.classList.add('sbb-light');
+        } else if (value === 'dark') {
+          document.documentElement.classList.add('sbb-dark');
+        }
       });
   }
 

--- a/src/showcase/app/variant-switch.ts
+++ b/src/showcase/app/variant-switch.ts
@@ -57,8 +57,7 @@ export class VariantSwitch implements CanActivate, OnDestroy {
         localStorage.setItem(variantLocalstorageKey, value);
 
         // switch between light and dark mode
-        document.documentElement.classList.remove('sbb-dark');
-        document.documentElement.classList.remove('sbb-light');
+        document.documentElement.classList.remove(...['sbb-dark', 'sbb-light']);
         if (value === 'light') {
           document.documentElement.classList.add('sbb-light');
         } else if (value === 'dark') {

--- a/src/showcase/styles.scss
+++ b/src/showcase/styles.scss
@@ -4,7 +4,7 @@
 :root {
   --highlight-color: #efefef;
 
-  &:where(.sbb-lean.sbb-dark) {
+  &:where(.sbb-lean.sbb-dark, .sbb-lean.sbb-preferred-color-scheme-dark):not(.sbb-light) {
     @import 'highlight.js/styles/github-dark';
     --highlight-color: var(--sbb-color-charcoal);
   }


### PR DESCRIPTION
This removes the newly introduced `lean_dark` variant. Instead, if the system's preferred color scheme is dark, the dark mode is applied automatically for the lean design variant.

The default behavior can be overridden by adding the `sbb-light` or `sbb-dark` class to the page's `<html>` element.