### PR TITLE
fix(showcase): make expandable table example working on all browsers

### DIFF
--- a/src/components-examples/angular/table/expandable-table/expandable-table-example.html
+++ b/src/components-examples/angular/table/expandable-table/expandable-table-example.html
@@ -37,7 +37,7 @@
     <tr
       sbb-row
       *sbbRowDef="let row; columns: ['expandedDetail']; when: isExpansionDetailRow"
-      [style.visibility]="row.id == selectedId ? 'visible' : 'collapse'"
+      [style.display]="row.id == selectedId ? 'table-row' : 'none'"
     ></tr>
   </table>
 </sbb-table-wrapper>


### PR DESCRIPTION
Not all browsers support `visibility: collapse` on table rows. Some browsers, e.g. Safari, treat it like `visibility: hidden` which causes a gap below the clickable rows. Therefore, rows are now hidden using `display: none` and shown using `display: table-row` what is supported by all major browsers.

See https://developer.mozilla.org/en-US/docs/Web/CSS/display and https://developer.mozilla.org/en-US/docs/Web/CSS/visibility

Closes #2100