### PR TITLE
fix: enforce @angular/cdk versions >= 17.1.0

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -6,7 +6,7 @@
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
 ANGULAR_PACKAGE_VERSION = "^17.0.0 || ^18.0.0"
-CDK_PACKAGE_VERSION = "^17.0.0"
+CDK_PACKAGE_VERSION = "^17.1.0"
 TSLIB_PACKAGE_VERSION = "^2.3.0"
 RXJS_PACKAGE_VERSION = "^6.5.3 || ^7.4.0"
 


### PR DESCRIPTION
SBB Angular is not working with @angular/cdk versions smaller than 17.1.0. Therefore, we enforce the minimum cdk version 17.1.0.