### PR TITLE
fix(angular/datepicker): avoid losing focus when re-rendering the current view

### DIFF
--- a/src/angular/datepicker/calendar/calendar.ts
+++ b/src/angular/datepicker/calendar/calendar.ts
@@ -325,12 +325,16 @@ export class SbbCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
         ? changes['maxDate']
         : undefined;
 
-    const change = minDateChange || maxDateChange || changes['dateFilter'];
+    const changeRequiringRerender = minDateChange || maxDateChange || changes['dateFilter'];
 
-    if (change && !change.firstChange) {
+    if (changeRequiringRerender && !changeRequiringRerender.firstChange) {
       const view = this._getCurrentViewComponent();
 
       if (view) {
+        // Schedule focus to be moved to the active date since re-rendering
+        // can blur the active cell.
+        this._moveFocusOnNextTick = true;
+
         // We need to `detectChanges` manually here, because the `minDate`, `maxDate` etc. are
         // passed down to the view via data bindings which won't be up-to-date when we call `_init`.
         this._changeDetectorRef.detectChanges();


### PR DESCRIPTION
When some calendar inputs change, we need to re-render the entire view (e.g. `minDate` or `dateFilter`). This can cause the active cell to lose focus since it's being re-rendered.

These changes schedule the active cell to be re-focused in the cases where the view would be re-rendered.