### PR TITLE
fix(angular/menu): don't visually focus first item if menu is opened

### DIFF
--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -3013,7 +3013,10 @@ $menuItemPaddingTopBottom: 4;
     @include sbb.user-select(none);
   }
 
-  &:is(:not(:disabled):not([disabled]):not(.sbb-disabled):is(:hover, :focus), .sbb-focused) {
+  &:is(
+      :not(:disabled):not([disabled]):not(.sbb-disabled):is(:hover, .cdk-keyboard-focused),
+      .sbb-focused
+    ) {
     :is(&, & strong) {
       color: var(--sbb-color-red);
 


### PR DESCRIPTION
When opening a menu, the first item was always displayed in a focused state. The focus could only be removed using keyboard navigation or by clicking somewhere else.

This fix keeps the item focused in the background. However, the item is only displayed in a focused state if it was focused using keyboard navigation.

Fixes #2105