### PR TITLE
refactor(multiple): remove TypeScript mixin usage

### DIFF
--- a/src/angular/core/common-behaviors/initialized.ts
+++ b/src/angular/core/common-behaviors/initialized.ts
@@ -21,7 +21,11 @@ export interface HasInitialized {
   _markInitialized: () => void;
 }
 
-/** Mixin to augment a directive with an initialized property that will emits when ngOnInit ends. */
+/**
+ * Mixin to augment a directive with an initialized property that will emits when ngOnInit ends.
+ * @deprecated To be removed.
+ * @breaking-change 18.0.0
+ */
 export function mixinInitialized<T extends Constructor<{}>>(
   base: T,
 ): Constructor<HasInitialized> & T {

--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -142,7 +142,7 @@
         <source>Previous Page</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/pagination/paginator/paginator.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">81</context>
         </context-group>
         <note priority="1" from="description">Button label to navigate to the previous page</note>
       </trans-unit>
@@ -150,7 +150,7 @@
         <source>Next Page</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/pagination/paginator/paginator.ts</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">83</context>
         </context-group>
         <note priority="1" from="description">Button label to navigate to the next page</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -149,7 +149,7 @@
     </unit>
     <unit id="sbbPaginationPreviousPage">
       <notes>
-        <note category="location">../../../../../../src/angular/pagination/paginator/paginator.ts:85</note>
+        <note category="location">../../../../../../src/angular/pagination/paginator/paginator.ts:81</note>
         <note category="description">Button label to navigate to the previous page</note>
       </notes>
       <segment>
@@ -158,7 +158,7 @@
     </unit>
     <unit id="sbbPaginationNextPage">
       <notes>
-        <note category="location">../../../../../../src/angular/pagination/paginator/paginator.ts:87</note>
+        <note category="location">../../../../../../src/angular/pagination/paginator/paginator.ts:83</note>
         <note category="description">Button label to navigate to the next page</note>
       </notes>
       <segment>

--- a/src/angular/pagination/BUILD.bazel
+++ b/src/angular/pagination/BUILD.bazel
@@ -25,6 +25,7 @@ ng_module(
         "@npm//@angular/core",
         "@npm//@angular/localize",
         "@npm//@angular/router",
+        "@npm//rxjs",
     ],
 )
 


### PR DESCRIPTION
This removes the usage of `mixinInitialized` and marks it as deprecated