### PR TITLE
fix(angular/chips): simplify repeat chip removal prevention

### DIFF
--- a/src/angular/chips/chip-list.spec.ts
+++ b/src/angular/chips/chip-list.spec.ts
@@ -1,7 +1,6 @@
 import { animate, style, transition, trigger } from '@angular/animations';
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import {
-  A,
   BACKSPACE,
   DELETE,
   DOWN_ARROW,
@@ -617,28 +616,15 @@ describe('SbbChipList', () => {
           expectLastItemFocused();
         });
 
-        it(
-          'should not focus the last chip when pressing BACKSPACE after changing input, ' +
-            'until BACKSPACE is released and pressed again',
-          () => {
-            // Change the input
-            dispatchKeyboardEvent(nativeInput, 'keydown', A);
-
-            // It shouldn't focus until backspace is released and pressed again
-            dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
-            dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
-            dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
-            expectNoItemFocused();
-
-            // Still not focused
-            dispatchKeyboardEvent(nativeInput, 'keyup', BACKSPACE);
-            expectNoItemFocused();
-
-            // Only now should it focus the last element
-            dispatchKeyboardEvent(nativeInput, 'keydown', BACKSPACE);
-            expectLastItemFocused();
-          },
-        );
+        it('should not focus the last chip when the BACKSPACE key is being repeated', () => {
+          // Only now should it focus the last element
+          const event = createKeyboardEvent('keydown', BACKSPACE);
+          Object.defineProperty(event, 'repeat', {
+            get: () => true,
+          });
+          dispatchEvent(nativeInput, event);
+          expectNoItemFocused();
+        });
 
         it('should focus last chip after pressing BACKSPACE after creating a chip', () => {
           // Create a chip

--- a/src/angular/chips/chip.ts
+++ b/src/angular/chips/chip.ts
@@ -267,14 +267,11 @@ export class SbbChip implements FocusableOption, OnDestroy {
       return;
     }
 
-    switch (event.keyCode) {
-      case DELETE:
-      case BACKSPACE:
-        // If we are removable, remove the focused chip
-        this.remove();
-        // Always prevent so page navigation does not occur
-        event.preventDefault();
-        break;
+    // Ignore backspace events where the user is holding down the key
+    // so that we don't accidentally remove too many chips.
+    if ((event.keyCode === BACKSPACE && !event.repeat) || event.keyCode === DELETE) {
+      event.preventDefault();
+      this.remove();
     }
   }
 


### PR DESCRIPTION
We have some logic that prevents chip removal if the users is holding down the backspace key. It currently breaks down in the case where a value is pasted into the input via click.

These changes simplify our detection by using `KeyboardEvent.repeat` which also resolves the paste issue.