### PR TITLE
fix(angular/input): don't swallow the tabIndex

### DIFF
--- a/src/angular/input/input.spec.ts
+++ b/src/angular/input/input.spec.ts
@@ -872,6 +872,18 @@ describe('SbbInput with forms', () => {
       ).toBeFalsy();
     }));
 
+    it('should update the tabIndex of the input', fakeAsync(() => {
+      fixture.componentInstance.tabIndex = 3;
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+      expect(input.tabIndex).toBe(-1);
+
+      fixture.componentInstance.readonly = false;
+      fixture.detectChanges();
+      expect(input.tabIndex).toBe(3);
+    }));
+
     describe(`styles`, () => {
       let inputElementStyles: CSSStyleDeclaration;
       beforeEach(() => {
@@ -1263,7 +1275,7 @@ class SbbInputWithVariablePlaceholder {
 
 @Component({
   template: `<sbb-form-field>
-    <input sbbInput [readonly]="readonly" [formControl]="formControl" />
+    <input sbbInput [readonly]="readonly" [formControl]="formControl" [tabIndex]="tabIndex" />
   </sbb-form-field>`,
   imports: [SbbFormFieldModule, SbbInputModule, ReactiveFormsModule],
   standalone: true,
@@ -1271,4 +1283,5 @@ class SbbInputWithVariablePlaceholder {
 class SbbInputReadonly {
   readonly = true;
   formControl = new FormControl('');
+  tabIndex: number;
 }

--- a/src/angular/input/input.ts
+++ b/src/angular/input/input.ts
@@ -10,6 +10,7 @@ import {
   Inject,
   Input,
   NgZone,
+  numberAttribute,
   OnChanges,
   OnDestroy,
   Optional,
@@ -55,7 +56,7 @@ const SBB_INPUT_INVALID_TYPES = [
     '[attr.aria-invalid]': '(empty && required) ? null : errorState',
     '[attr.aria-required]': 'required',
     '[attr.placeholder]': `!readonly ? (placeholder || null) : '-'`,
-    '[attr.tabindex]': `empty && readonly ? -1  : null`,
+    '[attr.tabindex]': `empty && readonly ? -1  : tabIndex`,
   },
   providers: [{ provide: SbbFormFieldControl, useExisting: SbbInput }],
   standalone: true,
@@ -210,6 +211,11 @@ export class SbbInput
     this._readonly = coerceBooleanProperty(value);
   }
   private _readonly = false;
+  /** Tab index of the input. */
+  @Input({
+    transform: (value: unknown) => (value == null ? undefined : numberAttribute(value)),
+  })
+  tabIndex: number;
 
   /** Whether the input is in an error state. */
   get errorState() {


### PR DESCRIPTION
Fixes that the `tabIndex` attribute set on an `SbbInput` was swallowed by the component.

Fixes #2203