### PR TITLE
fix(angular/tabs): allow for tablist aria-label and aria-labelledby t…

### DIFF
--- a/src/angular/tabs/tab-group.html
+++ b/src/angular/tabs/tab-group.html
@@ -2,6 +2,8 @@
   #tabHeader
   [selectedIndex]="selectedIndex || 0"
   [disablePagination]="disablePagination"
+  [aria-label]="ariaLabel"
+  [aria-labelledby]="ariaLabelledby"
   (indexFocused)="_focusChanged($event)"
   (selectFocusedIndex)="selectedIndex = $event"
 >

--- a/src/angular/tabs/tab-group.spec.ts
+++ b/src/angular/tabs/tab-group.spec.ts
@@ -325,6 +325,42 @@ describe('SbbTabGroup', () => {
 
       expect(tabLabels.map((label) => label.getAttribute('tabindex'))).toEqual(['-1', '-1', '0']);
     });
+
+    it('should be able to set the aria-label of the tablist', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+
+      const tabList = fixture.nativeElement.querySelector('.sbb-tab-list') as HTMLElement;
+      expect(tabList.hasAttribute('aria-label')).toBe(false);
+
+      fixture.componentInstance.ariaLabel = 'hello';
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(tabList.getAttribute('aria-label')).toBe('hello');
+
+      fixture.componentInstance.ariaLabel = '';
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(tabList.hasAttribute('aria-label')).toBe(false);
+    }));
+
+    it('should be able to set the aria-labelledby of the tablist', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+
+      const tabList = fixture.nativeElement.querySelector('.sbb-tab-list') as HTMLElement;
+      expect(tabList.hasAttribute('aria-labelledby')).toBe(false);
+
+      fixture.componentInstance.ariaLabelledby = 'some-label';
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(tabList.getAttribute('aria-labelledby')).toBe('some-label');
+
+      fixture.componentInstance.ariaLabelledby = '';
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(tabList.hasAttribute('aria-labelledby')).toBe(false);
+    }));
   });
 
   describe('aria labelling', () => {
@@ -992,6 +1028,8 @@ describe('nested SbbTabGroup with enabled animations', () => {
     <sbb-tab-group
       class="tab-group"
       [(selectedIndex)]="selectedIndex"
+      [aria-label]="ariaLabel"
+      [aria-labelledby]="ariaLabelledby"
       (animationDone)="animationDone()"
       (focusChange)="handleFocus($event)"
       (selectedTabChange)="handleSelection($event)"
@@ -1019,6 +1057,8 @@ class SimpleTabsTestApp {
   selectedIndex: number = 1;
   focusEvent: any;
   selectEvent: any;
+  ariaLabel: string;
+  ariaLabelledby: string;
   handleFocus(event: any) {
     this.focusEvent = event;
   }

--- a/src/angular/tabs/tab-group.ts
+++ b/src/angular/tabs/tab-group.ts
@@ -168,6 +168,12 @@ export class SbbTabGroup implements AfterContentInit, AfterContentChecked, OnDes
   }
   private _preserveContent: boolean = false;
 
+  /** Aria label of the inner `tablist` of the group. */
+  @Input('aria-label') ariaLabel: string;
+
+  /** Sets the `aria-labelledby` of the inner `tablist` of the group. */
+  @Input('aria-labelledby') ariaLabelledby: string;
+
   /** Output to enable support for two-way binding on `[(selectedIndex)]` */
   @Output() readonly selectedIndexChange: EventEmitter<number> = new EventEmitter<number>();
 

--- a/src/angular/tabs/tab-header.html
+++ b/src/angular/tabs/tab-header.html
@@ -23,6 +23,8 @@
     class="sbb-tab-list"
     [class._sbb-animation-noopable]="_animationMode === 'NoopAnimations'"
     role="tablist"
+    [attr.aria-label]="ariaLabel || null"
+    [attr.aria-labelledby]="ariaLabelledby || null"
     (cdkObserveContent)="_onContentChanges()"
   >
     <div class="sbb-tab-labels" #tabListInner>

--- a/src/angular/tabs/tab-header.ts
+++ b/src/angular/tabs/tab-header.ts
@@ -13,6 +13,7 @@ import {
   ElementRef,
   EventEmitter,
   Inject,
+  Input,
   NgZone,
   OnDestroy,
   Optional,
@@ -59,6 +60,12 @@ export class SbbTabHeader
   @ViewChild('tabListInner', { static: true }) _tabListInner: ElementRef;
   @ViewChild('nextPaginator') _nextPaginator: ElementRef<HTMLElement>;
   @ViewChild('previousPaginator') _previousPaginator: ElementRef<HTMLElement>;
+
+  /** Aria label of the header. */
+  @Input('aria-label') ariaLabel: string;
+
+  /** Sets the `aria-labelledby` of the header. */
+  @Input('aria-labelledby') ariaLabelledby: string;
 
   @Output() override selectFocusedIndex: EventEmitter<number> = new EventEmitter<number>();
   @Output() override indexFocused: EventEmitter<number> = new EventEmitter<number>();


### PR DESCRIPTION
…o be set

According to the [W3C reference implementation](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/), the inner `tablist` can be labelled using `aria-label` or `aria-labelledby`. These changes add an input to allow them to be set.