### PR TITLE
fix(angular/dialog): sbb-dialog-title should work under OnPush `viewContainerRef`

### DIFF
--- a/src/angular/dialog/dialog-content-directives.ts
+++ b/src/angular/dialog/dialog-content-directives.ts
@@ -148,23 +148,19 @@ export class _SbbDialogTitleBase implements OnInit, OnDestroy {
         }
         // Note: we null check the queue, because there are some internal
         // tests that are mocking out `SbbDialogRef` incorrectly.
-        container._ariaLabelledByQueue?.push(this.id);
+        this._dialogRef._containerInstance?._addAriaLabelledBy?.(this.id);
       });
     }
   }
 
   ngOnDestroy() {
-    // Note: we null check the queue, because there are some internal
+    // Note: we null check because there are some internal
     // tests that are mocking out `MatDialogRef` incorrectly.
-    const queue = this._dialogRef?._containerInstance?._ariaLabelledByQueue;
+    const instance = this._dialogRef?._containerInstance;
 
-    if (queue) {
+    if (instance) {
       Promise.resolve().then(() => {
-        const index = queue.indexOf(this.id);
-
-        if (index > -1) {
-          queue.splice(index, 1);
-        }
+        instance._removeAriaLabelledBy?.(this.id);
       });
     }
   }


### PR DESCRIPTION
The `sbb-dialog-title` directive updates state in a microtask and should call `ChangeDetectorRef.markForCheck`. Failing to do this will cause the component tree to not be checked if it lives under an `OnPush` component that has not otherwise been marked for check. This commit updates the queue to be a signal so we don't have to think about calling `markForCheck` at the right times.