### PR TITLE
feat(angular/tooltip): allow specifying the preferred tooltip position

### DIFF
--- a/src/angular/tooltip/BUILD.bazel
+++ b/src/angular/tooltip/BUILD.bazel
@@ -17,6 +17,7 @@ ng_module(
     ),
     assets = [":tooltip.css"] + glob(["**/*.html"]),
     deps = [
+        "//src:dev_mode_types",
         "//src/angular/core",
         "//src/angular/icon",
         "@npm//@angular/cdk",

--- a/src/angular/tooltip/tooltip-wrapper.html
+++ b/src/angular/tooltip/tooltip-wrapper.html
@@ -2,6 +2,7 @@
   class="sbb-tooltip-icon sbb-tooltip-trigger sbb-icon-scaled sbb-button-reset-frameless"
   [class.sbb-tooltip-trigger-active]="tooltip._isTooltipVisible()"
   type="button"
+  [sbbTooltipPosition]="position"
   [sbbTooltip]="tooltipTemplate"
   [sbbTooltipTrigger]="trigger"
   [sbbTooltipShowDelay]="hoverShowDelay"

--- a/src/angular/tooltip/tooltip-wrapper.ts
+++ b/src/angular/tooltip/tooltip-wrapper.ts
@@ -18,7 +18,7 @@ import { SbbIcon } from '@sbb-esta/angular/icon';
 import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 
-import { SbbTooltip, SbbTooltipChangeEvent } from './tooltip';
+import { SbbTooltip, SbbTooltipChangeEvent, TooltipPosition } from './tooltip';
 
 // Boilerplate for applying mixins to SbbTooltipWrapper.
 // tslint:disable-next-line: naming-convention
@@ -54,6 +54,8 @@ export class SbbTooltipWrapper
 
   /** Customizations for hide delay */
   @Input({ transform: numberAttribute }) hoverHideDelay: number;
+
+  @Input() position: TooltipPosition = 'below';
 
   private _destroyed = new Subject<void>();
 

--- a/src/angular/tooltip/tooltip.scss
+++ b/src/angular/tooltip/tooltip.scss
@@ -46,6 +46,25 @@
     .sbb-tooltip-panel-right & {
       margin-left: var(--sbb-tooltip-arrow-horizontal-space);
     }
+
+    :is(.sbb-tooltip-panel-before, .sbb-tooltip-panel-after) & {
+      top: 0;
+      bottom: 0;
+      margin-top: auto;
+      margin-bottom: auto;
+    }
+
+    .sbb-tooltip-panel-after & {
+      left: calc(0.5 * var(--sbb-tooltip-shadow-arrow-size));
+      right: auto;
+      transform: rotate(315deg);
+    }
+
+    .sbb-tooltip-panel-before & {
+      left: auto;
+      right: calc(0.5 * var(--sbb-tooltip-shadow-arrow-size));
+      transform: rotate(135deg);
+    }
   }
 
   &::before {
@@ -72,6 +91,14 @@
 
   .sbb-tooltip-panel-above & {
     margin-bottom: calc(#{sbb.pxToRem(12)} * var(--sbb-scaling-factor));
+  }
+
+  .sbb-tooltip-panel-after & {
+    margin-left: calc(#{sbb.pxToRem(12)} * var(--sbb-scaling-factor));
+  }
+
+  .sbb-tooltip-panel-before & {
+    margin-right: calc(#{sbb.pxToRem(12)} * var(--sbb-scaling-factor));
   }
 }
 

--- a/src/angular/tooltip/tooltip.scss
+++ b/src/angular/tooltip/tooltip.scss
@@ -39,31 +39,31 @@
       transform: rotate(225deg);
     }
 
-    .sbb-tooltip-panel-left & {
+    .sbb-tooltip-panel-start & {
       margin-right: var(--sbb-tooltip-arrow-horizontal-space);
     }
 
-    .sbb-tooltip-panel-right & {
+    .sbb-tooltip-panel-end & {
       margin-left: var(--sbb-tooltip-arrow-horizontal-space);
     }
 
-    :is(.sbb-tooltip-panel-before, .sbb-tooltip-panel-after) & {
+    :is(.sbb-tooltip-panel-left, .sbb-tooltip-panel-right) & {
       top: 0;
       bottom: 0;
       margin-top: auto;
       margin-bottom: auto;
     }
 
-    .sbb-tooltip-panel-after & {
-      left: calc(0.5 * var(--sbb-tooltip-shadow-arrow-size));
-      right: auto;
-      transform: rotate(315deg);
-    }
-
-    .sbb-tooltip-panel-before & {
+    .sbb-tooltip-panel-left & {
       left: auto;
       right: calc(0.5 * var(--sbb-tooltip-shadow-arrow-size));
       transform: rotate(135deg);
+    }
+
+    .sbb-tooltip-panel-right & {
+      left: calc(0.5 * var(--sbb-tooltip-shadow-arrow-size));
+      right: auto;
+      transform: rotate(315deg);
     }
   }
 
@@ -93,12 +93,12 @@
     margin-bottom: calc(#{sbb.pxToRem(12)} * var(--sbb-scaling-factor));
   }
 
-  .sbb-tooltip-panel-after & {
-    margin-left: calc(#{sbb.pxToRem(12)} * var(--sbb-scaling-factor));
+  .sbb-tooltip-panel-left & {
+    margin-right: calc(#{sbb.pxToRem(12)} * var(--sbb-scaling-factor));
   }
 
-  .sbb-tooltip-panel-before & {
-    margin-right: calc(#{sbb.pxToRem(12)} * var(--sbb-scaling-factor));
+  .sbb-tooltip-panel-right & {
+    margin-left: calc(#{sbb.pxToRem(12)} * var(--sbb-scaling-factor));
   }
 }
 

--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -349,74 +349,81 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
   private readonly _destroyed = new Subject<void>();
 
   /** Predefined tooltip positions. */
-  private readonly _tooltipPositions: { [key: string]: ConnectedPosition } = {
-    above: {
-      originX: 'center',
-      originY: 'top',
-      overlayX: 'center',
-      overlayY: 'bottom',
-      offsetY: -2,
-    },
-    'above-right': {
-      originX: 'end',
-      originY: 'top',
-      overlayX: 'end',
-      overlayY: 'bottom',
-      offsetX: 5,
-      offsetY: -2,
-      panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-left`,
-    },
-    'above-left': {
-      originX: 'start',
-      originY: 'top',
-      overlayX: 'start',
-      overlayY: 'bottom',
-      offsetX: -5,
-      offsetY: -2,
-      panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-right`,
-    },
-    below: {
-      originX: 'center',
-      originY: 'bottom',
-      overlayX: 'center',
-      overlayY: 'top',
-      offsetY: 2,
-    },
-    'below-right': {
-      originX: 'end',
-      originY: 'bottom',
-      overlayX: 'end',
-      overlayY: 'top',
-      offsetX: 5,
-      offsetY: 2,
-      panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-left`,
-    },
-    'below-left': {
-      originX: 'start',
-      originY: 'bottom',
-      overlayX: 'start',
-      overlayY: 'top',
-      offsetX: -5,
-      offsetY: 2,
-      panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-right`,
-    },
-    before: {
-      originX: 'start',
-      originY: 'center',
-      overlayX: 'end',
-      overlayY: 'center',
-      offsetX: 2,
-      panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-before`,
-    },
-
-    after: {
-      originX: 'end',
-      originY: 'center',
-      overlayX: 'start',
-      overlayY: 'center',
-      offsetX: -2,
-      panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-after`,
-    },
+  private readonly _tooltipPositions: Record<TooltipPosition, ConnectedPosition[]> = {
+    above: [
+      {
+        originX: 'center',
+        originY: 'top',
+        overlayX: 'center',
+        overlayY: 'bottom',
+        offsetY: -2,
+      },
+      {
+        originX: 'end',
+        originY: 'top',
+        overlayX: 'end',
+        overlayY: 'bottom',
+        offsetX: 5,
+        offsetY: -2,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-left`,
+      },
+      {
+        originX: 'start',
+        originY: 'top',
+        overlayX: 'start',
+        overlayY: 'bottom',
+        offsetX: -5,
+        offsetY: -2,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-right`,
+      },
+    ],
+    below: [
+      {
+        originX: 'center',
+        originY: 'bottom',
+        overlayX: 'center',
+        overlayY: 'top',
+        offsetY: 2,
+      },
+      {
+        originX: 'end',
+        originY: 'bottom',
+        overlayX: 'end',
+        overlayY: 'top',
+        offsetX: 5,
+        offsetY: 2,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-left`,
+      },
+      {
+        originX: 'start',
+        originY: 'bottom',
+        overlayX: 'start',
+        overlayY: 'top',
+        offsetX: -5,
+        offsetY: 2,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-right`,
+      },
+    ],
+    before: [
+      {
+        originX: 'start',
+        originY: 'center',
+        overlayX: 'end',
+        overlayY: 'center',
+        offsetX: 2,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-before`,
+      },
+    ],
+    after: [
+      {
+        originX: 'end',
+        originY: 'center',
+        overlayX: 'start',
+        overlayY: 'center',
+        offsetX: -2,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-after`,
+      },
+    ],
   };
 
   /** Event emitted when the tooltip is opened. */
@@ -684,27 +691,13 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
     let overlayPositions: ConnectedPosition[] = [];
 
     if (position === 'above') {
-      overlayPositions = [
-        this._tooltipPositions.above,
-        this._tooltipPositions['above-left'],
-        this._tooltipPositions['above-right'],
-        this._tooltipPositions.below,
-        this._tooltipPositions['below-left'],
-        this._tooltipPositions['below-right'],
-      ];
+      overlayPositions = [...this._tooltipPositions.above, ...this._tooltipPositions.below];
     } else if (position === 'below') {
-      overlayPositions = [
-        this._tooltipPositions.below,
-        this._tooltipPositions['below-left'],
-        this._tooltipPositions['below-right'],
-        this._tooltipPositions.above,
-        this._tooltipPositions['above-left'],
-        this._tooltipPositions['above-right'],
-      ];
+      overlayPositions = [...this._tooltipPositions.below, ...this._tooltipPositions.above];
     } else if (position === 'before') {
-      overlayPositions = [this._tooltipPositions.before, this._tooltipPositions.after];
+      overlayPositions = [...this._tooltipPositions.before, ...this._tooltipPositions.after];
     } else if (position === 'after') {
-      overlayPositions = [this._tooltipPositions.after, this._tooltipPositions.before];
+      overlayPositions = [...this._tooltipPositions.after, ...this._tooltipPositions.before];
     } else if (typeof ngDevMode === 'undefined' || ngDevMode) {
       throw getSbbTooltipInvalidPositionError(position);
     }

--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -58,7 +58,7 @@ import { Observable, Subject } from 'rxjs';
 import { filter, take, takeUntil } from 'rxjs/operators';
 
 /** Possible positions for a tooltip. */
-export type TooltipPosition = 'before' | 'after' | 'above' | 'below';
+export type TooltipPosition = 'left' | 'right' | 'above' | 'below';
 
 /**
  * Options for how the tooltip trigger should handle touch gestures.
@@ -365,7 +365,7 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
         overlayY: 'bottom',
         offsetX: 5,
         offsetY: -2,
-        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-left`,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-start`,
       },
       {
         originX: 'start',
@@ -374,7 +374,7 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
         overlayY: 'bottom',
         offsetX: -5,
         offsetY: -2,
-        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-right`,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-end`,
       },
     ],
     below: [
@@ -392,7 +392,7 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
         overlayY: 'top',
         offsetX: 5,
         offsetY: 2,
-        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-left`,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-start`,
       },
       {
         originX: 'start',
@@ -401,27 +401,27 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
         overlayY: 'top',
         offsetX: -5,
         offsetY: 2,
-        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-right`,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-end`,
       },
     ],
-    before: [
+    left: [
       {
         originX: 'start',
         originY: 'center',
         overlayX: 'end',
         overlayY: 'center',
         offsetX: 2,
-        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-before`,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-left`,
       },
     ],
-    after: [
+    right: [
       {
         originX: 'end',
         originY: 'center',
         overlayX: 'start',
         overlayY: 'center',
         offsetX: -2,
-        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-after`,
+        panelClass: `${this._cssClassPrefix}-${PANEL_CLASS}-right`,
       },
     ],
   };
@@ -694,10 +694,10 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
       overlayPositions = [...this._tooltipPositions.above, ...this._tooltipPositions.below];
     } else if (position === 'below') {
       overlayPositions = [...this._tooltipPositions.below, ...this._tooltipPositions.above];
-    } else if (position === 'before') {
-      overlayPositions = [...this._tooltipPositions.before, ...this._tooltipPositions.after];
-    } else if (position === 'after') {
-      overlayPositions = [...this._tooltipPositions.after, ...this._tooltipPositions.before];
+    } else if (position === 'left') {
+      overlayPositions = [...this._tooltipPositions.left, ...this._tooltipPositions.right];
+    } else if (position === 'right') {
+      overlayPositions = [...this._tooltipPositions.right, ...this._tooltipPositions.left];
     } else if (typeof ngDevMode === 'undefined' || ngDevMode) {
       throw getSbbTooltipInvalidPositionError(position);
     }
@@ -740,7 +740,7 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
       // Note that since this information is used for styling, we want to
       // resolve `start` and `end` to their real values, otherwise consumers
       // would have to remember to do it themselves on each consumption.
-      newPosition = originX === 'start' ? 'before' : 'after';
+      newPosition = originX === 'start' ? 'left' : 'right';
     } else {
       newPosition = overlayY === 'bottom' && originY === 'top' ? 'above' : 'below';
     }

--- a/src/components-examples/angular/tooltip/BUILD.bazel
+++ b/src/components-examples/angular/tooltip/BUILD.bazel
@@ -16,6 +16,7 @@ ng_module(
         "//src/angular/button",
         "//src/angular/form-field",
         "//src/angular/input",
+        "//src/angular/select",
         "//src/angular/tooltip",
         "@npm//@angular/core",
         "@npm//@angular/forms",

--- a/src/components-examples/angular/tooltip/tooltip-simple/tooltip-simple-example.html
+++ b/src/components-examples/angular/tooltip/tooltip-simple/tooltip-simple-example.html
@@ -4,8 +4,8 @@
   <sbb-select [(ngModel)]="tooltipPreferredPosition">
     <sbb-option value="above">above</sbb-option>
     <sbb-option value="below">below</sbb-option>
-    <sbb-option value="after">after</sbb-option>
-    <sbb-option value="before">before</sbb-option>
+    <sbb-option value="left">left</sbb-option>
+    <sbb-option value="right">right</sbb-option>
   </sbb-select>
   <sbb-form-field label="Tooltip text content">
     <input type="text" [(ngModel)]="tooltipContent" sbbInput />

--- a/src/components-examples/angular/tooltip/tooltip-simple/tooltip-simple-example.html
+++ b/src/components-examples/angular/tooltip/tooltip-simple/tooltip-simple-example.html
@@ -1,16 +1,24 @@
-<sbb-tooltip>{{ tooltipContent }}</sbb-tooltip>
+<sbb-tooltip [position]="tooltipPreferredPosition">{{ tooltipContent }}</sbb-tooltip>
 <h4>Properties</h4>
-<sbb-form-field label="Tooltip text content">
-  <input type="text" [(ngModel)]="tooltipContent" sbbInput />
+<sbb-form-field label="Tooltip preferred position">
+  <sbb-select [(ngModel)]="tooltipPreferredPosition">
+    <sbb-option value="above">above</sbb-option>
+    <sbb-option value="below">below</sbb-option>
+    <sbb-option value="after">after</sbb-option>
+    <sbb-option value="before">before</sbb-option>
+  </sbb-select>
+  <sbb-form-field label="Tooltip text content">
+    <input type="text" [(ngModel)]="tooltipContent" sbbInput />
+  </sbb-form-field>
+  <p>
+    <small class="font-italic">
+      * to open a tooltip you can use the ENTER key while focusing the question mark or you can
+      click on it.
+    </small>
+    <br />
+    <small class="font-italic">
+      ** to close a tooltip you can use the ESCAPE key, click on the question mark, on the close
+      button or click outside the tooltip content box.
+    </small>
+  </p>
 </sbb-form-field>
-<p>
-  <small class="font-italic"
-    >* to open a tooltip you can use the ENTER key while focusing the question mark or you can click
-    on it.</small
-  >
-  <br />
-  <small class="font-italic"
-    >** to close a tooltip you can use the ESCAPE key, click on the question mark, on the close
-    button or click outside the tooltip content box.</small
-  >
-</p>

--- a/src/components-examples/angular/tooltip/tooltip-simple/tooltip-simple-example.ts
+++ b/src/components-examples/angular/tooltip/tooltip-simple/tooltip-simple-example.ts
@@ -2,7 +2,8 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SbbFormFieldModule } from '@sbb-esta/angular/form-field';
 import { SbbInputModule } from '@sbb-esta/angular/input';
-import { SbbTooltipModule } from '@sbb-esta/angular/tooltip';
+import { SbbSelectModule } from '@sbb-esta/angular/select';
+import { SbbTooltipModule, TooltipPosition } from '@sbb-esta/angular/tooltip';
 
 /**
  * @title Tooltip Simple
@@ -12,8 +13,9 @@ import { SbbTooltipModule } from '@sbb-esta/angular/tooltip';
   selector: 'sbb-tooltip-simple-example',
   templateUrl: 'tooltip-simple-example.html',
   standalone: true,
-  imports: [SbbTooltipModule, SbbFormFieldModule, SbbInputModule, FormsModule],
+  imports: [SbbTooltipModule, SbbFormFieldModule, SbbInputModule, FormsModule, SbbSelectModule],
 })
 export class TooltipSimpleExample {
   tooltipContent = 'Tooltip text content';
+  tooltipPreferredPosition: TooltipPosition = 'below';
 }


### PR DESCRIPTION
This allows specifying the preferred position of the tooltip. Allowed position values are `above`, `below`, `left`, `right`. Each position has at least one fallback position associated where the tooltip is positioned if there's not enough space.

If the tooltip is positioned `below` or `above`, if is centered by default and moved to the start or end position if there's not enough space to the side.

Closes #889 