### PR TITLE
fix: update schematics for v18

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,8 @@ This document describes how to create a new release of SBB Angular.
 - Check TODOs, @breaking-change annotations and @deprecated annotations.
 - Check angular components commits to be considered for next major release in the [sync issue](https://github.com/sbb-design-systems/sbb-angular/issues/1047).
 - Create new route for previous release (e.g. angular-v13.app.sbb.ch) and deploy corresponding version.
+- Update `src/angular/schematics/migration.json`. There must be a function in index.ts that matches the function referenced via "factory"
+  (e.g. if `"factory": "./ng-update/index#updateToV18"`, there must be a function called `updateToV18` in `index.ts`)
 - Github maintenance workflow
   - Create new maintenance branch (e.g. 14.x).
   - Edit TARGET_RELEASE in `.github/workflows/maintenance-tagging-workflow.yml`.

--- a/src/angular/schematics/migration.json
+++ b/src/angular/schematics/migration.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
   "schematics": {
-    "migration-v17": {
-      "version": "17.0.0-0",
-      "description": "Updates SBB Angular to v17",
-      "factory": "./ng-update/index#updateToV17"
+    "migration-v18": {
+      "version": "18.0.0-0",
+      "description": "Updates SBB Angular to v18",
+      "factory": "./ng-update/index#updateToV18"
     }
   }
 }

--- a/src/angular/schematics/ng-update/index.ts
+++ b/src/angular/schematics/ng-update/index.ts
@@ -1,14 +1,13 @@
 import { Rule, SchematicContext } from '@angular-devkit/schematics';
 import { createMigrationSchematicRule, TargetVersion } from '@angular/cdk/schematics';
 
-import { IconMigration } from './migrations/icon-names';
 import { sbbAngularUpgradeData } from './upgrade-data';
 
 /** Entry point for the migration schematics with target of Angular 18 */
 export function updateToV18(): Rule {
   return createMigrationSchematicRule(
     TargetVersion.V18,
-    [IconMigration],
+    [],
     sbbAngularUpgradeData,
     onMigrationComplete,
   );


### PR DESCRIPTION
Updating SBB-Angular to v18 using the recommended `ng update` did not work because the schematic function was not updated. This PR fixes the update schematics.