### PR TITLE
fix(angular/button): dark mode style for frameless button

### DIFF
--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -199,7 +199,7 @@
   --sbb-ghost-button-label-color-disabled: var(--sbb-color-iron-alpha40);
 
   // Button Frameless
-  --sbb-frameless-button-color: var(--sbb-color-iron);
+  --sbb-frameless-button-label-color: var(--sbb-color-iron);
 
   // Checkbox & Radiobutton
   --sbb-selection-container-background-color-default: var(--sbb-color-background);
@@ -792,7 +792,7 @@
       --sbb-ghost-button-label-color-disabled: var(--sbb-color-white-alpha50);
 
       // Button Frameless
-      --sbb-frameless-button-color: var(--sbb-color-silver);
+      --sbb-frameless-button-label-color: var(--sbb-color-silver);
 
       // Checkbox & Radiobutton
       --sbb-selection-container-background-color-default: var(--sbb-color-background);
@@ -1904,7 +1904,7 @@ textarea {
 }
 
 .sbb-frameless-button {
-  color: var(--sbb-frameless-button-color);
+  color: var(--sbb-frameless-button-label-color);
 
   &:is(:disabled, .sbb-disabled) {
     display: none;

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -198,6 +198,9 @@
   --sbb-ghost-button-label-color: var(--sbb-color-granite);
   --sbb-ghost-button-label-color-disabled: var(--sbb-color-iron-alpha40);
 
+  // Button Frameless
+  --sbb-frameless-button-color: var(--sbb-color-iron);
+
   // Checkbox & Radiobutton
   --sbb-selection-container-background-color-default: var(--sbb-color-background);
   --sbb-selection-container-background-color-disabled: var(--sbb-color-milk);
@@ -787,6 +790,9 @@
       --sbb-ghost-button-border-color-disabled: var(--sbb-color-iron);
       --sbb-ghost-button-label-color: var(--sbb-color-white);
       --sbb-ghost-button-label-color-disabled: var(--sbb-color-white-alpha50);
+
+      // Button Frameless
+      --sbb-frameless-button-color: var(--sbb-color-silver);
 
       // Checkbox & Radiobutton
       --sbb-selection-container-background-color-default: var(--sbb-color-background);
@@ -1898,7 +1904,7 @@ textarea {
 }
 
 .sbb-frameless-button {
-  color: var(--sbb-color-iron);
+  color: var(--sbb-frameless-button-color);
 
   &:is(:disabled, .sbb-disabled) {
     display: none;


### PR DESCRIPTION
Although the button should only be used in standard variant, there should be a suitable color for dark mode. This pr changes the color to aluminium in dark mode.