### PR TITLE
refactor(multiple): extract error tracking behavior into a class

### DIFF
--- a/src/angular/core/common-behaviors/error-state.ts
+++ b/src/angular/core/common-behaviors/error-state.ts
@@ -32,6 +32,44 @@ export interface HasErrorState {
 }
 
 /**
+ * Class that tracks the error state of a component.
+ * @docs-private
+ */
+// tslint:disable-next-line:class-name
+export class _ErrorStateTracker {
+  /** Whether the tracker is currently in an error state. */
+  errorState: boolean = false;
+
+  /** User-defined matcher for the error state. */
+  matcher: SbbErrorStateMatcher;
+
+  constructor(
+    private _defaultMatcher: SbbErrorStateMatcher | null,
+    public ngControl: NgControl | null,
+    private _parentFormGroup: FormGroupDirective | null,
+    private _parentForm: NgForm | null,
+    private _stateChanges: Subject<void>,
+  ) {}
+
+  /** Updates the error state based on the provided error state matcher. */
+  updateErrorState() {
+    const oldState = this.errorState;
+    const parent = this._parentFormGroup || this._parentForm;
+    const matcher = this.matcher || this._defaultMatcher;
+    const control = this.ngControl ? (this.ngControl.control as AbstractControl) : null;
+    // Note: the null check here shouldn't be necessary, but there's an internal
+    // test that appears to pass an object whose `isErrorState` isn't a function.
+    const newState =
+      typeof matcher?.isErrorState === 'function' ? matcher.isErrorState(control, parent) : false;
+
+    if (newState !== oldState) {
+      this.errorState = newState;
+      this._stateChanges.next();
+    }
+  }
+}
+
+/**
  * Mixin to augment a directive with updateErrorState method.
  * For component with `errorState` and need to update `errorState`.
  */
@@ -42,24 +80,41 @@ export function mixinErrorState<T extends Constructor<HasErrorState>>(
   base: T,
 ): CanUpdateErrorStateCtor & T {
   return class extends base {
+    private _tracker: _ErrorStateTracker | undefined;
+
     /** Whether the component is in an error state. */
-    errorState: boolean = false;
+    get errorState() {
+      return this._getTracker().errorState;
+    }
+    set errorState(value: boolean) {
+      this._getTracker().errorState = value;
+    }
 
     /** An object used to control the error state of the component. */
-    errorStateMatcher: SbbErrorStateMatcher;
+    get errorStateMatcher() {
+      return this._getTracker().matcher;
+    }
+    set errorStateMatcher(value: SbbErrorStateMatcher) {
+      this._getTracker().matcher = value;
+    }
 
     /** Updates the error state based on the provided error state matcher. */
     updateErrorState() {
-      const oldState = this.errorState;
-      const parent = this._parentFormGroup || this._parentForm;
-      const matcher = this.errorStateMatcher || this._defaultErrorStateMatcher;
-      const control = this.ngControl ? (this.ngControl.control as AbstractControl) : null;
-      const newState = matcher.isErrorState(control, parent);
+      this._getTracker().updateErrorState();
+    }
 
-      if (newState !== oldState) {
-        this.errorState = newState;
-        this.stateChanges.next();
+    private _getTracker() {
+      if (!this._tracker) {
+        this._tracker = new _ErrorStateTracker(
+          this._defaultErrorStateMatcher,
+          this.ngControl,
+          this._parentFormGroup,
+          this._parentForm,
+          this.stateChanges,
+        );
       }
+
+      return this._tracker;
     }
 
     constructor(...args: any[]) {

--- a/src/angular/core/common-behaviors/error-state.ts
+++ b/src/angular/core/common-behaviors/error-state.ts
@@ -72,6 +72,8 @@ export class _ErrorStateTracker {
 /**
  * Mixin to augment a directive with updateErrorState method.
  * For component with `errorState` and need to update `errorState`.
+ * @deprecated To be removed.
+ * @breaking-change 18.0.0
  */
 export function mixinErrorState<T extends AbstractConstructor<HasErrorState>>(
   base: T,

--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -226,7 +226,7 @@
         <source><x id="PH" equiv-text="this._counter.value"/> characters remaining</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/textarea/textarea/textarea.ts</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">52</context>
         </context-group>
         <note priority="1" from="description">Counter text for textarea</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -240,7 +240,7 @@
     </unit>
     <unit id="sbbTextareaCounterText">
       <notes>
-        <note category="location">../../../../../../src/angular/textarea/textarea/textarea.ts:83</note>
+        <note category="location">../../../../../../src/angular/textarea/textarea/textarea.ts:52</note>
         <note category="description">Counter text for textarea</note>
       </notes>
       <segment>

--- a/src/angular/schematics/ng-update/migrations/sbb-angular-symbols.json
+++ b/src/angular/schematics/ng-update/migrations/sbb-angular-symbols.json
@@ -90,6 +90,7 @@
   "SbbChipTextControl": "chips",
   "SbbChipTrailingIcon": "chips",
   "_$localize": "core",
+  "_ErrorStateTracker": "core",
   "_global": "core",
   "AbstractConstructor": "core",
   "Breakpoints": "core",


### PR DESCRIPTION
Extract error tracking behavior into a class and remove TypeScript mixin usages. The `mixinErrorState` is marked as deprecated.