### PR TITLE
feat(journey-maps): added high-contrast-mode controls to horizontal level switch

### DIFF
--- a/src/journey-maps/angular/components/level-switch/level-switch-horizontal.scss
+++ b/src/journey-maps/angular/components/level-switch/level-switch-horizontal.scss
@@ -128,3 +128,15 @@
     }
   }
 }
+
+@media (forced-colors: active) {
+  .main-button-wrapper {
+    /* Tell Windows not to change styles for this component */
+    forced-color-adjust: none;
+  }
+
+  .side-buttons-container {
+    /* Tell Windows not to change styles for this component */
+    forced-color-adjust: none;
+  }
+}

--- a/src/journey-maps/angular/components/level-switch/level-switch-horizontal.scss
+++ b/src/journey-maps/angular/components/level-switch/level-switch-horizontal.scss
@@ -129,6 +129,13 @@
   }
 }
 
+.map-control-button-selected,
+.map-control-button:focus-within {
+  @extend .map-control-button;
+  background-color: esta.$sbbColorCharcoal;
+  color: white;
+}
+
 @media (forced-colors: active) {
   .main-button-wrapper {
     /* Tell Windows not to change styles for this component */


### PR DESCRIPTION
Refs: ROKAS-1372

Als Benutzer von ESTA Journey-Maps möchte ich dass die Map Controls auf allen Browsern in einem einheitlichen UX daher kommen damit die Karte für alle Benutzer optimal bedienbar ist.