### PR TITLE
build: resolve deprecation warning during build

### DIFF
--- a/src/journey-maps/angular/components/level-switch/level-switch-horizontal.scss
+++ b/src/journey-maps/angular/components/level-switch/level-switch-horizontal.scss
@@ -42,9 +42,9 @@
     max-width 0.5s ease,
     visibility 0s linear 0.5s;
   visibility: hidden; /* Initially not visible */
-  right: v.$controlsMargin + (v.$controlsWidth / 2);
-  border-top-left-radius: (v.$controlsWidth / 2);
-  border-bottom-left-radius: (v.$controlsWidth / 2);
+  right: v.$controlsMargin + calc(v.$controlsWidth / 2);
+  border-top-left-radius: calc(v.$controlsWidth / 2);
+  border-bottom-left-radius: calc(v.$controlsWidth / 2);
   background-color: esta.$sbbColorWhite;
 
   @include esta.mq($from: tabletPortrait) {
@@ -94,7 +94,7 @@
 }
 
 .map-control-button-wrapper.half-width {
-  width: v.$controlsWidth / 2;
+  width: calc(v.$controlsWidth / 2);
 
   @include esta.mq($from: tabletPortrait) {
     @at-root .map-control-container.small-buttons #{&} {

--- a/src/journey-maps/angular/style/_functions.scss
+++ b/src/journey-maps/angular/style/_functions.scss
@@ -15,7 +15,7 @@
     margin: v.$controlsMargin;
     background: esta.$sbbColorWhite;
     box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-    border-radius: v.$controlsWidth / 2;
+    border-radius: calc(v.$controlsWidth / 2);
 
     @include esta.mq($from: tabletPortrait) {
       &.small-buttons {


### PR DESCRIPTION
example warning
```
DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(v.$controlsWidthSmall, 2) or calc(v.$controlsWidthSmall / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
101 │       width: v.$controlsWidthSmall / 2;
    │              ^^^^^^^^^^^^^^^^^^^^^^^^^
```