### PR TITLE
Revert "fix(angular/tabs): use ResizeObserver to react to size changes

### DIFF
--- a/src/angular/tabs/paginated-tab-header.ts
+++ b/src/angular/tabs/paginated-tab-header.ts
@@ -1,7 +1,6 @@
 import { FocusableOption, FocusKeyManager } from '@angular/cdk/a11y';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { ENTER, hasModifierKey, SPACE } from '@angular/cdk/keycodes';
-import { SharedResizeObserver } from '@angular/cdk/observers/private';
 import { normalizePassiveListenerOptions, Platform } from '@angular/cdk/platform';
 import { ViewportRuler } from '@angular/cdk/scrolling';
 import {
@@ -25,7 +24,7 @@ import {
   QueryList,
 } from '@angular/core';
 import { mixinVariant } from '@sbb-esta/angular/core';
-import { debounceTime, fromEvent, merge, Subject, timer } from 'rxjs';
+import { fromEvent, merge, Subject, timer } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith, switchMap, takeUntil } from 'rxjs/operators';
 
 /** Config used to bind passive event listeners */
@@ -165,8 +164,6 @@ export abstract class SbbPaginatedTabHeader
   /** Event emitted when a label is focused. */
   readonly indexFocused: EventEmitter<number> = new EventEmitter<number>();
 
-  private _sharedResizeObserver = inject(SharedResizeObserver);
-
   private _injector = inject(Injector);
 
   constructor(
@@ -207,18 +204,7 @@ export abstract class SbbPaginatedTabHeader
   }
 
   ngAfterContentInit() {
-    // We need to debounce resize events because the alignment logic is expensive.
-    // If someone animates the width of tabs, we don't want to realign on every animation frame.
-    // Once we haven't seen any more resize events in the last 32ms (~2 animaion frames) we can
-    // re-align.
-    const resize = this._sharedResizeObserver
-      .observe(this._elementRef.nativeElement)
-      .pipe(debounceTime(32), takeUntil(this._destroyed));
-    // Note: We do not actually need to watch these events for proper functioning of the tabs,
-    // the resize events above should capture any viewport resize that we care about. However,
-    // removing this is fairly breaking for screenshot tests, so we're leaving it here for now.
-    const viewportResize = this._viewportRuler.change(150).pipe(takeUntil(this._destroyed));
-
+    const resize = this._viewportRuler.change(150);
     const realign = () => this.updatePagination();
     this._keyManager = new FocusKeyManager<SbbPaginatedTabHeaderItem>(this._items)
       .withHorizontalOrientation('ltr')
@@ -234,7 +220,7 @@ export abstract class SbbPaginatedTabHeader
     afterNextRender(realign, { injector: this._injector });
 
     // On window resize, items change or variant change, realign
-    merge(viewportResize, this._items.changes, this.variant)
+    merge(resize, this._items.changes, this.variant)
       .pipe(takeUntil(this._destroyed))
       .subscribe(() => {
         // We need to defer this to give the browser some time to recalculate


### PR DESCRIPTION
This reverts commit 0f67f0ce7493215b1fdd40c511953bf07a749c62.

Undoing, because this breaks the Showcase. I'll investigate it later.