### PR TITLE
fix(angular/sidebar): prevent unnecessary events when switching to mobile

### DIFF
--- a/src/angular/sidebar/sidebar/sidebar.ts
+++ b/src/angular/sidebar/sidebar/sidebar.ts
@@ -544,9 +544,9 @@ export class SbbSidebar
       this._enableAnimations = false;
       this.mode = this.collapsible || mobile ? 'over' : 'side';
 
-      if (mobile) {
+      if (mobile && this.opened) {
         this.close();
-      } else {
+      } else if (!mobile && !this.opened) {
         this.open();
       }
       this._enableAnimations = wasAnimationsEnabled;


### PR DESCRIPTION
Fixes an issue where 'opened' or 'closed' events were triggered when switching between mobile and non-mobile mode, regardless of whether the sidebar was already open or closed.