### PR TITLE
fix(angular/datepicker): resolve repeater warnings in calendar

### DIFF
--- a/src/angular/datepicker/calendar-body/calendar-body.html
+++ b/src/angular/datepicker/calendar-body/calendar-body.html
@@ -1,5 +1,5 @@
 <!-- Create the first row separately so we can include a special spacer cell. -->
-@for (row of rows; track row; let rowIndex = $index) {
+@for (row of rows; track _trackRow(row); let rowIndex = $index) {
   <tr role="row">
     @if (weeksInMonth.length) {
       <td role="gridcell" [style.width.%]="100 / (numCols + 1)">
@@ -35,7 +35,7 @@
     cell is interactable, as well as the selection state via `aria-pressed`. See angular/components#23476 for
     background.
     -->
-    @for (item of row; track item; let colIndex = $index) {
+    @for (item of row; track item.id; let colIndex = $index) {
       <td
         role="gridcell"
         class="sbb-calendar-body-cell-container"

--- a/src/angular/datepicker/calendar-body/calendar-body.ts
+++ b/src/angular/datepicker/calendar-body/calendar-body.ts
@@ -20,11 +20,14 @@ export type SbbCalendarCellCssClasses = string | string[] | Set<string> | { [key
 /** Function that can generate the extra classes that should be added to a calendar cell. */
 export type SbbCalendarCellClassFunction<D> = (date: D) => SbbCalendarCellCssClasses;
 
+let uniqueIdCounter = 0;
+
 /**
  * An internal class that represents the data corresponding to a single calendar cell.
  * @docs-private
  */
 export class SbbCalendarCell {
+  readonly id = uniqueIdCounter++;
   constructor(
     public value: number,
     public displayValue: string,
@@ -107,6 +110,13 @@ export class SbbCalendarBody implements AfterViewChecked {
   @Output() readonly activeDateChange = new EventEmitter<number>();
 
   private _injector = inject(Injector);
+
+  /**
+   * Tracking function for rows based on their identity. Ideally we would use some sort of
+   * key on the row, but that would require a breaking change for the `rows` input. We don't
+   * use the built-in identity tracking, because it logs warnings.
+   */
+  _trackRow = (row: SbbCalendarCell[]) => row;
 
   constructor(
     private _elementRef: ElementRef<HTMLElement>,

--- a/src/angular/datepicker/month-view/month-view.html
+++ b/src/angular/datepicker/month-view/month-view.html
@@ -4,7 +4,7 @@
       @if (showWeekNumbers) {
         <th>#</th>
       }
-      @for (day of weekdays; track day) {
+      @for (day of weekdays; track day.index) {
         <th>
           @switch (isWeekdaySelectable) {
             @case (true) {


### PR DESCRIPTION
Fixes that the calendar was triggering some newly-introduced warnings from the framework.