### PR TITLE
fix(angular/dialog): mark dialog content as scrollable

### DIFF
--- a/src/angular/dialog/dialog-content-directives.ts
+++ b/src/angular/dialog/dialog-content-directives.ts
@@ -1,6 +1,7 @@
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
 /// <reference types="@angular/localize/init" />
 
+import { CdkScrollable } from '@angular/cdk/scrolling';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -201,6 +202,7 @@ export class SbbDialogTitle extends _SbbDialogTitleBase {}
   selector: `[sbb-dialog-content], sbb-dialog-content, [sbbDialogContent]`,
   host: { class: 'sbb-dialog-content sbb-scrollbar' },
   standalone: true,
+  hostDirectives: [CdkScrollable],
 })
 export class SbbDialogContent {}
 

--- a/src/angular/dialog/dialog.spec.ts
+++ b/src/angular/dialog/dialog.spec.ts
@@ -80,6 +80,8 @@ describe('SbbDialog', () => {
           provide: ScrollDispatcher,
           useFactory: () => ({
             scrolled: () => scrolledSubject,
+            register: () => {},
+            deregister: () => {},
           }),
         },
       ],

--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -78,11 +78,11 @@
         <source>Close dialog</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/dialog/dialog-content-directives.ts</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/dialog/dialog-content-directives.ts</context>
-          <context context-type="linenumber">114</context>
+          <context context-type="linenumber">115</context>
         </context-group>
         <note priority="1" from="description">Aria label to close a dialog</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -84,8 +84,8 @@
     </unit>
     <unit id="sbbDialogCloseDialog">
       <notes>
-        <note category="location">../../../../../../src/angular/dialog/dialog-content-directives.ts:41</note>
-        <note category="location">../../../../../../src/angular/dialog/dialog-content-directives.ts:114</note>
+        <note category="location">../../../../../../src/angular/dialog/dialog-content-directives.ts:42</note>
+        <note category="location">../../../../../../src/angular/dialog/dialog-content-directives.ts:115</note>
         <note category="description">Aria label to close a dialog</note>
       </notes>
       <segment>


### PR DESCRIPTION
Adds `CdkScrollable` to `SbbDialogContent` so that overlays inside of it can reposition on scroll.