### PR TITLE
fix(angular/datepicker): remove dependency on NgClass

### DIFF
--- a/src/angular/datepicker/calendar-body/calendar-body.html
+++ b/src/angular/datepicker/calendar-body/calendar-body.html
@@ -47,7 +47,7 @@
         <button
           type="button"
           class="sbb-calendar-body-cell sbb-button-reset-frameless"
-          [ngClass]="item.cssClasses"
+          [class]="item.cssClasses"
           [tabindex]="isActiveCell(rowIndex, colIndex) ? 0 : -1"
           [class.sbb-calendar-body-disabled]="!item.enabled"
           [class.sbb-calendar-body-active]="isActiveCell(rowIndex, colIndex)"

--- a/src/angular/datepicker/calendar-body/calendar-body.ts
+++ b/src/angular/datepicker/calendar-body/calendar-body.ts
@@ -1,4 +1,3 @@
-import { NgClass } from '@angular/common';
 import {
   afterNextRender,
   AfterViewChecked,
@@ -49,7 +48,6 @@ export class SbbCalendarCell {
     role: 'grid',
   },
   standalone: true,
-  imports: [NgClass],
 })
 export class SbbCalendarBody implements AfterViewChecked {
   /**

--- a/src/angular/datepicker/datepicker-content/datepicker-content.html
+++ b/src/angular/datepicker/datepicker-content/datepicker-content.html
@@ -5,7 +5,7 @@
   [attr.aria-labelledby]="_dialogLabelId ?? undefined"
   class="sbb-datepicker-content-container"
   [id]="datepicker.id"
-  [ngClass]="datepicker.panelClass"
+  [class]="datepicker.panelClass"
   [startAt]="datepicker.startAt"
   [minDate]="datepicker.minDate"
   [maxDate]="datepicker.maxDate"

--- a/src/angular/datepicker/datepicker-content/datepicker-content.ts
+++ b/src/angular/datepicker/datepicker-content/datepicker-content.ts
@@ -1,5 +1,4 @@
 import { CdkTrapFocus } from '@angular/cdk/a11y';
-import { NgClass } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -29,7 +28,7 @@ import { SbbDatepicker } from '../datepicker/datepicker';
     class: 'sbb-datepicker-content',
   },
   standalone: true,
-  imports: [SbbCalendar, CdkTrapFocus, NgClass],
+  imports: [SbbCalendar, CdkTrapFocus],
 })
 export class SbbDatepickerContent<D> implements AfterViewInit {
   /** Reference to the internal calendar component. */

--- a/src/angular/datepicker/datepicker/datepicker.ts
+++ b/src/angular/datepicker/datepicker/datepicker.ts
@@ -111,7 +111,7 @@ export class SbbDatepicker<D> implements OnDestroy {
   }
   private _disabled?: boolean;
 
-  /** Classes to be passed to the date picker panel. Supports the same syntax as `ngClass`. */
+  /** Classes to be passed to the date picker panel. */
   @Input() panelClass: string | string[];
 
   /** Second datepicker to be used in 2 datepickers use case */


### PR DESCRIPTION
We can set classes directly through `[class]` instead of having to import `NgClass`.