### PR TITLE
fix(angular/sidebar): not closing on escape key press

### DIFF
--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -182,7 +182,7 @@
         <source>Close Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">132</context>
         </context-group>
         <note priority="1" from="description">Button label to close the sidebar</note>
       </trans-unit>
@@ -190,7 +190,7 @@
         <source>Open Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">569</context>
+          <context context-type="linenumber">574</context>
         </context-group>
         <note priority="1" from="description">Button label to open the sidebar</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -194,7 +194,7 @@
     </unit>
     <unit id="sbbSidebarCloseSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:131</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:132</note>
         <note category="description">Button label to close the sidebar</note>
       </notes>
       <segment>
@@ -203,7 +203,7 @@
     </unit>
     <unit id="sbbSidebarOpenSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:569</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:574</note>
         <note category="description">Button label to open the sidebar</note>
       </notes>
       <segment>

--- a/src/angular/sidebar/sidebar/sidebar.ts
+++ b/src/angular/sidebar/sidebar/sidebar.ts
@@ -28,6 +28,7 @@ import {
   forwardRef,
   HostBinding,
   HostListener,
+  inject,
   Inject,
   Input,
   NgZone,
@@ -263,6 +264,8 @@ export class SbbSidebar
     ),
   );
 
+  private _changeDetectorRef = inject(ChangeDetectorRef);
+
   constructor(
     elementRef: ElementRef<HTMLElement>,
     private _focusTrapFactory: ConfigurableFocusTrapFactory,
@@ -484,6 +487,8 @@ export class SbbSidebar
       }
     }
 
+    // Needed to ensure that the closing sequence fires off correctly.
+    this._changeDetectorRef.markForCheck();
     this._updateFocusTrapState();
 
     return new Promise<SbbSidebarToggleResult>((resolve) => {


### PR DESCRIPTION
Fixes that the sidebar wasn't triggering change detection when closing via escape key press.