### PR TITLE
fix(angular/checkbox): move required validation into component

### DIFF
--- a/src/angular/checkbox/checkbox-required-validator.ts
+++ b/src/angular/checkbox/checkbox-required-validator.ts
@@ -1,6 +1,10 @@
 import { Directive, forwardRef, Provider } from '@angular/core';
 import { CheckboxRequiredValidator, NG_VALIDATORS } from '@angular/forms';
 
+/**
+ * @deprecated No longer used, `SbbCheckbox` implements required validation directly.
+ * @breaking-change 19.0.0
+ */
 export const SBB_CHECKBOX_REQUIRED_VALIDATOR: Provider = {
   provide: NG_VALIDATORS,
   useExisting: forwardRef(() => SbbCheckboxRequiredValidator),
@@ -8,9 +12,12 @@ export const SBB_CHECKBOX_REQUIRED_VALIDATOR: Provider = {
 };
 
 /**
- * Validator for Sbberial checkbox's required attribute in template-driven checkbox.
+ * Validator for SBB checkbox's required attribute in template-driven checkbox.
  * Current CheckboxRequiredValidator only work with `input type=checkbox` and does not
  * work with `sbb-checkbox`.
+ * @deprecated No longer used, `MatCheckbox` implements required validation directly.
+ * @breaking-change 19.0.0
+ *
  */
 @Directive({
   selector: `sbb-checkbox[required][formControlName],

--- a/src/angular/checkbox/checkbox.module.ts
+++ b/src/angular/checkbox/checkbox.module.ts
@@ -3,10 +3,9 @@ import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 
 import { SbbCheckbox } from './checkbox';
-import { SbbCheckboxRequiredValidator } from './checkbox-required-validator';
 
 @NgModule({
-  imports: [ObserversModule, SbbCommonModule, SbbCheckbox, SbbCheckboxRequiredValidator],
-  exports: [SbbCheckbox, SbbCheckboxRequiredValidator],
+  imports: [ObserversModule, SbbCommonModule, SbbCheckbox],
+  exports: [SbbCheckbox],
 })
 export class SbbCheckboxModule {}


### PR DESCRIPTION
Currently, required validation is implemented as a separate directive. This is problematic, because with standalone users would have to add two imports.

These changes move the required validation into the checkbox and deprecate the old module.