### PR TITLE
fix(angular/autocomplete): clear previous selection on reactive form reset

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -704,6 +704,12 @@ export class SbbAutocompleteTrigger
   }
 
   private _updateNativeInputValue(value: string): void {
+    // We want to clear the previous selection if our new value is falsy. e.g: reactive form field
+    // being reset.
+    if (!value) {
+      this._clearPreviousSelectedOption(null, false);
+    }
+
     // If it's used within a `SbbFormField`, we should set it through the property so it can go
     // through change detection.
     if (this._formField && this._formField._control) {

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -1265,6 +1265,37 @@ describe('SbbAutocomplete', () => {
       expect(input.value).withContext(`Expected input value to be empty after reset.`).toEqual('');
     }));
 
+    it('should clear the previous selection when reactive form field is reset programmatically', fakeAsync(() => {
+      fixture.componentInstance.trigger.openPanel();
+      fixture.detectChanges();
+      zone.simulateZoneExit();
+
+      const options = overlayContainerElement.querySelectorAll(
+        'sbb-option',
+      ) as NodeListOf<HTMLElement>;
+      const clickedOption = options[0];
+      const option = fixture.componentInstance.options.first;
+
+      clickedOption.click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.numberCtrl.value).toEqual({
+        code: '1',
+        name: 'Eins',
+        height: 48,
+      });
+      expect(option.selected).toBe(true);
+
+      fixture.componentInstance.numberCtrl.reset();
+      tick();
+
+      fixture.detectChanges();
+      tick();
+
+      expect(fixture.componentInstance.numberCtrl.value).toEqual(null);
+      expect(option.selected).toBe(false);
+    }));
+
     it('should disable input in view when disabled programmatically', () => {
       const formFieldElement = fixture.debugElement.query(By.css('.sbb-form-field'))!.nativeElement;
 


### PR DESCRIPTION
Prior to this commit the previous selection on reactive form field wasn't getting unselected on programmatically reset of a field.