### PR TITLE
fix(angular/autocomplete): clear selected option if it is removed while typing

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -652,7 +652,6 @@ export class SbbAutocompleteTrigger
                 //   of the available options,
                 // - if a valid string is entered after an invalid one.
                 if (this.panelOpen) {
-                  this._captureValueOnAttach();
                   this._emitOpened();
                 } else {
                   this.autocomplete.closed.emit();
@@ -676,11 +675,6 @@ export class SbbAutocompleteTrigger
    */
   private _emitOpened() {
     this.autocomplete.opened.emit();
-  }
-
-  /** Intended to be called when the panel is attached. Captures the current value of the input. */
-  private _captureValueOnAttach() {
-    this._valueOnAttach = this._element.nativeElement.value;
   }
 
   /** Destroys the autocomplete suggestion panel. */
@@ -807,6 +801,7 @@ export class SbbAutocompleteTrigger
 
     if (overlayRef && !overlayRef.hasAttached()) {
       overlayRef.attach(this._portal);
+      this._valueOnAttach = this._element.nativeElement.value;
       this._closingActionsSubscription = this._subscribeToClosingActions();
     }
 
@@ -814,7 +809,6 @@ export class SbbAutocompleteTrigger
 
     this.autocomplete._isOpen = this._overlayAttached = true;
     this._updatePanelState();
-    this._captureValueOnAttach();
 
     // We need to do an extra `panelOpen` check in here, because the
     // autocomplete won't be shown if there are no options.

--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -566,6 +566,18 @@ export class SbbAutocompleteTrigger
 
       if (!value) {
         this._clearPreviousSelectedOption(null, false);
+      } else if (this.panelOpen && !this.autocomplete.requireSelection) {
+        // Note that we don't reset this when `requireSelection` is enabled,
+        // because the option will be reset when the panel is closed.
+        const selectedOption = this.autocomplete.options?.find((option) => option.selected);
+
+        if (selectedOption) {
+          const display = this.autocomplete.displayWith?.(selectedOption) ?? selectedOption.value;
+
+          if (value !== display) {
+            selectedOption.deselect(false);
+          }
+        }
       }
 
       if (this._canOpen() && this._document.activeElement === event.target) {
@@ -691,6 +703,10 @@ export class SbbAutocompleteTrigger
       this.autocomplete && this.autocomplete.displayWith
         ? this.autocomplete.displayWith(value)
         : value;
+
+    if (value == null) {
+      this._clearPreviousSelectedOption(null, false);
+    }
 
     // Simply falling back to an empty string if the display value is falsy does not work properly.
     // The display value can also be the number zero and shouldn't fall back to an empty string.

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -1118,6 +1118,65 @@ describe('SbbAutocomplete', () => {
     }).not.toThrow();
   });
 
+  it('should clear the selected option if it no longer matches the input text while typing', fakeAsync(() => {
+    const fixture = createComponent(SimpleAutocomplete);
+    fixture.detectChanges();
+    tick();
+
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    zone.simulateZoneExit();
+
+    // Select an option and reopen the panel.
+    (overlayContainerElement.querySelector('sbb-option') as HTMLElement).click();
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    zone.simulateZoneExit();
+
+    expect(fixture.componentInstance.options.first.selected).toBe(true);
+
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    input.value = '';
+    typeInElement(input, 'Ein');
+    fixture.detectChanges();
+    tick();
+
+    expect(fixture.componentInstance.options.first.selected).toBe(false);
+  }));
+
+  it('should not clear the selected option if it no longer matches the input text while typing with requireSelection', fakeAsync(() => {
+    const fixture = createComponent(SimpleAutocomplete);
+    fixture.componentInstance.requireSelection = true;
+    fixture.detectChanges();
+    tick();
+
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    zone.simulateZoneExit();
+
+    // Select an option and reopen the panel.
+    (overlayContainerElement.querySelector('sbb-option') as HTMLElement).click();
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    fixture.componentInstance.trigger.openPanel();
+    fixture.detectChanges();
+    zone.simulateZoneExit();
+
+    expect(fixture.componentInstance.options.first.selected).toBe(true);
+
+    const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+    input.value = '';
+    typeInElement(input, 'Ein');
+    fixture.detectChanges();
+    tick();
+
+    expect(fixture.componentInstance.options.first.selected).toBe(true);
+  }));
+
   describe('forms integration', () => {
     let fixture: ComponentFixture<SimpleAutocomplete>;
     let input: HTMLInputElement;


### PR DESCRIPTION
Clears the selected option in the autocomplete if the user types in something else.

This also fixes a regression #2010 where the call to capture the input value was moved into the root of `_attachOverlay` in order to capture it even when there are no options. This is problematic, because `_attachOverlay` is called as the user is typing which basically breaks the `requireSelection` feature.

These changes resolve the issue while preserving the original fix by only capturing the value when the overlay is actually attached.