### PR TITLE
fix(multiple): import ANIMATION_MODULE_TYPE from core

### DIFF
--- a/src/angular/badge/BUILD.bazel
+++ b/src/angular/badge/BUILD.bazel
@@ -19,7 +19,6 @@ ng_module(
         "//src/angular/core",
         "@npm//@angular/cdk",
         "@npm//@angular/core",
-        "@npm//@angular/platform-browser",
     ],
 )
 

--- a/src/angular/badge/badge.ts
+++ b/src/angular/badge/badge.ts
@@ -1,6 +1,7 @@
 import { AriaDescriber } from '@angular/cdk/a11y';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
+  ANIMATION_MODULE_TYPE,
   Directive,
   ElementRef,
   Inject,
@@ -11,7 +12,6 @@ import {
   Optional,
   Renderer2,
 } from '@angular/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { CanDisable, mixinDisabled } from '@sbb-esta/angular/core';
 
 let nextId = 0;

--- a/src/angular/button/BUILD.bazel
+++ b/src/angular/button/BUILD.bazel
@@ -21,7 +21,6 @@ ng_module(
         "@npm//@angular/cdk",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],
 )

--- a/src/angular/button/button.ts
+++ b/src/angular/button/button.ts
@@ -4,6 +4,7 @@ import { AsyncPipe } from '@angular/common';
 import {
   AfterContentInit,
   AfterViewInit,
+  ANIMATION_MODULE_TYPE,
   ChangeDetectionStrategy,
   Component,
   ContentChildren,
@@ -16,7 +17,6 @@ import {
   QueryList,
   ViewEncapsulation,
 } from '@angular/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { CanDisable, mixinDisabled, mixinVariant } from '@sbb-esta/angular/core';
 import { SbbIcon } from '@sbb-esta/angular/icon';
 import { SbbIconModule } from '@sbb-esta/angular/icon';

--- a/src/angular/chips/BUILD.bazel
+++ b/src/angular/chips/BUILD.bazel
@@ -24,7 +24,6 @@ ng_module(
         "@npm//@angular/cdk",
         "@npm//@angular/core",
         "@npm//@angular/forms",
-        "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],
 )

--- a/src/angular/chips/chip.ts
+++ b/src/angular/chips/chip.ts
@@ -2,6 +2,7 @@ import { FocusableOption } from '@angular/cdk/a11y';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { BACKSPACE, DELETE } from '@angular/cdk/keycodes';
 import {
+  ANIMATION_MODULE_TYPE,
   Attribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -21,7 +22,6 @@ import {
   Output,
   ViewEncapsulation,
 } from '@angular/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { CanDisable, HasTabIndex, mixinTabIndex, TypeRef } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
 import { Subject } from 'rxjs';

--- a/src/angular/sidebar/BUILD.bazel
+++ b/src/angular/sidebar/BUILD.bazel
@@ -29,7 +29,6 @@ ng_module(
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/localize",
-        "@npm//@angular/platform-browser",
         "@npm//@angular/router",
         "@npm//rxjs",
     ],

--- a/src/angular/sidebar/sidebar/sidebar.ts
+++ b/src/angular/sidebar/sidebar/sidebar.ts
@@ -16,6 +16,7 @@ import { DOCUMENT } from '@angular/common';
 import {
   AfterContentChecked,
   AfterContentInit,
+  ANIMATION_MODULE_TYPE,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -35,7 +36,6 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { NavigationStart, Router } from '@angular/router';
 import { SbbIcon } from '@sbb-esta/angular/icon';
 import { fromEvent, merge, NEVER, Observable, Subject } from 'rxjs';

--- a/src/angular/tabs/BUILD.bazel
+++ b/src/angular/tabs/BUILD.bazel
@@ -29,7 +29,6 @@ ng_module(
         "@npm//@angular/cdk",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],
 )

--- a/src/angular/tabs/paginated-tab-header.ts
+++ b/src/angular/tabs/paginated-tab-header.ts
@@ -12,6 +12,7 @@ import {
   AfterContentChecked,
   AfterContentInit,
   AfterViewInit,
+  ANIMATION_MODULE_TYPE,
   ChangeDetectorRef,
   Directive,
   ElementRef,
@@ -23,7 +24,6 @@ import {
   Optional,
   QueryList,
 } from '@angular/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { mixinVariant } from '@sbb-esta/angular/core';
 import { fromEvent, merge, Subject, timer } from 'rxjs';
 import {

--- a/src/angular/tabs/tab-group.ts
+++ b/src/angular/tabs/tab-group.ts
@@ -10,6 +10,7 @@ import { NgClass } from '@angular/common';
 import {
   AfterContentChecked,
   AfterContentInit,
+  ANIMATION_MODULE_TYPE,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -25,7 +26,6 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { merge, Subscription } from 'rxjs';
 import { startWith } from 'rxjs/operators';
 

--- a/src/angular/tabs/tab-header.ts
+++ b/src/angular/tabs/tab-header.ts
@@ -5,6 +5,7 @@ import {
   AfterContentChecked,
   AfterContentInit,
   AfterViewInit,
+  ANIMATION_MODULE_TYPE,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -20,7 +21,6 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { SbbIcon } from '@sbb-esta/angular/icon';
 
 import { SbbPaginatedTabHeader } from './paginated-tab-header';

--- a/src/angular/tabs/tab-nav-bar.ts
+++ b/src/angular/tabs/tab-nav-bar.ts
@@ -8,6 +8,7 @@ import {
   AfterContentChecked,
   AfterContentInit,
   AfterViewInit,
+  ANIMATION_MODULE_TYPE,
   Attribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -25,7 +26,6 @@ import {
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { CanDisable, HasTabIndex, mixinDisabled, mixinTabIndex } from '@sbb-esta/angular/core';
 import { SbbIcon } from '@sbb-esta/angular/icon';
 import { startWith, takeUntil } from 'rxjs/operators';

--- a/src/angular/tooltip/BUILD.bazel
+++ b/src/angular/tooltip/BUILD.bazel
@@ -22,7 +22,6 @@ ng_module(
         "@npm//@angular/cdk",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@angular/platform-browser",
         "@npm//rxjs",
     ],
 )

--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -25,6 +25,7 @@ import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { AsyncPipe, DOCUMENT, NgClass, NgTemplateOutlet } from '@angular/common';
 import {
   AfterViewInit,
+  ANIMATION_MODULE_TYPE,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -44,7 +45,6 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { ANIMATION_MODULE_TYPE } from '@angular/platform-browser/animations';
 import { Breakpoints } from '@sbb-esta/angular/core';
 import { SbbIcon } from '@sbb-esta/angular/icon';
 import { Observable, Subject } from 'rxjs';

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -131,7 +131,6 @@ def ng_module(
     local_deps = [
         # Add tslib because we use import helpers for all public packages.
         "@npm//tslib",
-        "@npm//@angular/platform-browser",
     ]
 
     # Append given deps only if they're not in the default set of deps


### PR DESCRIPTION
Moves all imports of `ANIMATION_MODULE_TYPE` from `platform-browser/animations` to `core` to reduce our dependence on the animations module and to avoid potential issues when lazy-loading animations.