### PR TITLE
fix(angular/sidebar): change dark mode background to charcoal

### DIFF
--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -965,7 +965,7 @@
       --sbb-select-arrow-icon-color: var(--sbb-color-white);
 
       // Sidebar
-      --sbb-sidebar-background-color: var(--sbb-color-midnight);
+      --sbb-sidebar-background-color: var(--sbb-color-charcoal);
       --sbb-icon-sidebar-background-color: var(--sbb-color-black);
       --sbb-sidebar-border-right-color: var(--sbb-color-iron);
       --sbb-icon-sidebar-background-color-active: var(--sbb-color-charcoal);


### PR DESCRIPTION
Change sidebar background color from midnight to charcoal to match design specification.