### PR TITLE
feat(angular/sidebar): allow controlling the opened state of the sidebar

### DIFF
--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -182,7 +182,7 @@
         <source>Close Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">135</context>
         </context-group>
         <note priority="1" from="description">Button label to close the sidebar</note>
       </trans-unit>
@@ -190,7 +190,7 @@
         <source>Open Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">581</context>
+          <context context-type="linenumber">592</context>
         </context-group>
         <note priority="1" from="description">Button label to open the sidebar</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -194,7 +194,7 @@
     </unit>
     <unit id="sbbSidebarCloseSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:134</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:135</note>
         <note category="description">Button label to close the sidebar</note>
       </notes>
       <segment>
@@ -203,7 +203,7 @@
     </unit>
     <unit id="sbbSidebarOpenSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:581</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:592</note>
         <note category="description">Button label to open the sidebar</note>
       </notes>
       <segment>

--- a/src/angular/sidebar/sidebar.md
+++ b/src/angular/sidebar/sidebar.md
@@ -129,6 +129,10 @@ It can be made collapsible by setting the `collapsible` attribute to `true`. In 
 displayed above the content and can be collapsed using the close icon, by clicking in the content are or by
 pressing the escape key.
 
+Like the normal sidebar, the collapsible sidebar is opened by default. You can close it by setting the `opened`
+property to `false`. If the `opened` state is controlled with the input property, the sidebar will not be toggled
+automatically if the mobile state changes.
+
 In collapsible mode, the sidebar can have a title displayed next to the close icon. This label can be set using the
 `collapsibleTitle` attribute.
 

--- a/src/angular/sidebar/sidebar/sidebar.spec.ts
+++ b/src/angular/sidebar/sidebar/sidebar.spec.ts
@@ -452,6 +452,26 @@ describe('SbbSidebar', () => {
   });
 
   describe('attributes', () => {
+    it('should correctly parse opened="false"', () => {
+      const fixture = TestBed.createComponent(SidebarSetToOpenedFalseTestComponent);
+
+      fixture.detectChanges();
+
+      const sidebar = fixture.debugElement.query(By.directive(SbbSidebar))!.componentInstance;
+
+      expect((sidebar as SbbSidebar).opened).toBe(false);
+    });
+
+    it('should correctly parse opened="true"', () => {
+      const fixture = TestBed.createComponent(SidebarSetToOpenedTrueTestComponent);
+
+      fixture.detectChanges();
+
+      const sidebar = fixture.debugElement.query(By.directive(SbbSidebar))!.componentInstance;
+
+      expect((sidebar as SbbSidebar).opened).toBe(true);
+    });
+
     it('should remove align attr from DOM', () => {
       const fixture = TestBed.createComponent(BasicTestComponent);
       fixture.detectChanges();
@@ -505,6 +525,21 @@ describe('SbbSidebar', () => {
 
       tick(1);
       flush();
+    }));
+
+    it('should bind 2-way bind on opened property', fakeAsync(() => {
+      const fixture = TestBed.createComponent(SidebarOpenBindingTestComponent);
+      fixture.detectChanges();
+
+      const sidebar: SbbSidebar = fixture.debugElement.query(
+        By.directive(SbbSidebar),
+      )!.componentInstance;
+
+      sidebar.open();
+      fixture.detectChanges();
+      tick();
+
+      expect(fixture.componentInstance.isOpen).toBe(true);
     }));
   });
 
@@ -1215,14 +1250,25 @@ class SidebarSetToOpenedTrueTestComponent {
 
 @Component({
   template: ` <sbb-sidebar-container>
-    <sbb-sidebar #sidebar>
+    <sbb-sidebar #sidebar opened="false"> Closed Drawer. </sbb-sidebar>
+  </sbb-sidebar-container>`,
+  standalone: true,
+  imports: [SbbSidebarModule],
+})
+class SidebarSetToOpenedFalseTestComponent {}
+
+@Component({
+  template: ` <sbb-sidebar-container>
+    <sbb-sidebar #sidebar [(opened)]="isOpen">
       <fieldset>Closed Sidebar.</fieldset>
     </sbb-sidebar>
   </sbb-sidebar-container>`,
   standalone: true,
   imports: [SbbSidebarModule],
 })
-class SidebarOpenBindingTestComponent {}
+class SidebarOpenBindingTestComponent {
+  isOpen = false;
+}
 
 @Component({
   template: ` <sbb-sidebar-container>

--- a/src/angular/sidebar/sidebar/sidebar.ts
+++ b/src/angular/sidebar/sidebar/sidebar.ts
@@ -8,6 +8,7 @@ import {
   FocusOrigin,
   FocusTrap,
 } from '@angular/cdk/a11y';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { ESCAPE, hasModifierKey } from '@angular/cdk/keycodes';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { Platform } from '@angular/cdk/platform';
@@ -168,12 +169,23 @@ export class SbbSidebar
   }
 
   /**
-   * Whether the sidebar is opened. We overload this because we trigger an event when it
-   * starts or end.
+   * Whether the collapsible sidebar is opened.
    */
+  @Input()
   get opened(): boolean {
     return this._opened;
   }
+  set opened(value: BooleanInput) {
+    this._openedViaInput = true;
+    this.toggle(coerceBooleanProperty(value));
+  }
+  private _opened: boolean = true;
+
+  /**
+   * Whether the `opened` state was set via the @Input.
+   * If true, the sidebar will not be toggled automatically if the mobile state changes.
+   */
+  private _openedViaInput: boolean = false;
 
   /**
    * Name of the svg icon for the trigger on mobile devices.
@@ -208,7 +220,6 @@ export class SbbSidebar
   private _elementFocusedBeforeSidebarWasOpened: HTMLElement | null = null;
 
   private _mode: SbbSidebarMode = 'side';
-  private _opened: boolean = true;
 
   /** How the sidebar was opened (keypress, mouse click etc.) */
   private _openedVia: FocusOrigin | null;
@@ -544,10 +555,10 @@ export class SbbSidebar
       this._enableAnimations = false;
       this.mode = this.collapsible || mobile ? 'over' : 'side';
 
-      if (mobile) {
-        this.close();
+      if (!this._openedViaInput) {
+        this.toggle(!mobile);
       } else {
-        this.open();
+        this._changeDetectorRef.markForCheck();
       }
       this._enableAnimations = wasAnimationsEnabled;
     });


### PR DESCRIPTION
This adds the `opened` input property to control the open state of the sidebar. If `opened` is set, the sidebar is not toggled automatically if the mobile state changes.

Closes #2360