### PR TITLE
fix(angular/tabs): prevent scrolling and disable interaction if disabled

### DIFF
--- a/src/angular/tabs/tab-nav-bar.spec.ts
+++ b/src/angular/tabs/tab-nav-bar.spec.ts
@@ -80,25 +80,6 @@ describe('SbbTabNavBar', () => {
       expect(tabLinkElements[1].getAttribute('aria-current')).toEqual('page');
     });
 
-    it('should add the disabled class if disabled', () => {
-      const tabLinkElements = fixture.debugElement
-        .queryAll(By.css('a'))
-        .map((tabLinkDebugEl) => tabLinkDebugEl.nativeElement);
-
-      expect(
-        tabLinkElements.every((tabLinkEl) => !tabLinkEl.classList.contains('sbb-tab-disabled')),
-      )
-        .withContext('Expected every tab link to not have the disabled class initially')
-        .toBe(true);
-
-      fixture.componentInstance.disabled = true;
-      fixture.detectChanges();
-
-      expect(tabLinkElements.every((tabLinkEl) => tabLinkEl.classList.contains('sbb-tab-disabled')))
-        .withContext('Expected every tab link to have the disabled class if set through binding')
-        .toBe(true);
-    });
-
     it('should update aria-disabled if disabled', () => {
       const tabLinkElements = fixture.debugElement
         .queryAll(By.css('a'))
@@ -142,6 +123,20 @@ describe('SbbTabNavBar', () => {
       fixture.detectChanges();
 
       expect(tabLinkElement.classList).toContain('sbb-tab-disabled');
+    });
+
+    it('should prevent default keyboard actions on disabled links', () => {
+      const link = fixture.debugElement.query(By.css('a')).nativeElement;
+      fixture.componentInstance.disabled = true;
+      fixture.detectChanges();
+
+      const spaceEvent = dispatchKeyboardEvent(link, 'keydown', SPACE);
+      fixture.detectChanges();
+      expect(spaceEvent.defaultPrevented).toBe(true);
+
+      const enterEvent = dispatchKeyboardEvent(link, 'keydown', ENTER);
+      fixture.detectChanges();
+      expect(enterEvent.defaultPrevented).toBe(true);
     });
 
     it('should update the focusIndex when a tab receives focus directly', () => {

--- a/src/angular/tabs/tab-nav-bar.ts
+++ b/src/angular/tabs/tab-nav-bar.ts
@@ -206,8 +206,17 @@ export class _SbbTabLinkBase implements AfterViewInit, OnDestroy, FocusableOptio
   }
 
   _handleKeydown(event: KeyboardEvent) {
-    if (this._tabNavBar.tabPanel && (event.keyCode === SPACE || event.keyCode === ENTER)) {
-      this.elementRef.nativeElement.click();
+    if (event.keyCode === SPACE || event.keyCode === ENTER) {
+      if (this.disabled) {
+        event.preventDefault();
+      } else if (this._tabNavBar.tabPanel) {
+        // Only prevent the default action on space since it can scroll the page.
+        // Don't prevent enter since it can break link navigation.
+        if (event.keyCode === SPACE) {
+          event.preventDefault();
+        }
+        this.elementRef.nativeElement.click();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes that while we were preventing clicks on disabled links using `pointer-events`, we didn't prevent keyboard events.

Moreover, scrolling when hitting space is prevented.