### PR TITLE
fix(angular/input): change border color to smoke

### DIFF
--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -313,7 +313,7 @@
   --sbb-form-input-color: var(--sbb-color-charcoal);
   --sbb-form-input-color-disabled: var(--sbb-color-granite);
   --sbb-form-input-color-placeholder: var(--sbb-color-metal);
-  --sbb-form-input-border-color: var(--sbb-color-graphite);
+  --sbb-form-input-border-color: var(--sbb-color-smoke);
   --sbb-form-input-border-color-disabled: var(--sbb-color-aluminum);
   --sbb-form-input-background-color: var(--sbb-color-background);
   --sbb-form-input-background-color-disabled: var(--sbb-color-milk);


### PR DESCRIPTION
Change border color of input elements to smoke to be wcag 2.2 conform. This changes the color in lean and standard mode.