### PR TITLE
chore: fix disabled radio button and checkbox style

### DIFF
--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -2253,6 +2253,10 @@ textarea {
   }
 
   .sbb-selection-disabled & {
+    color: var(--sbb-selection-container-icon-color-disabled);
+  }
+
+  .sbb-radio-button:is(.sbb-selection-disabled) & {
     background-color: var(--sbb-selection-container-icon-color-disabled);
   }
 


### PR DESCRIPTION
In my last pr I changed the color of disabled selection containers to fix the radio button disabled style. This broke the checkbox. This pr now fixes the disabled style for both, radio button and checkbox.