### PR TITLE
chore: adjust deprecation target version

### DIFF
--- a/src/angular/core/common-behaviors/disabled.ts
+++ b/src/angular/core/common-behaviors/disabled.ts
@@ -11,7 +11,7 @@ export interface CanDisable {
 /**
  * Mixin to augment a directive with a `disabled` property.
  * @deprecated To be removed.
- * @breaking-change 18.0.0
+ * @breaking-change 19.0.0
  */
 export function mixinDisabled<T extends AbstractConstructor<{}>>(
   base: T,

--- a/src/angular/core/common-behaviors/error-state.ts
+++ b/src/angular/core/common-behaviors/error-state.ts
@@ -73,7 +73,7 @@ export class _ErrorStateTracker {
  * Mixin to augment a directive with updateErrorState method.
  * For component with `errorState` and need to update `errorState`.
  * @deprecated To be removed.
- * @breaking-change 18.0.0
+ * @breaking-change 19.0.0
  */
 export function mixinErrorState<T extends AbstractConstructor<HasErrorState>>(
   base: T,

--- a/src/angular/core/common-behaviors/initialized.ts
+++ b/src/angular/core/common-behaviors/initialized.ts
@@ -24,7 +24,7 @@ export interface HasInitialized {
 /**
  * Mixin to augment a directive with an initialized property that will emits when ngOnInit ends.
  * @deprecated To be removed.
- * @breaking-change 18.0.0
+ * @breaking-change 19.0.0
  */
 export function mixinInitialized<T extends Constructor<{}>>(
   base: T,

--- a/src/angular/core/common-behaviors/tabindex.ts
+++ b/src/angular/core/common-behaviors/tabindex.ts
@@ -15,7 +15,7 @@ export interface HasTabIndex {
 /**
  * Mixin to augment a directive with a `tabIndex` property.
  * @deprecated To be removed.
- * @breaking-change 18.0.0
+ * @breaking-change 19.0.0
  */
 export function mixinTabIndex<T extends AbstractConstructor<CanDisable>>(
   base: T,

--- a/src/angular/sidebar/sidebar-base.ts
+++ b/src/angular/sidebar/sidebar-base.ts
@@ -146,7 +146,7 @@ export abstract class SbbSidebarContainerBase<T extends SbbSidebarBase>
   /**
    * The sidebar child at the start or end position.
    * @deprecated Use `start` or `end` instead.
-   * @breaking-change 18.0.0
+   * @breaking-change 19.0.0
    */
   get sidebar(): T | null {
     return this._start || this._end;


### PR DESCRIPTION
Give the consumers a bit more time. These deprecations are only a few weeks old.