### PR TITLE
fix(angular/tags): remove focus on mouse blur

### DIFF
--- a/src/angular/tag/tag.scss
+++ b/src/angular/tag/tag.scss
@@ -65,7 +65,7 @@
     color: var(--sbb-tag-badge-label-color-disabled);
   }
 
-  .sbb-tag:not(.sbb-tag-disabled):is(:hover, :focus, .cdk-focused) & {
+  .sbb-tag:not(.sbb-tag-disabled):is(:hover, :focus, .cdk-keyboard-focused) & {
     background-color: var(--sbb-tag-background-color-inactive-hover);
     color: var(--sbb-tag-label-color-inactive-hover);
 
@@ -86,7 +86,7 @@
     }
   }
 
-  .sbb-tag-active:not(.sbb-tag-disabled):is(:hover, :focus, .cdk-focused) & {
+  .sbb-tag-active:not(.sbb-tag-disabled):is(:hover, :focus, .cdk-keyboard-focused) & {
     background-color: transparent;
     border-color: var(--sbb-tag-border-color-active-hover);
     color: var(--sbb-tag-label-color-active-hover);


### PR DESCRIPTION
The `SbbTag`, which inherits from the `SbbCheckbox`, stayed focussed until the user clicked somewhere else. This PR fixes this and removes the visible focus on blur leaving the element focussed in the background for not breaking keyboard navigation. Only tags focussed using keyboard navigation remain focussed.

Fixes #2119