### PR TITLE
refactor(angular/dialog): use enum instead of const enum

### DIFF
--- a/src/angular/dialog/dialog-ref.ts
+++ b/src/angular/dialog/dialog-ref.ts
@@ -10,7 +10,7 @@ import { SbbDialogConfig, SbbDialogPosition } from './dialog-config';
 import { _SbbDialogContainerBase } from './dialog-container';
 
 /** Possible states of the lifecycle of a dialog. */
-export const enum SbbDialogState {
+export enum SbbDialogState {
   OPEN,
   CLOSING,
   CLOSED,


### PR DESCRIPTION
Const enums prevent enabling the `isolatedModules` check which is needed for fast TS compilation based on transpileModule API.