### PR TITLE
build: add workflow to regenerate images of latest major versions

### DIFF
--- a/.github/Dockerfile.regenerate
+++ b/.github/Dockerfile.regenerate
@@ -1,0 +1,22 @@
+ARG BASE=ghcr.io/sbb-design-systems/sbb-angular/showcase:latest
+FROM $BASE as base
+
+# For version 11 + 12
+FROM nginxinc/nginx-unprivileged:stable as initless
+
+# Copy config from base image
+COPY --from=base /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+# Copy showcase from base image
+COPY --from=base /usr/share/nginx/html /usr/share/nginx/html
+
+# For versions 13+
+FROM nginxinc/nginx-unprivileged:stable as init
+
+# Copy config from base image
+COPY --from=base /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+# Copy showcase from base image
+COPY --from=base /usr/share/nginx/html /usr/share/nginx/html
+# Copy ngssc from base image if it exists
+COPY --from=base /usr/sbin/ngssc /usr/sbin/ngssc
+# Copy ngssc.sh from base image if it exists
+COPY --from=base /docker-entrypoint.d/ngssc.sh /docker-entrypoint.d/ngssc.sh

--- a/.github/workflows/regenerate-images.yml
+++ b/.github/workflows/regenerate-images.yml
@@ -1,0 +1,50 @@
+name: Regenerate Images
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Once per week on sunday
+    - cron: '0 0 * * 0'
+
+permissions:
+  packages: write
+
+jobs:
+  preview-image:
+    runs-on: ubuntu-latest
+    env:
+      START_VERSION: 11
+      IMAGE_URL: ghcr.io/sbb-design-systems/sbb-angular/showcase
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: 'Container: Login to GitHub Container Repository'
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+      - name: Regenerate latest container images to keep them up to date
+        run: |
+          majorVersion=$START_VERSION
+          while : ; do
+            version=$(git tag --sort=v:refname -l "$majorVersion.*.*" | tail -1)
+            [[ "$version" != "" ]] || break
+          
+            image="$IMAGE_URL:$version"
+            echo ""
+            echo "Regenerating $image"
+            echo ""
+          
+            (( $majorVersion < 13 )) && target=initless || target=init  
+            docker build \
+              --tag tmp \
+              --build-arg BASE="$image" \
+              --file .github/Dockerfile.regenerate \
+              --target $target
+            docker tag tmp "$image"
+            docker push "$image"
+          
+            echo ""
+            echo "Finished regenerating $image"
+            echo ""
+          
+            majorVersion=$((majorVersion+1))
+          done
+        env:
+          DOCKER_BUILDKIT: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,8 @@ jobs:
   showcase:
     runs-on: ubuntu-latest
     steps:
-    - name: Login to GitHub Docker Repository
-      uses: azure/docker-login@v1
-      with:
-        login-server: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: 'Container: Login to GitHub Container Repository'
+      run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - name: "Bazel: Copy .bazelrc to user home"
       run: cp ./.github/.bazelrc ~/
@@ -96,6 +92,8 @@ jobs:
         -t ghcr.io/sbb-design-systems/sbb-angular/showcase:${{ steps.docker_release_version.outputs.docker_release_version }} \
         -t ghcr.io/sbb-design-systems/sbb-angular/showcase:latest \
         .
+      env:
+        DOCKER_BUILDKIT: 1
     - name: "Docker: Publish image"
       run: docker push ghcr.io/sbb-design-systems/sbb-angular/showcase:${{ steps.docker_release_version.outputs.docker_release_version }}
     - name: "Docker: Publish image as latest"


### PR DESCRIPTION
This should prevent security issues from accumulating in the images, as they are continuously regenerated from the newest nginx stable image.