### PR TITLE
feat(angular/sidebar): make sidebar collapsible

### DIFF
--- a/src/angular/accordion/expansion-panel.scss
+++ b/src/angular/accordion/expansion-panel.scss
@@ -47,16 +47,7 @@
   }
 
   &.sbb-expanded::after {
-    content: '';
-    display: block;
-    position: absolute;
-    height: 0;
-    bottom: 0;
-    width: calc(
-      100% - var(--sbb-expansion-panel-padding-horizontal) * 2 + var(--sbb-border-width-thin) * 2
-    );
-    left: calc(var(--sbb-expansion-panel-padding-horizontal) - var(--sbb-border-width-thin));
-    border-bottom: var(--sbb-border-width-thin) solid var(--sbb-expansion-panel-border-color-open);
+    @include sbb.expansionPanelBorderBottom();
   }
 
   &:is(.sbb-expanded, .sbb-expanded:is(:focus, :hover)) {

--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -182,7 +182,7 @@
         <source>Close Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">131</context>
         </context-group>
         <note priority="1" from="description">Button label to close the sidebar</note>
       </trans-unit>
@@ -190,7 +190,7 @@
         <source>Open Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">544</context>
+          <context context-type="linenumber">569</context>
         </context-group>
         <note priority="1" from="description">Button label to open the sidebar</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -194,7 +194,7 @@
     </unit>
     <unit id="sbbSidebarCloseSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:128</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:131</note>
         <note category="description">Button label to close the sidebar</note>
       </notes>
       <segment>
@@ -203,7 +203,7 @@
     </unit>
     <unit id="sbbSidebarOpenSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:544</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:569</note>
         <note category="description">Button label to open the sidebar</note>
       </notes>
       <segment>

--- a/src/angular/sidebar/sidebar.md
+++ b/src/angular/sidebar/sidebar.md
@@ -122,6 +122,23 @@ For example if using with a routerLink, write `routerLinkActive="sbb-active"`.
 </sbb-icon-sidebar-container>
 ```
 
+### Expanding and collapsing the sidebar
+
+By default, the `<sbb-sidebar>` is displayed next to the content and cannot be collapsed.
+It can be made collapsible by setting the `collapsible` attribute to `true`. In collapsible mode the sidebar is
+displayed above the content and can be collapsed using the close icon, by clicking in the content are or by
+pressing the escape key.
+
+In collapsible mode, the sidebar can have a title displayed next to the close icon. This label can be set using the
+`collapsibleTitle` attribute.
+
+```html
+<sbb-sidebar-container>
+  <sbb-sidebar collapsible="true">...</sbb-sidebar>
+  <sbb-sidebar-content>...</sbb-sidebar-content>
+</sbb-sidebar-container>
+```
+
 ### Expanding and collapsing an icon sidebar
 
 An `<sbb-icon-sidebar>` can be expanded or collapsed using the `toggleExpanded(expanded: boolean)` method.

--- a/src/angular/sidebar/sidebar/sidebar-container.html
+++ b/src/angular/sidebar/sidebar/sidebar-container.html
@@ -1,26 +1,28 @@
-<div class="sbb-sidebar-mobile-menu-bar">
-  @if (_start) {
-    <button
-      type="button"
-      class="sbb-button-reset-frameless sbb-sidebar-mobile-menu-bar-trigger sbb-icon-scaled"
-      (click)="toggleSidebar('start')"
-      [attr.aria-label]="_labelOpenSidebar"
-    >
-      <sbb-icon [svgIcon]="(_start._svgIcon | async)!"></sbb-icon>
-    </button>
-  }
-  <span></span>
-  @if (_end) {
-    <button
-      type="button"
-      class="sbb-button-reset-frameless sbb-sidebar-mobile-menu-bar-trigger sbb-icon-scaled"
-      (click)="toggleSidebar('end')"
-      [attr.aria-label]="_labelOpenSidebar"
-    >
-      <sbb-icon [svgIcon]="(_end._svgIcon | async)!"></sbb-icon>
-    </button>
-  }
-</div>
+@if (_mobile) {
+  <div class="sbb-sidebar-mobile-menu-bar">
+    @if (_start) {
+      <button
+        type="button"
+        class="sbb-button-reset-frameless sbb-sidebar-mobile-menu-bar-trigger sbb-icon-scaled"
+        (click)="toggleSidebar('start')"
+        [attr.aria-label]="_labelOpenSidebar"
+      >
+        <sbb-icon [svgIcon]="(_start._svgIcon | async)!"></sbb-icon>
+      </button>
+    }
+    <span></span>
+    @if (_end) {
+      <button
+        type="button"
+        class="sbb-button-reset-frameless sbb-sidebar-mobile-menu-bar-trigger sbb-icon-scaled"
+        (click)="toggleSidebar('end')"
+        [attr.aria-label]="_labelOpenSidebar"
+      >
+        <sbb-icon [svgIcon]="(_end._svgIcon | async)!"></sbb-icon>
+      </button>
+    }
+  </div>
+}
 
 @if (hasBackdrop) {
   <div

--- a/src/angular/sidebar/sidebar/sidebar.html
+++ b/src/angular/sidebar/sidebar/sidebar.html
@@ -1,13 +1,16 @@
 <div class="sbb-sidebar-inner-container sbb-scrollbar sbb-scrollbar-opaque" cdkScrollable>
-  <div class="sbb-sidebar-mobile-menu-bar-close-wrapper">
-    <button
-      type="button"
-      class="sbb-button-reset-frameless sbb-sidebar-mobile-menu-bar-close sbb-icon-scaled"
-      (click)="toggle()"
-      [attr.aria-label]="_labelCloseSidebar"
-    >
-      <sbb-icon svgIcon="cross-small"></sbb-icon>
-    </button>
-  </div>
+  @if (mode === 'over') {
+    <div class="sbb-sidebar-menu-bar-wrapper">
+      <span class="sbb-sidebar-menu-bar-title">{{ collapsibleHeaderLabel }}</span>
+      <button
+        type="button"
+        class="sbb-button-reset-frameless sbb-sidebar-menu-bar-close sbb-icon-scaled"
+        (click)="toggle()"
+        [attr.aria-label]="_labelCloseSidebar"
+      >
+        <sbb-icon svgIcon="cross-small"></sbb-icon>
+      </button>
+    </div>
+  }
   <ng-content select="sbb-expansion-panel, fieldset"></ng-content>
 </div>

--- a/src/angular/sidebar/sidebar/sidebar.html
+++ b/src/angular/sidebar/sidebar/sidebar.html
@@ -1,7 +1,7 @@
 <div class="sbb-sidebar-inner-container sbb-scrollbar sbb-scrollbar-opaque" cdkScrollable>
   @if (mode === 'over') {
     <div class="sbb-sidebar-menu-bar-wrapper">
-      <span class="sbb-sidebar-menu-bar-title">{{ collapsibleHeaderLabel }}</span>
+      <span class="sbb-sidebar-menu-bar-title">{{ collapsibleTitle }}</span>
       <button
         type="button"
         class="sbb-button-reset-frameless sbb-sidebar-menu-bar-close sbb-icon-scaled"

--- a/src/angular/sidebar/sidebar/sidebar.scss
+++ b/src/angular/sidebar/sidebar/sidebar.scss
@@ -114,7 +114,7 @@
 .sbb-sidebar-inner-container {
   @include sidebar.sbb-sidebar-inner-container();
 
-  .sbb-sidebar-container-mobile & {
+  :is(.sbb-sidebar-container-mobile &, .sbb-sidebar-over &) {
     padding-top: var(--sbb-sidebar-mobile-menu-bar-height);
   }
 
@@ -241,17 +241,13 @@
   flex: 1 1;
 }
 
-:is(.sbb-sidebar-mobile-menu-bar, .sbb-sidebar-mobile-menu-bar-close-wrapper) {
-  display: none;
+:is(.sbb-sidebar-mobile-menu-bar, .sbb-sidebar-menu-bar-wrapper) {
+  display: flex;
+  justify-content: space-between;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-
-  .sbb-sidebar-container-mobile & {
-    display: flex;
-    justify-content: space-between;
-  }
 }
 
 .sbb-sidebar-mobile-menu-bar {
@@ -259,7 +255,7 @@
   border-bottom: var(--sbb-border-width-thin) solid var(--sbb-color-cloud);
 }
 
-:is(.sbb-sidebar-mobile-menu-bar-trigger, .sbb-sidebar-mobile-menu-bar-close) {
+:is(.sbb-sidebar-mobile-menu-bar-trigger, .sbb-sidebar-menu-bar-close) {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -274,7 +270,36 @@
   }
 }
 
-.sbb-sidebar-mobile-menu-bar-close-wrapper {
+.sbb-sidebar-menu-bar-wrapper {
   background-color: var(--sbb-sidebar-background-color);
   z-index: 1;
+
+  .sbb-sidebar-menu-bar-title {
+    font-size: var(--sbb-font-size-large);
+    font-family: var(--sbb-font-light);
+    padding: var(--sbb-expansion-panel-header-padding-top)
+      var(--sbb-expansion-panel-padding-horizontal);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: none;
+  }
+}
+
+// Style overrides for collapsible sidebar in non-mobile mode.
+:is(.sbb-sidebar-over:not(.sbb-sidebar-mobile)) {
+  .sbb-sidebar-menu-bar-wrapper {
+    &::after {
+      @include sbb.expansionPanelBorderBottom();
+    }
+
+    .sbb-sidebar-menu-bar-title {
+      display: block;
+      height: var(--sbb-sidebar-collapsible-menu-bar-height);
+    }
+  }
+
+  .sbb-sidebar-inner-container {
+    padding-top: var(--sbb-sidebar-collapsible-menu-bar-height);
+  }
 }

--- a/src/angular/sidebar/sidebar/sidebar.spec.ts
+++ b/src/angular/sidebar/sidebar/sidebar.spec.ts
@@ -804,24 +804,22 @@ describe('SbbSidebar', () => {
 
     it('should display a label in the header', () => {
       const fixture = TestBed.createComponent(BasicTestComponent);
-      let collapsibleHeaderLabel = fixture.debugElement.query(
-        By.css('.sbb-sidebar-menu-bar-title'),
-      );
-      expect(collapsibleHeaderLabel).toBeFalsy();
+      let collapsibleTitle = fixture.debugElement.query(By.css('.sbb-sidebar-menu-bar-title'));
+      expect(collapsibleTitle).toBeFalsy();
 
       fixture.componentInstance.collapsible = true;
       fixture.detectChanges();
-      collapsibleHeaderLabel = fixture.debugElement.query(By.css('.sbb-sidebar-menu-bar-title'));
-      expect(collapsibleHeaderLabel.nativeElement.textContent).toBe('');
+      collapsibleTitle = fixture.debugElement.query(By.css('.sbb-sidebar-menu-bar-title'));
+      expect(collapsibleTitle.nativeElement.textContent).toBe('');
 
-      fixture.componentInstance.collapsibleHeaderLabel = 'Test header label';
+      fixture.componentInstance.collapsibleTitle = 'Test header label';
       fixture.detectChanges();
-      expect(collapsibleHeaderLabel).toBeTruthy();
-      expect(collapsibleHeaderLabel.nativeElement.textContent).toBe('Test header label');
+      expect(collapsibleTitle).toBeTruthy();
+      expect(collapsibleTitle.nativeElement.textContent).toBe('Test header label');
 
-      fixture.componentInstance.collapsibleHeaderLabel = null;
+      fixture.componentInstance.collapsibleTitle = null;
       fixture.detectChanges();
-      expect(collapsibleHeaderLabel.nativeElement.textContent).toBe('');
+      expect(collapsibleTitle.nativeElement.textContent).toBe('');
     });
   });
 });
@@ -1109,7 +1107,7 @@ class SidebarContainerTwoSidebarsTestComponent {
       #sidebar="sbbSidebar"
       [position]="position"
       [collapsible]="collapsible"
-      [collapsibleHeaderLabel]="collapsibleHeaderLabel"
+      [collapsibleTitle]="collapsibleTitle"
       [triggerSvgIcon]="triggerIcon"
       (opened)="open()"
       (openedStart)="openStart()"
@@ -1144,7 +1142,7 @@ class BasicTestComponent {
   position = 'start';
   triggerIcon: string;
   collapsible = false;
-  collapsibleHeaderLabel: string | null = null;
+  collapsibleTitle: string | null = null;
 
   @ViewChild('sidebar') sidebar: SbbSidebar;
   @ViewChild('sidebarButton') sidebarButton: ElementRef<HTMLButtonElement>;

--- a/src/angular/sidebar/sidebar/sidebar.ts
+++ b/src/angular/sidebar/sidebar/sidebar.ts
@@ -17,6 +17,7 @@ import {
   AfterContentChecked,
   AfterContentInit,
   ANIMATION_MODULE_TYPE,
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -113,8 +114,10 @@ export class SbbSidebarContent extends SbbSidebarContentBase implements AfterCon
     // must prevent the browser from aligning text based on value
     '[attr.align]': 'null',
     '[class.sbb-sidebar-over]': 'mode === "over"',
+    '[class.sbb-sidebar-mobile]': '_mobile',
     '[class.sbb-sidebar-side]': 'mode === "side"',
     '[class.sbb-sidebar-opened]': 'opened',
+    '[class.sbb-sidebar-collapsible]': 'collapsible',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
@@ -127,8 +130,29 @@ export class SbbSidebar
 {
   _labelCloseSidebar: string = $localize`:Button label to close the sidebar@@sbbSidebarCloseSidebar:Close Sidebar`;
 
+  /** Whether the sidebar is in mobile mode. */
+  _mobile: boolean = false;
+
   /** Whether the sidebar is initialized. Used for disabling the initial animation. */
   private _enableAnimations = false;
+
+  /** Whether the sidebar is collapsible. */
+  @Input({ transform: booleanAttribute })
+  set collapsible(value: boolean) {
+    this._collapsible = value;
+    this.mode = value || this._mobile ? 'over' : 'side';
+
+    if (!this._collapsible && !this.opened) {
+      this.open();
+    }
+  }
+  get collapsible(): boolean {
+    return this._collapsible;
+  }
+  _collapsible: boolean = false;
+
+  /** Optional label to display in the header if sidebar is collapsible. */
+  @Input() collapsibleHeaderLabel?: string | null;
 
   /** Mode of the sidebar; one of 'over', or 'side'. */
   get mode(): SbbSidebarMode {
@@ -500,16 +524,17 @@ export class SbbSidebar
   }
 
   _mobileChanged(mobile: boolean): void {
+    this._mobile = mobile;
     Promise.resolve().then(() => {
       const wasAnimationsEnabled = this._enableAnimations;
 
       // temporary disabled animations when changing mode
       this._enableAnimations = false;
+      this.mode = this.collapsible || mobile ? 'over' : 'side';
+
       if (mobile) {
         this.close();
-        this.mode = 'over';
       } else {
-        this.mode = 'side';
         this.open();
       }
       this._enableAnimations = wasAnimationsEnabled;

--- a/src/angular/sidebar/sidebar/sidebar.ts
+++ b/src/angular/sidebar/sidebar/sidebar.ts
@@ -151,8 +151,8 @@ export class SbbSidebar
   }
   _collapsible: boolean = false;
 
-  /** Optional label to display in the header if sidebar is collapsible. */
-  @Input() collapsibleHeaderLabel?: string | null;
+  /** Optional title to display in the sidebar header next to the close icon if sidebar is collapsible. */
+  @Input() collapsibleTitle?: string | null;
 
   /** Mode of the sidebar; one of 'over', or 'side'. */
   get mode(): SbbSidebarMode {

--- a/src/angular/styles/_mixins.scss
+++ b/src/angular/styles/_mixins.scss
@@ -162,3 +162,16 @@
   -webkit-user-select: $value;
   user-select: $value;
 }
+
+@mixin expansionPanelBorderBottom() {
+  content: '';
+  display: block;
+  position: absolute;
+  height: 0;
+  bottom: 0;
+  width: calc(
+    100% - var(--sbb-expansion-panel-padding-horizontal) * 2 + var(--sbb-border-width-thin) * 2
+  );
+  left: calc(var(--sbb-expansion-panel-padding-horizontal) - var(--sbb-border-width-thin));
+  border-bottom: var(--sbb-border-width-thin) solid var(--sbb-expansion-panel-border-color-open);
+}

--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -416,6 +416,9 @@
 
   // Sidebar
   --sbb-sidebar-mobile-menu-bar-height: calc(2 * var(--sbb-icon-size-default));
+  --sbb-sidebar-collapsible-menu-bar-height: calc(
+    2 * var(--sbb-icon-size-default) + #{sbb.pxToRem(8)} * var(--sbb-scaling-factor)
+  );
   --sbb-icon-sidebar-item-dimension: calc(2 * var(--sbb-icon-size-default));
   --sbb-sidebar-background-color: var(--sbb-color-background);
   --sbb-sidebar-background-color-hover: var(--sbb-menu-item-background-color-hover);

--- a/src/components-examples/angular/sidebar/BUILD.bazel
+++ b/src/components-examples/angular/sidebar/BUILD.bazel
@@ -23,6 +23,7 @@ ng_module(
         "//src/angular/core/testing",
         "//src/angular/form-field",
         "//src/angular/icon",
+        "//src/angular/input",
         "//src/angular/select",
         "//src/angular/sidebar",
         "@npm//@angular/cdk",

--- a/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.css
+++ b/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.css
@@ -1,0 +1,16 @@
+.sbb-icon-sidebar-item.sbb-active {
+  pointer-events: unset;
+  cursor: pointer;
+}
+
+.sidebar-frame {
+  display: block;
+  height: 400px;
+  width: 500px;
+  position: relative;
+  border: 1px solid #b7b7b7;
+}
+
+sbb-sidebar-content {
+  padding: 15px;
+}

--- a/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.html
+++ b/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.html
@@ -1,0 +1,60 @@
+<div class="sidebar-frame">
+  <sbb-icon-sidebar-container>
+    <sbb-icon-sidebar [position]="position.value">
+      <a sbbIconSidebarItem label="Station" href="">
+        <sbb-icon svgIcon="station-small"></sbb-icon>
+      </a>
+      <a sbbIconSidebarItem label="Lockers" class="sbb-active" (click)="sidebar.toggle()">
+        <sbb-icon svgIcon="locker-small"></sbb-icon>
+      </a>
+      <hr />
+      <a sbbIconSidebarItem label="Money Exchange" href="">
+        <sbb-icon svgIcon="money-exchange-small"></sbb-icon>
+      </a>
+      <a sbbIconSidebarItem label="Waiting Room" href="">
+        <sbb-icon svgIcon="waiting-room-small"></sbb-icon>
+      </a>
+    </sbb-icon-sidebar>
+    <sbb-icon-sidebar-content role="main">
+      <sbb-sidebar-container>
+        <sbb-sidebar
+          #sidebar
+          role="navigation"
+          [position]="position.value"
+          [collapsible]="collapsible.value"
+          [collapsibleHeaderLabel]="collapsibleHeaderLabel.value"
+        >
+          <sbb-expansion-panel expanded>
+            <sbb-expansion-panel-header>Introduction</sbb-expansion-panel-header>
+            <a sbbSidebarLink class="sbb-active">Getting Started</a>
+            <a sbbSidebarLink href="">Typography</a>
+          </sbb-expansion-panel>
+          <sbb-expansion-panel>
+            <sbb-expansion-panel-header>Components</sbb-expansion-panel-header>
+            <a sbbSidebarLink href="">Autocomplete</a>
+            <a sbbSidebarLink href="">Checkbox</a>
+          </sbb-expansion-panel>
+        </sbb-sidebar>
+        <sbb-sidebar-content role="main"> Content </sbb-sidebar-content>
+      </sbb-sidebar-container>
+    </sbb-icon-sidebar-content>
+  </sbb-icon-sidebar-container>
+</div>
+
+<h4>Properties</h4>
+<div class="sbb-checkbox-group-vertical">
+  <sbb-form-field label="Sidebar positions">
+    <sbb-select [formControl]="position" placeholder="Position">
+      <sbb-option value="start">Start</sbb-option>
+      <sbb-option value="end">End</sbb-option>
+    </sbb-select>
+  </sbb-form-field>
+  <sbb-checkbox [formControl]="collapsible" [disabled]="simulateMobile.value"
+    >Make sidebar collapsible</sbb-checkbox
+  >
+  <sbb-checkbox [formControl]="simulateMobile">Simulate Mobile View</sbb-checkbox>
+
+  <sbb-form-field label="Label for collapsible header">
+    <input sbbInput [formControl]="collapsibleHeaderLabel" />
+  </sbb-form-field>
+</div>

--- a/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.html
+++ b/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.html
@@ -22,7 +22,7 @@
           role="navigation"
           [position]="position.value"
           [collapsible]="collapsible.value"
-          [collapsibleHeaderLabel]="collapsibleHeaderLabel.value"
+          [collapsibleTitle]="collapsibleTitle.value"
         >
           <sbb-expansion-panel expanded>
             <sbb-expansion-panel-header>Introduction</sbb-expansion-panel-header>
@@ -55,6 +55,6 @@
   <sbb-checkbox [formControl]="simulateMobile">Simulate Mobile View</sbb-checkbox>
 
   <sbb-form-field label="Label for collapsible header">
-    <input sbbInput [formControl]="collapsibleHeaderLabel" />
+    <input sbbInput [formControl]="collapsibleTitle" />
   </sbb-form-field>
 </div>

--- a/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.ts
+++ b/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.ts
@@ -50,7 +50,7 @@ export class CollapsibleSidebarExample implements AfterViewInit, OnDestroy {
   position = new FormControl<'start' | 'end'>('start', { nonNullable: true });
   collapsible = new FormControl(true);
   simulateMobile = new FormControl(false, { initialValueIsDefault: true });
-  collapsibleHeaderLabel = new FormControl('SBB Angular');
+  collapsibleTitle = new FormControl('SBB Angular');
   private _destroyed = new Subject<void>();
 
   constructor(private _mediaMatcher: FakeMediaMatcher) {}

--- a/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.ts
+++ b/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.ts
@@ -1,0 +1,68 @@
+import { BreakpointObserver, MediaMatcher } from '@angular/cdk/layout';
+import { AfterViewInit, Component, OnDestroy, ViewChild } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SbbExpansionPanel, SbbExpansionPanelHeader } from '@sbb-esta/angular/accordion';
+import { SbbButton } from '@sbb-esta/angular/button';
+import { SbbCheckboxModule } from '@sbb-esta/angular/checkbox';
+import { Breakpoints, SbbOptionModule } from '@sbb-esta/angular/core';
+import { FakeMediaMatcher } from '@sbb-esta/angular/core/testing';
+import { SbbFormField } from '@sbb-esta/angular/form-field';
+import { SbbIconModule } from '@sbb-esta/angular/icon';
+import { SbbInput } from '@sbb-esta/angular/input';
+import { SbbSelect } from '@sbb-esta/angular/select';
+import { SbbSidebarContainer, SbbSidebarModule } from '@sbb-esta/angular/sidebar';
+import { Subject } from 'rxjs';
+import { startWith, takeUntil } from 'rxjs/operators';
+
+/**
+ * @title Collapsible Sidebar
+ * @order 1
+ */
+@Component({
+  selector: 'sbb-collapsible-sidebar-example',
+  templateUrl: 'collapsible-sidebar-example.html',
+  styleUrls: ['collapsible-sidebar-example.css'],
+  providers: [
+    FakeMediaMatcher,
+    { provide: MediaMatcher, useExisting: FakeMediaMatcher },
+    BreakpointObserver,
+  ],
+  standalone: true,
+  imports: [
+    SbbSidebarModule,
+    SbbIconModule,
+    SbbCheckboxModule,
+    FormsModule,
+    ReactiveFormsModule,
+    SbbOptionModule,
+    SbbSelect,
+    SbbFormField,
+    SbbButton,
+    SbbExpansionPanel,
+    SbbExpansionPanelHeader,
+    SbbInput,
+  ],
+})
+export class CollapsibleSidebarExample implements AfterViewInit, OnDestroy {
+  @ViewChild(SbbSidebarContainer) sidebarContainer: SbbSidebarContainer;
+
+  mode = new FormControl<'over' | 'side'>('over', { nonNullable: true });
+  position = new FormControl<'start' | 'end'>('start', { nonNullable: true });
+  collapsible = new FormControl(true);
+  simulateMobile = new FormControl(false, { initialValueIsDefault: true });
+  collapsibleHeaderLabel = new FormControl('SBB Angular');
+  private _destroyed = new Subject<void>();
+
+  constructor(private _mediaMatcher: FakeMediaMatcher) {}
+
+  ngAfterViewInit(): void {
+    this.simulateMobile.valueChanges
+      .pipe(startWith(this.simulateMobile.value), takeUntil(this._destroyed))
+      .subscribe((matches) => this._mediaMatcher.setMatchesQuery(Breakpoints.Mobile, matches));
+  }
+
+  ngOnDestroy(): void {
+    this._destroyed.next();
+    this._destroyed.complete();
+  }
+}

--- a/src/components-examples/angular/sidebar/index.ts
+++ b/src/components-examples/angular/sidebar/index.ts
@@ -1,3 +1,4 @@
 export { MultipleSidebarsExample } from './multiple-sidebars/multiple-sidebars-example';
 export { IconSidebarExample } from './icon-sidebar/icon-sidebar-example';
 export { SidebarExample } from './sidebar/sidebar-example';
+export { CollapsibleSidebarExample } from './collapsible-sidebar/collapsible-sidebar-example';


### PR DESCRIPTION
This allows to make the `SbbSidebar` collapsible. If collapsible, the sidebar is displayed in `over` mode (above the content) and can be closed by clicking the close button. The `toggleSidebar()` method can be used to open or collapse the sidebar.

Closes #2263