### PR TITLE
test: convert remaining tests to zoneless change detection

### DIFF
--- a/src/angular/breadcrumb/breadcrumbs.ts
+++ b/src/angular/breadcrumb/breadcrumbs.ts
@@ -3,8 +3,10 @@
 
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ContentChildren,
+  inject,
   QueryList,
   ViewEncapsulation,
 } from '@angular/core';
@@ -49,6 +51,8 @@ export class SbbBreadcrumbs {
   /** List of all user defined SbbBreadcrumb entries. */
   @ContentChildren(SbbBreadcrumb) levels: QueryList<SbbBreadcrumb>;
 
+  private readonly _changeDetectorRef = inject(ChangeDetectorRef);
+
   /** Whether the sbb-breadcrumbs are expanded or not in mobile view */
   get expanded(): boolean {
     if (this.levels.length > 1) {
@@ -61,5 +65,6 @@ export class SbbBreadcrumbs {
 
   expand() {
     this._expanded = true;
+    this._changeDetectorRef.markForCheck();
   }
 }

--- a/src/angular/chips/chip-list.spec.ts
+++ b/src/angular/chips/chip-list.spec.ts
@@ -98,11 +98,13 @@ describe('SbbChipList', () => {
         expect(chips.toArray().every((chip) => chip.disabled)).toBe(false);
 
         chipListInstance.disabled = true;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(chips.toArray().every((chip) => chip.disabled)).toBe(true);
 
         fixture.componentInstance.chips.push(5, 6);
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
         fixture.detectChanges();
@@ -114,6 +116,7 @@ describe('SbbChipList', () => {
         const chipArray = chips.toArray();
 
         chipArray[2].disabled = true;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(chips.toArray().map((chip) => chip.disabled)).toEqual([
@@ -125,6 +128,7 @@ describe('SbbChipList', () => {
         ]);
 
         chipListInstance.disabled = true;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(chips.toArray().map((chip) => chip.disabled)).toEqual([
@@ -136,6 +140,7 @@ describe('SbbChipList', () => {
         ]);
 
         chipListInstance.disabled = false;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(chips.toArray().map((chip) => chip.disabled)).toEqual([
@@ -807,6 +812,7 @@ describe('SbbChipList', () => {
 
       (testChipsAutocomplete!.selectedFruits!.value! as string[]).push('Pineapple');
 
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       await fixture.whenStable();
 

--- a/src/angular/chips/chip-list.ts
+++ b/src/angular/chips/chip-list.ts
@@ -623,6 +623,7 @@ export class SbbChipList
     if (this.chips) {
       this.chips.forEach((chip) => {
         chip._chipListDisabled = this._disabled;
+        chip._changeDetectorRef.markForCheck();
       });
     }
   }

--- a/src/angular/chips/chip-remove.spec.ts
+++ b/src/angular/chips/chip-remove.spec.ts
@@ -60,6 +60,7 @@ describe('Chip Remove', () => {
       const buttonElement = chipNativeElement.querySelector('button')!;
 
       testChip.removable = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       spyOn(testChip, 'didRemove');
@@ -75,6 +76,7 @@ describe('Chip Remove', () => {
 
       testChip.disabled = true;
       testChip.removable = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       spyOn(testChip, 'didRemove');
@@ -119,6 +121,7 @@ describe('Chip Remove', () => {
 
     it('should hide fallback icon because it is not removable', () => {
       testChip.removable = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       const iconElement = chipNativeElement.querySelector('sbb-icon')!;
 

--- a/src/angular/chips/chip.ts
+++ b/src/angular/chips/chip.ts
@@ -170,7 +170,7 @@ export class SbbChip implements FocusableOption, OnDestroy {
     public _elementRef: ElementRef<HTMLElement>,
     private _ngZone: NgZone,
     @Optional()
-    private _changeDetectorRef: ChangeDetectorRef,
+    public _changeDetectorRef: ChangeDetectorRef,
     @Optional() @Host() @Inject(SBB_CHIP_LIST) private _chipList?: TypeRef<SbbChipList>,
     @Optional() @Inject(ANIMATION_MODULE_TYPE) animationMode?: string,
     @Attribute('tabindex') tabIndex?: string,

--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -14,7 +14,7 @@
         <source>Show entire path</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/breadcrumb/breadcrumbs.ts</context>
-          <context context-type="linenumber">47</context>
+          <context context-type="linenumber">49</context>
         </context-group>
         <note priority="1" from="description">Button with three dots to show all breadcrumb levels</note>
       </trans-unit>

--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -182,7 +182,7 @@
         <source>Close Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">132</context>
+          <context context-type="linenumber">134</context>
         </context-group>
         <note priority="1" from="description">Button label to close the sidebar</note>
       </trans-unit>
@@ -190,7 +190,7 @@
         <source>Open Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">574</context>
+          <context context-type="linenumber">581</context>
         </context-group>
         <note priority="1" from="description">Button label to open the sidebar</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -194,7 +194,7 @@
     </unit>
     <unit id="sbbSidebarCloseSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:132</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:134</note>
         <note category="description">Button label to close the sidebar</note>
       </notes>
       <segment>
@@ -203,7 +203,7 @@
     </unit>
     <unit id="sbbSidebarOpenSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:574</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:581</note>
         <note category="description">Button label to open the sidebar</note>
       </notes>
       <segment>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -12,7 +12,7 @@
     </unit>
     <unit id="sbbBreadcrumbExpand">
       <notes>
-        <note category="location">../../../../../../src/angular/breadcrumb/breadcrumbs.ts:47</note>
+        <note category="location">../../../../../../src/angular/breadcrumb/breadcrumbs.ts:49</note>
         <note category="description">Button with three dots to show all breadcrumb levels</note>
       </notes>
       <segment>

--- a/src/angular/radio-button-panel/radio-button-panel.spec.ts
+++ b/src/angular/radio-button-panel/radio-button-panel.spec.ts
@@ -119,6 +119,7 @@ describe('SbbRadioButtonPanel', () => {
       const [opt1, opt2] = component.optionSelections.toArray();
 
       component.testValue = '1';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       await fixture.whenStable();

--- a/src/angular/radio-button/radio-button.spec.ts
+++ b/src/angular/radio-button/radio-button.spec.ts
@@ -258,6 +258,7 @@ describe('RadioButton', () => {
 
     it('should coerce the disabled binding on the radio group', () => {
       (testComponent as any).isGroupDisabled = '';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       radioLabelElements[0].click();
@@ -269,6 +270,7 @@ describe('RadioButton', () => {
 
     it('should disable click interaction when the group is disabled', () => {
       testComponent.isGroupDisabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       radioLabelElements[0].click();
@@ -279,6 +281,7 @@ describe('RadioButton', () => {
 
     it('should disable each individual radio when the group is disabled', () => {
       testComponent.isGroupDisabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       for (const radio of radioInstances) {
@@ -288,6 +291,7 @@ describe('RadioButton', () => {
 
     it('should set required to each radio button when the group is required', () => {
       testComponent.isGroupRequired = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       for (const radio of radioInstances) {
@@ -378,6 +382,7 @@ describe('RadioButton', () => {
       expect(groupInstance.value).toBeFalsy();
 
       testComponent.groupValue = 'fire';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(groupInstance.value).toBe('fire');
@@ -386,6 +391,7 @@ describe('RadioButton', () => {
       expect(radioInstances[1].checked).toBe(false);
 
       testComponent.groupValue = 'water';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(groupInstance.value).toBe('water');
@@ -525,6 +531,7 @@ describe('RadioButton', () => {
       expect(groupInstance.value).toBe('fire');
 
       fixture.componentInstance.isFirstShown = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(groupInstance.selected).toBe(null);
@@ -583,6 +590,7 @@ describe('RadioButton', () => {
         .toBe(true);
 
       fixture.componentInstance.groupName = 'changed-name';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(groupInstance.name).toBe('changed-name');
@@ -639,6 +647,7 @@ describe('RadioButton', () => {
 
     it('should write to the radio button based on ngModel', fakeAsync(() => {
       testComponent.modelValue = 'chocolate';
+      fixture.changeDetectorRef.markForCheck();
 
       fixture.detectChanges();
       tick();
@@ -818,6 +827,7 @@ describe('RadioButton', () => {
       expect(fruitRadioNativeInputs[0].getAttribute('aria-label')).toBe('Banana');
 
       testComponent.ariaLabel = 'Pineapple';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fruitRadioNativeInputs[0].getAttribute('aria-label')).toBe('Pineapple');
@@ -835,6 +845,7 @@ describe('RadioButton', () => {
       expect(fruitRadioNativeInputs[0].getAttribute('aria-labelledby')).toBe('xyz');
 
       testComponent.ariaLabelledby = 'uvw';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fruitRadioNativeInputs[0].getAttribute('aria-labelledby')).toBe('uvw');
@@ -852,6 +863,7 @@ describe('RadioButton', () => {
       expect(fruitRadioNativeInputs[0].getAttribute('aria-describedby')).toBe('abc');
 
       testComponent.ariaDescribedby = 'uvw';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fruitRadioNativeInputs[0].getAttribute('aria-describedby')).toBe('uvw');
@@ -902,6 +914,7 @@ describe('RadioButton', () => {
         .toBe(0);
 
       fixture.componentInstance.tabIndex = 4;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(radioButtonInput.tabIndex)

--- a/src/angular/select/select.spec.ts
+++ b/src/angular/select/select.spec.ts
@@ -2701,6 +2701,7 @@ describe('SbbSelect', () => {
         expect(select.textContent!.trim()).toBe('Pizza');
 
         fixture.componentInstance.foods[1].viewValue = 'Calzone';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         // tslint:disable-next-line:no-non-null-assertion
@@ -2714,6 +2715,7 @@ describe('SbbSelect', () => {
         expect(select.textContent!.trim()).toBe('Pizza');
 
         fixture.componentInstance.capitalize = true;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         fixture.checkNoChanges();
 
@@ -3130,7 +3132,7 @@ describe('SbbSelect', () => {
           .toBe(true);
       }));
 
-      fit(
+      it(
         'should keep the disabled state in sync if the form group is swapped and ' +
           'disabled at the same time',
         fakeAsync(() => {
@@ -3419,6 +3421,7 @@ describe('SbbSelect', () => {
       fixture.detectChanges();
 
       fixture.componentInstance.isDisabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       flush();
 
@@ -3439,6 +3442,7 @@ describe('SbbSelect', () => {
         .toBe(false);
 
       fixture.componentInstance.isDisabled = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       flush();
 
@@ -3632,6 +3636,7 @@ describe('SbbSelect', () => {
 
       // The first change detection run will throw the "ngModel is missing a name" error.
       expect(() => fixture.detectChanges()).toThrowError(/the name attribute must be set/g);
+      fixture.changeDetectorRef.markForCheck();
 
       // The second run shouldn't throw selection-model related errors.
       expect(() => fixture.detectChanges()).not.toThrow();
@@ -3912,6 +3917,7 @@ describe('SbbSelect', () => {
       expect(component.select.errorState).toBe(false);
 
       fixture.componentInstance.errorStateMatcher = { isErrorState: matcher };
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       fixture.detectChanges();
 
@@ -4190,6 +4196,7 @@ describe('SbbSelect', () => {
 
       fixture.detectChanges();
       fixture.componentInstance.selectedFood = 'sandwich-2';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const select = fixture.debugElement.query(By.css('sbb-select'))!.nativeElement;
@@ -4226,6 +4233,7 @@ describe('SbbSelect', () => {
       expect(select.textContent).toContain('Steak');
 
       fixture.componentInstance.selectedFood = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       flush();
 
@@ -4430,6 +4438,7 @@ describe('SbbSelect', () => {
 
       instance.selectedFood = 'sandwich-2';
       instance.foods[0].value = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const subscription = instance.select.selectionChange.subscribe(spy);

--- a/src/angular/sidebar/icon-sidebar/icon-sidebar.spec.ts
+++ b/src/angular/sidebar/icon-sidebar/icon-sidebar.spec.ts
@@ -136,16 +136,11 @@ describe('SbbIconSidebar', () => {
     });
 
     it('should throw when multiple sidebars are included', fakeAsync(() => {
-      const fixture = TestBed.createComponent(TwoSidebarsTestComponent);
-
       expect(() => {
-        try {
-          fixture.detectChanges();
-          tick(0);
-        } catch {
-          tick(0);
-        }
-      }).toThrow();
+        const fixture = TestBed.createComponent(TwoSidebarsTestComponent);
+        fixture.detectChanges();
+        tick(0);
+      }).toThrowError(/A sidebar was already declared/);
     }));
 
     it('should bind 2-way bind on expanded property', fakeAsync(() => {

--- a/src/angular/sidebar/icon-sidebar/icon-sidebar.spec.ts
+++ b/src/angular/sidebar/icon-sidebar/icon-sidebar.spec.ts
@@ -68,6 +68,7 @@ describe('SbbIconSidebar', () => {
       expect(fixture.componentInstance.sidebar.expanded).toBe(false);
 
       fixture.componentInstance.sidebar.expanded = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
@@ -84,6 +85,7 @@ describe('SbbIconSidebar', () => {
       expect(instance.innerSidebar.expanded).toBe(false);
 
       instance.outerSidebar.expanded = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
@@ -92,6 +94,7 @@ describe('SbbIconSidebar', () => {
       expect(instance.innerSidebar.expanded).toBe(false);
 
       instance.innerSidebar.expanded = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
@@ -378,6 +381,7 @@ describe('SbbIconSidebar', () => {
         .toBeGreaterThan(contentTop);
 
       fixture.componentInstance.position = 'end';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       sidebarTop = fixture.nativeElement.querySelector('.sbb-icon-sidebar').offsetTop;

--- a/src/angular/sidebar/sidebar/sidebar.spec.ts
+++ b/src/angular/sidebar/sidebar/sidebar.spec.ts
@@ -304,6 +304,7 @@ describe('SbbSidebar', () => {
       sidebar.open();
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
 
       const backdrop = fixture.nativeElement.querySelector('.sbb-sidebar-backdrop');
       expect(backdrop).toBeTruthy();
@@ -338,6 +339,7 @@ describe('SbbSidebar', () => {
       sidebar.open();
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
       sidebarButton.focus();
 
       sidebar.close();
@@ -363,6 +365,7 @@ describe('SbbSidebar', () => {
       sidebar.open();
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
       sidebarButton.focus();
 
       sidebar.close();
@@ -392,6 +395,7 @@ describe('SbbSidebar', () => {
 
       fixture.detectChanges();
       tick();
+      fixture.detectChanges();
       closeButton.focus();
 
       sidebar.close();
@@ -525,6 +529,7 @@ describe('SbbSidebar', () => {
       sidebar.open();
       fixture.detectChanges();
       tick();
+      fixture.detectChanges();
 
       const mobileCloseSidebarButton = fixture.debugElement.query(
         By.css('.sbb-sidebar-menu-bar-close'),
@@ -562,6 +567,7 @@ describe('SbbSidebar', () => {
       sidebarEl.componentInstance.open();
       nonFocusableFixture.detectChanges();
       tick();
+      nonFocusableFixture.detectChanges();
 
       expect(document.activeElement).toBe(
         nonFocusableFixture.debugElement.query(By.css('.sbb-sidebar-menu-bar-close'))!
@@ -608,6 +614,7 @@ describe('SbbSidebar', () => {
     it('should project start sidebar before the content', () => {
       const fixture = TestBed.createComponent(BasicTestComponent);
       fixture.componentInstance.position = 'start';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const allNodes = getSidebarNodesArray(fixture);
@@ -630,6 +637,7 @@ describe('SbbSidebar', () => {
     it('should project end sidebar after the content', () => {
       const fixture = TestBed.createComponent(BasicTestComponent);
       fixture.componentInstance.position = 'end';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const allNodes = getSidebarNodesArray(fixture);
@@ -652,6 +660,7 @@ describe('SbbSidebar', () => {
     it('should move the sidebar before/after the content when its position changes after being initialized at `start`', () => {
       const fixture = TestBed.createComponent(BasicTestComponent);
       fixture.componentInstance.position = 'start';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const sidebar = fixture.nativeElement.querySelector('.sbb-sidebar');
@@ -672,6 +681,7 @@ describe('SbbSidebar', () => {
         .toBeLessThan(startContentIndex);
 
       fixture.componentInstance.position = 'end';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       allNodes = getSidebarNodesArray(fixture);
 
@@ -680,6 +690,7 @@ describe('SbbSidebar', () => {
         .toBeGreaterThan(allNodes.indexOf(content));
 
       fixture.componentInstance.position = 'start';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       allNodes = getSidebarNodesArray(fixture);
 
@@ -694,6 +705,7 @@ describe('SbbSidebar', () => {
       () => {
         const fixture = TestBed.createComponent(BasicTestComponent);
         fixture.componentInstance.position = 'end';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         const sidebar = fixture.nativeElement.querySelector('.sbb-sidebar');
@@ -717,6 +729,7 @@ describe('SbbSidebar', () => {
         );
 
         fixture.componentInstance.position = 'start';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         allNodes = getSidebarNodesArray(fixture);
 
@@ -726,6 +739,7 @@ describe('SbbSidebar', () => {
         );
 
         fixture.componentInstance.position = 'end';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         allNodes = getSidebarNodesArray(fixture);
 
@@ -747,6 +761,7 @@ describe('SbbSidebar', () => {
       expect(icon.componentInstance.svgIcon).toBe('hamburger-menu-small');
 
       fixture.componentInstance.position = 'end';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       icon = fixture.debugElement.query(By.directive(SbbIcon));
       expect(icon.componentInstance.svgIcon).toBe('controls-small');
@@ -765,6 +780,7 @@ describe('SbbSidebar', () => {
       expect(icon.componentInstance.svgIcon).toBe('bell-small');
 
       fixture.componentInstance.position = 'end';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       icon = fixture.debugElement.query(By.directive(SbbIcon));
       expect(icon.componentInstance.svgIcon).toBe('bell-small');
@@ -808,16 +824,19 @@ describe('SbbSidebar', () => {
       expect(collapsibleTitle).toBeFalsy();
 
       fixture.componentInstance.collapsible = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       collapsibleTitle = fixture.debugElement.query(By.css('.sbb-sidebar-menu-bar-title'));
       expect(collapsibleTitle.nativeElement.textContent).toBe('');
 
       fixture.componentInstance.collapsibleTitle = 'Test header label';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(collapsibleTitle).toBeTruthy();
       expect(collapsibleTitle.nativeElement.textContent).toBe('Test header label');
 
       fixture.componentInstance.collapsibleTitle = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(collapsibleTitle.nativeElement.textContent).toBe('');
     });
@@ -872,6 +891,7 @@ describe('SbbSidebarContainer', () => {
     expect(parseInt(contentElement.style.marginLeft, 10)).toBeFalsy();
 
     fixture.componentInstance.showSidebar = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     fixture.componentInstance.sidebar.open();
@@ -897,6 +917,7 @@ describe('SbbSidebarContainer', () => {
     expect(initialMargin).toBeGreaterThan(0);
 
     fixture.componentInstance.renderSidebar = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     tick();
 
@@ -1071,6 +1092,7 @@ describe('SbbSidebar Usage', () => {
 
     mobileCloseSidebarButton.click();
 
+    flush();
     expect(sidebar.componentInstance.opened).toBe(false);
   }));
 });

--- a/src/angular/sidebar/sidebar/sidebar.spec.ts
+++ b/src/angular/sidebar/sidebar/sidebar.spec.ts
@@ -462,13 +462,9 @@ describe('SbbSidebar', () => {
       const fixture = TestBed.createComponent(TwoSidebarsTestComponent);
 
       expect(() => {
-        try {
-          fixture.detectChanges();
-          tick(0);
-        } catch {
-          tick(0);
-        }
-      }).toThrow();
+        fixture.detectChanges();
+        tick();
+      }).toThrowError(/A sidebar was already declared/);
     }));
 
     it('should not throw when a two-way binding is toggled quickly while animating', fakeAsync(() => {

--- a/src/angular/table/sort/sort.spec.ts
+++ b/src/angular/table/sort/sort.spec.ts
@@ -188,6 +188,7 @@ describe('SbbSort', () => {
       it('should be correct when sort has been disabled', () => {
         // Mousing over the first sort should set the view state to hint
         component.disabledColumnSort = true;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         component.dispatchMouseEvent('defaultA', 'mouseenter');
@@ -197,6 +198,7 @@ describe('SbbSort', () => {
       it('should be correct when sorting programmatically', () => {
         component.active = 'defaultB';
         component.direction = 'asc';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expectedStates.set('defaultB', {
@@ -211,20 +213,24 @@ describe('SbbSort', () => {
       component.disableClear = true;
 
       component.start = 'asc';
+      fixture.changeDetectorRef.markForCheck();
       testSingleColumnSortDirectionSequence(fixture, ['asc', 'desc']);
 
       // Reverse directions
       component.start = 'desc';
+      fixture.changeDetectorRef.markForCheck();
       testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc']);
     });
 
     it('should be able to cycle asc -> desc -> [none]', () => {
       component.start = 'asc';
+      fixture.changeDetectorRef.markForCheck();
       testSingleColumnSortDirectionSequence(fixture, ['asc', 'desc', '']);
     });
 
     it('should be able to cycle desc -> asc -> [none]', () => {
       component.start = 'desc';
+      fixture.changeDetectorRef.markForCheck();
       testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc', '']);
     });
 
@@ -426,6 +432,7 @@ describe('SbbSort', () => {
       expect(descriptionElement?.textContent).toBe('Sort second column');
 
       fixture.componentInstance.secondColumnDescription = 'Sort 2nd column';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       descriptionId = sortButton.getAttribute('aria-describedby');
       descriptionElement = document.getElementById(descriptionId);
@@ -471,6 +478,7 @@ describe('SbbSort', () => {
       const sbbSortWithArrowPositionComponent = sbbSortWithArrowPositionFixture.componentInstance;
 
       sbbSortWithArrowPositionFixture.detectChanges();
+      sbbSortWithArrowPositionFixture.changeDetectorRef.markForCheck();
 
       const containerA = sbbSortWithArrowPositionFixture.nativeElement.querySelector(
         '#defaultA .sbb-sort-header-container',
@@ -485,6 +493,7 @@ describe('SbbSort', () => {
       sbbSortWithArrowPositionComponent.arrowPosition = 'before';
 
       sbbSortWithArrowPositionFixture.detectChanges();
+      fixture.changeDetectorRef.markForCheck();
 
       expect(containerA.classList.contains('sbb-sort-header-position-before')).toBe(true);
       expect(containerB.classList.contains('sbb-sort-header-position-before')).toBe(true);
@@ -517,10 +526,12 @@ describe('SbbSort', () => {
 
     it('should be able to cycle from asc -> desc from either start point', () => {
       component.start = 'asc';
+      fixture.changeDetectorRef.markForCheck();
       testSingleColumnSortDirectionSequence(fixture, ['asc', 'desc']);
 
       // Reverse directions
       component.start = 'desc';
+      fixture.changeDetectorRef.markForCheck();
       testSingleColumnSortDirectionSequence(fixture, ['desc', 'asc']);
     });
   });

--- a/src/angular/table/table.spec.ts
+++ b/src/angular/table/table.spec.ts
@@ -604,6 +604,7 @@ describe('SbbTable', () => {
 
     // When scrolling to a middle position
     tableWrapper.nativeElement.scrollLeft = 1;
+    fixture.changeDetectorRef.markForCheck();
     tableWrapper.nativeElement.dispatchEvent(new CustomEvent('scroll'));
 
     // Then it should have offset right and left

--- a/src/angular/tabs/tab-body.spec.ts
+++ b/src/angular/tabs/tab-body.spec.ts
@@ -2,8 +2,10 @@ import { Direction, Directionality } from '@angular/cdk/bidi';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { CdkScrollable, ScrollingModule } from '@angular/cdk/scrolling';
 import {
-  AfterContentInit,
+  AfterViewInit,
   Component,
+  inject,
+  signal,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -38,6 +40,7 @@ describe('SbbTabBody', () => {
     it('should be show position if origin is unchanged', () => {
       fixture = TestBed.createComponent(SimpleTabBodyApp);
       fixture.componentInstance.position = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.componentInstance.tabBody._position).toBe('show');
@@ -51,6 +54,7 @@ describe('SbbTabBody', () => {
       // binding. This test should ensure that the body does properly such origin value.
       // The `SbbTab` class sets the origin by default to null. See related issue: #12455
       fixture.componentInstance.origin = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.componentInstance.tabBody._position).toBe('show');
@@ -64,6 +68,7 @@ describe('SbbTabBody', () => {
       it('should be show position with negative or zero origin', () => {
         fixture.componentInstance.position = 0;
         fixture.componentInstance.origin = 0;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(fixture.componentInstance.tabBody._position).toBe('show');
@@ -72,6 +77,7 @@ describe('SbbTabBody', () => {
       it('should be show position with positive nonzero origin', () => {
         fixture.componentInstance.position = 0;
         fixture.componentInstance.origin = 1;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(fixture.componentInstance.tabBody._position).toBe('show');
@@ -87,6 +93,7 @@ describe('SbbTabBody', () => {
       it('should be show position with negative or zero origin', () => {
         fixture.componentInstance.position = 0;
         fixture.componentInstance.origin = 0;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(fixture.componentInstance.tabBody._position).toBe('show');
@@ -95,6 +102,7 @@ describe('SbbTabBody', () => {
       it('should be show position with positive nonzero origin', () => {
         fixture.componentInstance.position = 0;
         fixture.componentInstance.origin = 1;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(fixture.componentInstance.tabBody._position).toBe('show');
@@ -113,6 +121,7 @@ describe('SbbTabBody', () => {
 
     it('to be hidden position with negative position', () => {
       fixture.componentInstance.position = -1;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.componentInstance.tabBody._position).toBe('hidden');
@@ -120,6 +129,7 @@ describe('SbbTabBody', () => {
 
     it('to be show position with zero position', () => {
       fixture.componentInstance.position = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.componentInstance.tabBody._position).toBe('show');
@@ -127,6 +137,7 @@ describe('SbbTabBody', () => {
 
     it('to be hidden position with positive position', () => {
       fixture.componentInstance.position = 1;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.componentInstance.tabBody._position).toBe('hidden');
@@ -152,22 +163,22 @@ describe('SbbTabBody', () => {
 @Component({
   template: `
     <ng-template>Tab Body Content</ng-template>
-    <sbb-tab-body [content]="content" [position]="position" [origin]="origin"></sbb-tab-body>
+    <sbb-tab-body [content]="content()" [position]="position" [origin]="origin"></sbb-tab-body>
   `,
   standalone: true,
   imports: [SbbTabBody],
 })
-class SimpleTabBodyApp implements AfterContentInit {
-  content: TemplatePortal;
+class SimpleTabBodyApp implements AfterViewInit {
+  content = signal<TemplatePortal | undefined>(undefined);
   position: number;
   origin: number | null;
 
   @ViewChild(SbbTabBody) tabBody: SbbTabBody;
   @ViewChild(TemplateRef) template: TemplateRef<any>;
 
-  constructor(private _viewContainerRef: ViewContainerRef) {}
+  private readonly _viewContainerRef = inject(ViewContainerRef);
 
-  ngAfterContentInit() {
-    this.content = new TemplatePortal(this.template, this._viewContainerRef);
+  ngAfterViewInit() {
+    this.content.set(new TemplatePortal(this.template, this._viewContainerRef));
   }
 }

--- a/src/angular/tabs/tab-body.ts
+++ b/src/angular/tabs/tab-body.ts
@@ -59,7 +59,7 @@ export class SbbTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestr
     this._centeringSub = this._host._beforeCentering
       .pipe(startWith(this._host._isCenterPosition(this._host._position)))
       .subscribe((isCentering: boolean) => {
-        if (isCentering && !this.hasAttached()) {
+        if (this._host._content && isCentering && !this.hasAttached()) {
           this.attach(this._host._content);
         }
       });

--- a/src/angular/tabs/tab-group.spec.ts
+++ b/src/angular/tabs/tab-group.spec.ts
@@ -106,6 +106,7 @@ describe('SbbTabGroup', () => {
       checkSelectedIndex(1, fixture);
 
       tabComponent.selectedIndex = 2;
+      fixture.changeDetectorRef.markForCheck();
 
       checkSelectedIndex(2, fixture);
       tick();
@@ -127,6 +128,7 @@ describe('SbbTabGroup', () => {
 
       // Move to third tab
       component.selectedIndex = 2;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(tabs[0].position).toBeLessThan(0);
       expect(tabs[1].position).toBeLessThan(0);
@@ -134,6 +136,7 @@ describe('SbbTabGroup', () => {
 
       // Move to the first tab
       component.selectedIndex = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(tabs[0].position).toBe(0);
       expect(tabs[1].position).toBeGreaterThan(0);
@@ -148,11 +151,13 @@ describe('SbbTabGroup', () => {
 
       // Set the index to be negative, expect first tab selected
       fixture.componentInstance.selectedIndex = -1;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(component.selectedIndex).toBe(0);
 
       // Set the index beyond the size of the tabs, expect last tab selected
       fixture.componentInstance.selectedIndex = 3;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(component.selectedIndex).toBe(2);
     });
@@ -162,6 +167,7 @@ describe('SbbTabGroup', () => {
 
       expect(() => {
         component.selectedIndex = NaN;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
       }).not.toThrow();
     });
@@ -177,6 +183,7 @@ describe('SbbTabGroup', () => {
       expect(tabs[2].isActive).toBe(false);
 
       fixture.componentInstance.selectedIndex = 2;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -350,12 +357,14 @@ describe('SbbTabGroup', () => {
     it('should not be able to set both an aria-label and aria-labelledby', () => {
       fixture.componentInstance.ariaLabel = 'Fruit';
       fixture.componentInstance.ariaLabelledby = 'fruit-label';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(tab.getAttribute('aria-label')).toBe('Fruit');
       expect(tab.hasAttribute('aria-labelledby')).toBe(false);
 
       fixture.componentInstance.ariaLabel = 'Veggie';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(tab.getAttribute('aria-label')).toBe('Veggie');
     });
@@ -404,6 +413,7 @@ describe('SbbTabGroup', () => {
       expect(labels[0].nativeElement.getAttribute('aria-disabled')).toBe('true');
 
       fixture.componentInstance.isDisabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(tabs[2].disabled).toBe(true);
@@ -438,6 +448,7 @@ describe('SbbTabGroup', () => {
       // Add a new tab on the right and select it, expect an origin >= than 0 (animate right)
       fixture.componentInstance.tabs.push({ label: 'New tab', content: 'to right of index' });
       fixture.componentInstance.selectedIndex = 4;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -446,6 +457,7 @@ describe('SbbTabGroup', () => {
 
       // Add a new tab in the beginning and select it, expect an origin < than 0 (animate left)
       fixture.componentInstance.selectedIndex = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -464,6 +476,7 @@ describe('SbbTabGroup', () => {
 
       const numberOfTabs = component._tabs.length;
       fixture.componentInstance.selectedIndex = numberOfTabs - 1;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -482,10 +495,12 @@ describe('SbbTabGroup', () => {
       )!.componentInstance;
 
       fixture.componentInstance.selectedIndex = 1;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Add a new tab at the beginning.
       fixture.componentInstance.tabs.unshift({ label: 'New tab', content: 'at the start' });
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(component.selectedIndex).toBe(2);
@@ -495,6 +510,7 @@ describe('SbbTabGroup', () => {
     it('should maintain the selected tab if a tab is removed', () => {
       // Select the second tab.
       fixture.componentInstance.selectedIndex = 1;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const component: SbbTabGroup = fixture.debugElement.query(
@@ -503,6 +519,7 @@ describe('SbbTabGroup', () => {
 
       // Remove the first tab that is right before the selected one.
       fixture.componentInstance.tabs.splice(0, 1);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Since the first tab has been removed and the second one was selected before, the selected
@@ -518,6 +535,7 @@ describe('SbbTabGroup', () => {
       )!.componentInstance;
 
       fixture.componentInstance.tabs.push({ label: 'Last tab', content: 'at the end' });
+      fixture.changeDetectorRef.markForCheck();
       fixture.componentInstance.selectedIndex = 3;
 
       fixture.detectChanges();
@@ -530,11 +548,13 @@ describe('SbbTabGroup', () => {
     it('should not fire `selectedTabChange` when the amount of tabs changes', fakeAsync(() => {
       fixture.detectChanges();
       fixture.componentInstance.selectedIndex = 1;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Add a new tab at the beginning.
       spyOn(fixture.componentInstance, 'handleSelection');
       fixture.componentInstance.tabs.unshift({ label: 'New tab', content: 'at the start' });
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       fixture.detectChanges();
@@ -553,6 +573,7 @@ describe('SbbTabGroup', () => {
         label: 'New',
         content: 'New',
       };
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -598,6 +619,7 @@ describe('SbbTabGroup', () => {
       expect(getSelectedContent(fixture).textContent).toMatch('Pizza, fries');
 
       tabGroup.selectedIndex = 2;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -621,6 +643,7 @@ describe('SbbTabGroup', () => {
       expect(fixture.nativeElement.textContent).not.toContain('Peanuts');
 
       tabGroup.selectedIndex = 3;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -636,6 +659,7 @@ describe('SbbTabGroup', () => {
       expect(fixture.nativeElement.textContent).not.toContain('Peanuts');
 
       tabGroup.selectedIndex = 3;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -656,6 +680,7 @@ describe('SbbTabGroup', () => {
       ]);
 
       tabGroup.selectedIndex = 2;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -667,6 +692,7 @@ describe('SbbTabGroup', () => {
       ]);
 
       tabGroup.selectedIndex = 1;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -820,6 +846,7 @@ describe('SbbTabGroup', () => {
 
       fixture.componentInstance.labelClassList = 'custom-label-class';
       fixture.componentInstance.bodyClassList = 'custom-body-class';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(labelElements[0].nativeElement.classList).toContain('custom-label-class');
@@ -827,6 +854,7 @@ describe('SbbTabGroup', () => {
 
       delete fixture.componentInstance.labelClassList;
       delete fixture.componentInstance.bodyClassList;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(labelElements[0].nativeElement.classList).not.toContain('custom-label-class');
@@ -839,6 +867,7 @@ describe('SbbTabGroup', () => {
 
       fixture.componentInstance.labelClassList = ['custom-label-class'];
       fixture.componentInstance.bodyClassList = ['custom-body-class'];
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(labelElements[0].nativeElement.classList).toContain('custom-label-class');
@@ -846,6 +875,7 @@ describe('SbbTabGroup', () => {
 
       delete fixture.componentInstance.labelClassList;
       delete fixture.componentInstance.bodyClassList;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(labelElements[0].nativeElement.classList).not.toContain('custom-label-class');

--- a/src/angular/tabs/tab-group.spec.ts
+++ b/src/angular/tabs/tab-group.spec.ts
@@ -81,14 +81,17 @@ describe('SbbTabGroup', () => {
     it('should set to correct tab on fast change', waitForAsync(() => {
       const component = fixture.componentInstance;
       component.selectedIndex = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       setTimeout(() => {
         component.selectedIndex = 1;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         setTimeout(() => {
           component.selectedIndex = 0;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           fixture.whenStable().then(() => {
             expect(component.selectedIndex).toBe(0);

--- a/src/angular/tabs/tab-header.spec.ts
+++ b/src/angular/tabs/tab-header.spec.ts
@@ -2,7 +2,7 @@ import { Direction } from '@angular/cdk/bidi';
 import { END, ENTER, HOME, LEFT_ARROW, RIGHT_ARROW, SPACE } from '@angular/cdk/keycodes';
 import { MutationObserverFactory } from '@angular/cdk/observers';
 import { ScrollingModule, ViewportRuler } from '@angular/cdk/scrolling';
-import { Component, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, inject, ViewChild } from '@angular/core';
 import {
   ComponentFixture,
   discardPeriodicTasks,
@@ -169,6 +169,7 @@ describe('SbbTabHeader', () => {
     it('should skip disabled items when moving focus using HOME', () => {
       appComponent.tabHeader.focusIndex = 3;
       appComponent.tabs[0].disabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(3);
 
@@ -194,6 +195,7 @@ describe('SbbTabHeader', () => {
     it('should skip disabled items when moving focus using END', () => {
       appComponent.tabHeader.focusIndex = 0;
       appComponent.tabs[3].disabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(appComponent.tabHeader.focusIndex).toBe(0);
 
@@ -256,6 +258,7 @@ describe('SbbTabHeader', () => {
 
         // Focus on the last tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = appComponent.tabs.length - 1;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         expect(appComponent.tabHeader.scrollDistance).toBe(
           appComponent.tabHeader._getMaxScrollDistance(),
@@ -263,6 +266,7 @@ describe('SbbTabHeader', () => {
 
         // Focus on the first tab, expect this to be the maximum scroll distance.
         appComponent.tabHeader.focusIndex = 0;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         expect(appComponent.tabHeader.scrollDistance).toBe(0);
       });
@@ -646,6 +650,8 @@ class SimpleTabHeaderApp {
 
   @ViewChild(SbbTabHeader, { static: true }) tabHeader: SbbTabHeader;
 
+  private readonly _changeDetectorRef = inject(ChangeDetectorRef);
+
   constructor() {
     this.tabs[this.disabledTabIndex].disabled = true;
   }
@@ -654,5 +660,7 @@ class SimpleTabHeaderApp {
     for (let i = 0; i < amount; i++) {
       this.tabs.push({ label: 'new' });
     }
+
+    this._changeDetectorRef.markForCheck();
   }
 }

--- a/src/angular/tabs/tab-nav-bar.spec.ts
+++ b/src/angular/tabs/tab-nav-bar.spec.ts
@@ -90,6 +90,7 @@ describe('SbbTabNavBar', () => {
         .toBe(true);
 
       fixture.componentInstance.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(tabLinkElements.every((tabLink) => tabLink.getAttribute('aria-disabled') === 'true'))
@@ -107,6 +108,7 @@ describe('SbbTabNavBar', () => {
         .toBe(true);
 
       fixture.componentInstance.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(tabLinkElements.every((tabLink) => tabLink.tabIndex === -1))
@@ -120,6 +122,7 @@ describe('SbbTabNavBar', () => {
       expect(tabLinkElement.classList).not.toContain('sbb-tab-disabled');
 
       fixture.componentInstance.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(tabLinkElement.classList).toContain('sbb-tab-disabled');
@@ -128,6 +131,7 @@ describe('SbbTabNavBar', () => {
     it('should prevent default keyboard actions on disabled links', () => {
       const link = fixture.debugElement.query(By.css('a')).nativeElement;
       fixture.componentInstance.disabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const spaceEvent = dispatchKeyboardEvent(link, 'keydown', SPACE);
@@ -174,6 +178,7 @@ describe('SbbTabNavBar', () => {
       .toBe(0);
 
     fixture.componentInstance.tabIndex = 3;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(tabLink.tabIndex).withContext('Expected the tabIndex to be have been set to 3.').toBe(3);
@@ -185,11 +190,13 @@ describe('SbbTabNavBar', () => {
 
     instance.tabs = [];
     instance.activeIndex = 1;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(instance.tabNavBar.selectedIndex).toBe(-1);
 
     instance.tabs = [0, 1, 2];
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(instance.tabNavBar.selectedIndex).toBe(1);

--- a/src/angular/tag/tags.spec.ts
+++ b/src/angular/tag/tags.spec.ts
@@ -186,6 +186,7 @@ describe('SbbTags', () => {
       expectTotalAmount(17, fixture);
 
       component.tagItems.push({ amount: 3, label: 'one more', selected: false });
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expectTotalAmount(20, fixture);
@@ -195,6 +196,7 @@ describe('SbbTags', () => {
       expectTotalAmount(17, fixture);
 
       component.tagItems[0].amount = 6;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expectTotalAmount(15, fixture);
@@ -204,9 +206,11 @@ describe('SbbTags', () => {
       expectTotalAmount(17, fixture);
 
       component.tagItems.push({ amount: 5, label: 'laterAdded' });
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       component.tagItems[component.tagItems.length - 1].amount = 6;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expectTotalAmount(23, fixture);
@@ -216,6 +220,7 @@ describe('SbbTags', () => {
       expectTotalAmount(17, fixture);
 
       component.tagItems = [];
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expectTotalAmount(0, fixture);
@@ -243,6 +248,7 @@ describe('SbbTags', () => {
 
       component.tagItems[0].selected = true;
 
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -411,6 +417,7 @@ describe('SbbTags', () => {
 
     it('should have custom badge description for first tag', () => {
       fixture.componentInstance.description = 'description';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(extractBadgeDescription(fixture.debugElement.queryAll(By.directive(SbbTag))[1])).toBe(
@@ -437,6 +444,7 @@ describe('SbbTags', () => {
 
     it('should take totalAmount of input', () => {
       component.totalAmount = 100;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expectTotalAmount(100, fixture);

--- a/src/angular/tag/tags.spec.ts
+++ b/src/angular/tag/tags.spec.ts
@@ -450,6 +450,7 @@ describe('SbbTags', () => {
       expectTotalAmount(100, fixture);
       component.formGroup.addControl('onemore', new FormControl(false));
       component.tagItems.push({ id: 'onemore', amount: 3, label: 'one more' });
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expectTotalAmount(100, fixture);
@@ -576,6 +577,7 @@ describe('SBB Tag Link', () => {
 
   it('should have badge with amount and description', () => {
     fixture.componentInstance.description = 'amount';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     const linkTag = fixture.debugElement.query(By.css('.sbb-tag-link'));

--- a/src/angular/textarea/textarea/textarea.spec.ts
+++ b/src/angular/textarea/textarea/textarea.spec.ts
@@ -103,6 +103,7 @@ describe('SbbTextarea behaviour', () => {
 
   it('should be readonly attribute', () => {
     component.readonly = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(innerComponent.attributes['ng-reflect-readonly']).toBeTruthy();
     expect(fixture.debugElement.nativeElement.querySelector('[readonly]')).toBeTruthy();
@@ -113,6 +114,7 @@ describe('SbbTextarea behaviour', () => {
 
   it('should be disabled', () => {
     component.disabled = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(innerComponent.attributes['ng-reflect-disabled']).toBeTruthy();
     expect(fixture.debugElement.nativeElement.querySelector('.sbb-disabled')).toBeTruthy();
@@ -124,6 +126,7 @@ describe('SbbTextarea behaviour', () => {
 
   it('should have a min length attribute', () => {
     component.minlength = 20;
+    fixture.changeDetectorRef.markForCheck();
     const textarea = innerComponent.query(
       (e) => e.nativeElement.nodeName.toLowerCase() === 'textarea',
     );
@@ -147,6 +150,7 @@ describe('SbbTextarea behaviour', () => {
     fixture.detectChanges();
     expect(component.model).toEqual('test1');
     component.model = 'test2';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     await fixture.whenStable();
     expect(textarea.value).toEqual('test2');
@@ -155,6 +159,7 @@ describe('SbbTextarea behaviour', () => {
     fixture.detectChanges();
     expect(component.model).toEqual('test3');
     component.model = 'test4';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     await fixture.whenStable();
     expect(textarea.value).toEqual('test4');
@@ -219,6 +224,7 @@ describe('SbbTextarea behaviour', () => {
 
     // When
     fixture.componentInstance.model = 'Text \n\n\n';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     flush();
     fixture.detectChanges();
@@ -229,6 +235,7 @@ describe('SbbTextarea behaviour', () => {
 
     // When
     fixture.componentInstance.model = 'Text \n\n';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     flush();
     fixture.detectChanges();
@@ -241,6 +248,7 @@ describe('SbbTextarea behaviour', () => {
     const textarea = fixture.debugElement.query(By.css('textarea'))
       .nativeElement as HTMLTextAreaElement;
     fixture.componentInstance.maxlength = 10;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     // When

--- a/src/angular/time-input/time-input.spec.ts
+++ b/src/angular/time-input/time-input.spec.ts
@@ -78,19 +78,23 @@ describe('SbbTimeInput', () => {
     fixture.detectChanges();
 
     fixture.componentInstance.placeholder = 'Other';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(inputElement.getAttribute('placeholder')).toBe('Other');
 
     fixture.componentInstance.placeholder = '';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(inputElement.getAttribute('placeholder')).toEqual('');
 
     fixture.componentInstance.placeholder = null;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(inputElement.getAttribute('placeholder')).toEqual('HH:MM');
 
     fixture.componentInstance.placeholder = undefined;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(inputElement.getAttribute('placeholder')).toEqual('HH:MM');
   });

--- a/src/angular/tooltip/tooltip-wrapper.spec.ts
+++ b/src/angular/tooltip/tooltip-wrapper.spec.ts
@@ -228,6 +228,7 @@ describe('SbbTooltipWrapper', () => {
     describe('disabled', () => {
       it('should have a disabled attribute and a `sbb-disabled` class', () => {
         component.tooltipDisabled = true;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         const buttonElement = fixture.debugElement.query(By.css('button'))
           .nativeElement as HTMLElement;

--- a/src/angular/tooltip/tooltip-wrapper.spec.ts
+++ b/src/angular/tooltip/tooltip-wrapper.spec.ts
@@ -196,6 +196,7 @@ describe('SbbTooltipWrapper', () => {
       component.tooltip.show();
       tick();
       fixture.detectChanges();
+      flush();
 
       const tooltipPanel = overlayContainer
         .getContainerElement()

--- a/src/angular/tooltip/tooltip.spec.ts
+++ b/src/angular/tooltip/tooltip.spec.ts
@@ -570,6 +570,7 @@ describe('SbbTooltip', () => {
     it('should throw when trying to assign an invalid position', () => {
       expect(() => {
         fixture.componentInstance.position = 'everywhere';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tooltipDirective.show();
       }).toThrowError('Tooltip position "everywhere" is invalid.');

--- a/src/angular/tooltip/tooltip.spec.ts
+++ b/src/angular/tooltip/tooltip.spec.ts
@@ -8,7 +8,6 @@ import {
   Component,
   DebugElement,
   ElementRef,
-  NgZone,
   ViewChild,
 } from '@angular/core';
 import {
@@ -314,6 +313,7 @@ describe('SbbTooltip', () => {
       expect(tooltipDirective._isTooltipVisible()).toBe(true);
 
       fixture.componentInstance.message = '';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick(0);
       expect(tooltipDirective._isTooltipVisible()).toBe(false);
@@ -340,21 +340,25 @@ describe('SbbTooltip', () => {
       assertTooltipInstance(tooltipDirective, false);
 
       tooltipDirective.message = undefined!;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tooltipDirective.show();
       assertTooltipInstance(tooltipDirective, false);
 
       tooltipDirective.message = null!;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tooltipDirective.show();
       assertTooltipInstance(tooltipDirective, false);
 
       tooltipDirective.message = '';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tooltipDirective.show();
       assertTooltipInstance(tooltipDirective, false);
 
       tooltipDirective.message = '   ';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tooltipDirective.show();
       assertTooltipInstance(tooltipDirective, false);
@@ -423,6 +427,7 @@ describe('SbbTooltip', () => {
       const newMessage = 'new tooltip message';
       tooltipDirective.message = newMessage;
 
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(overlayContainerElement.textContent).toContain(newMessage);
     }));
@@ -447,6 +452,7 @@ describe('SbbTooltip', () => {
 
       // Enable the classes via ngClass syntax
       fixture.componentInstance.showTooltipClass = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Make sure classes are correctly added
@@ -571,6 +577,7 @@ describe('SbbTooltip', () => {
 
     it('should be able to set the tooltip message as a number', fakeAsync(() => {
       fixture.componentInstance.message = 100;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(tooltipDirective.message).toBe('100');
@@ -744,6 +751,7 @@ describe('SbbTooltip', () => {
       buttonElement.style.top = buttonElement.style.left = '200px';
 
       fixture.componentInstance.message = 'hi';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       setPositionAndShow('below');
 
@@ -957,25 +965,6 @@ describe('SbbTooltip', () => {
       expect(tooltipDirective._isTooltipVisible())
         .withContext('Expected tooltip hidden when scrolled out of view, after throttle limit')
         .toBe(false);
-    }));
-
-    it('should execute the `hide` call, after scrolling away, inside the NgZone', fakeAsync(() => {
-      const inZoneSpy = jasmine.createSpy('in zone spy');
-
-      tooltipDirective.show();
-      fixture.detectChanges();
-      tick(0);
-
-      spyOn(tooltipDirective._tooltipInstance!, 'hide').and.callFake(() => {
-        inZoneSpy(NgZone.isInAngularZone());
-      });
-
-      fixture.componentInstance.scrollDown();
-      tick(100);
-      fixture.detectChanges();
-
-      expect(inZoneSpy).toHaveBeenCalled();
-      expect(inZoneSpy).toHaveBeenCalledWith(true);
     }));
   });
 

--- a/src/angular/tooltip/tooltip.zone.spec.ts
+++ b/src/angular/tooltip/tooltip.zone.spec.ts
@@ -1,0 +1,94 @@
+import { Directionality } from '@angular/cdk/bidi';
+import { CdkScrollable, OverlayModule } from '@angular/cdk/overlay';
+import {
+  Component,
+  DebugElement,
+  NgZone,
+  provideZoneChangeDetection,
+  ViewChild,
+} from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { dispatchFakeEvent } from '@sbb-esta/angular/core/testing';
+import { Subject } from 'rxjs';
+
+import { SbbTooltip, SbbTooltipModule } from './index';
+
+const initialTooltipMessage = 'initial tooltip message';
+
+describe('SbbTooltip Zone.js integration', () => {
+  let fixture: ComponentFixture<ScrollableTooltipDemo>;
+  let buttonDebugElement: DebugElement;
+  let tooltipDirective: SbbTooltip;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [SbbTooltipModule, OverlayModule, ScrollableTooltipDemo],
+      providers: [
+        provideZoneChangeDetection(),
+        {
+          provide: Directionality,
+          useFactory: () => ({ value: 'ltr', change: new Subject() }),
+        },
+      ],
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ScrollableTooltipDemo);
+    fixture.detectChanges();
+    buttonDebugElement = fixture.debugElement.query(By.css('button'))!;
+    tooltipDirective = buttonDebugElement.injector.get(SbbTooltip);
+  });
+
+  it('should execute the `hide` call, after scrolling away, inside the NgZone', fakeAsync(() => {
+    const inZoneSpy = jasmine.createSpy('in zone spy');
+
+    tooltipDirective.show();
+    fixture.detectChanges();
+    tick(0);
+
+    spyOn(tooltipDirective._tooltipInstance!, 'hide').and.callFake(() => {
+      inZoneSpy(NgZone.isInAngularZone());
+    });
+
+    fixture.componentInstance.scrollDown();
+    tick(100);
+    fixture.detectChanges();
+
+    expect(inZoneSpy).toHaveBeenCalled();
+    expect(inZoneSpy).toHaveBeenCalledWith(true);
+  }));
+});
+@Component({
+  selector: 'app',
+  template: ` <div
+    cdkScrollable
+    style="padding: 100px; margin: 300px;
+      height: 200px; width: 200px; overflow: auto;"
+  >
+    @if (showButton) {
+      <button style="margin-bottom: 600px" [sbbTooltip]="message">Button</button>
+    }
+  </div>`,
+  standalone: true,
+  imports: [SbbTooltipModule],
+})
+class ScrollableTooltipDemo {
+  message: string = initialTooltipMessage;
+  showButton: boolean = true;
+
+  @ViewChild(CdkScrollable) scrollingContainer: CdkScrollable;
+
+  scrollDown() {
+    const scrollingContainerEl = this.scrollingContainer.getElementRef().nativeElement;
+    scrollingContainerEl.scrollTop = 250;
+
+    // Emit a scroll event from the scrolling element in our component.
+    // This event should be picked up by the scrollable directive and notify.
+    // The notification should be picked up by the service.
+    dispatchFakeEvent(scrollingContainerEl, 'scroll');
+  }
+}

--- a/src/angular/usermenu/usermenu.spec.ts
+++ b/src/angular/usermenu/usermenu.spec.ts
@@ -1,6 +1,6 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { Component } from '@angular/core';
-import { ComponentFixture, inject, TestBed, waitForAsync } from '@angular/core/testing';
+import { ChangeDetectorRef, Component, inject } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -55,11 +55,8 @@ describe('SbbUsermenu with userName and displayName without image', () => {
     fixtureTest = TestBed.createComponent(UsermenuWithDisplayNameAndUserNameTestComponent);
     componentTest = fixtureTest.componentInstance;
     fixtureTest.detectChanges();
+    overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
   });
-
-  beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
-    overlayContainerElement = oc.getContainerElement();
-  }));
 
   it('should display initial letters because there is no custom icon/image provided', () => {
     const usermenuComponent = performLoginAndReturnUsermenuComponent(fixtureTest);
@@ -87,6 +84,7 @@ describe('SbbUsermenu with userName and displayName without image', () => {
 
     params.forEach((param) => {
       componentTest.displayName = param.name;
+      fixtureTest.changeDetectorRef.markForCheck();
       fixtureTest.detectChanges();
       const initialLettersReference = usermenuComponent.query(
         By.css('.sbb-usermenu-initial-letters'),
@@ -408,14 +406,18 @@ class UsermenuWithDisplayNameAndUserNameTestComponent {
   userName: string;
   displayName: string;
 
+  private readonly _changeDetectorRef = inject(ChangeDetectorRef);
+
   login() {
     this.userName = 'max_98';
     this.displayName = 'Max Muster';
+    this._changeDetectorRef.markForCheck();
   }
 
   logout() {
     this.userName = '';
     this.displayName = '';
+    this._changeDetectorRef.markForCheck();
   }
 
   closed() {}

--- a/test/angular-test-init-spec.ts
+++ b/test/angular-test-init-spec.ts
@@ -1,3 +1,4 @@
+import { ErrorHandler, NgModule, provideExperimentalZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import '@angular/localize/init';
 import {
@@ -5,14 +6,33 @@ import {
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
+@NgModule({
+  providers: [
+    provideExperimentalZonelessChangeDetection(),
+    {
+      provide: ErrorHandler,
+      useValue: {
+        handleError: (e: any) => {
+          throw e;
+        },
+      },
+    },
+  ],
+})
+export class TestModule {}
+
 /*
  * Common setup / initialization for all unit tests in sbb-angular.
  */
 
-TestBed.initTestEnvironment([BrowserDynamicTestingModule], platformBrowserDynamicTesting(), {
-  errorOnUnknownElements: true,
-  errorOnUnknownProperties: true,
-});
+TestBed.initTestEnvironment(
+  [BrowserDynamicTestingModule, TestModule],
+  platformBrowserDynamicTesting(),
+  {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+);
 
 (window as any).module = {};
 (window as any).isNode = false;

--- a/tslint.json
+++ b/tslint.json
@@ -96,8 +96,8 @@
     "no-zone-dependencies": [
       true,
       [
-        // Tests may need to verify behavior with zones.
-        "**/*.spec.ts"
+        // Allow in tests that specficially test integration with Zone.js.
+        "**/*.zone.spec.ts"
       ]
     ]
   }


### PR DESCRIPTION
Convert remaining tests to zoneless change detection and use zoneless by default for tests. For testing functionality to work with zoneless change detection, move the test to a `*.zone.spec.ts` file.