### PR TITLE
feat(angular/checkbox): add new aria properties to SbbCheckbox

### DIFF
--- a/src/angular/checkbox/checkbox.html
+++ b/src/angular/checkbox/checkbox.html
@@ -11,10 +11,13 @@
     [disabled]="disabled"
     [attr.name]="name"
     [tabIndex]="disabled ? -1 : tabIndex"
+    [attr.aria-expanded]="ariaExpanded"
     [attr.aria-label]="ariaLabel || null"
     [attr.aria-labelledby]="ariaLabelledby"
     [attr.aria-describedby]="ariaDescribedby"
     [attr.aria-checked]="indeterminate ? 'mixed' : null"
+    [attr.aria-controls]="ariaControls"
+    [attr.aria-owns]="ariaOwns"
     (change)="_onInteractionEvent($event)"
     (click)="_onInputClick($event)"
   />

--- a/src/angular/checkbox/checkbox.md
+++ b/src/angular/checkbox/checkbox.md
@@ -72,3 +72,9 @@ binding these properties, as demonstrated below.
 ```html
 <sbb-checkbox [aria-label]="isSubscribedToEmailsMessage"> </sbb-checkbox>
 ```
+
+Additionally, `SbbCheckbox` supports the following accessibility properties:
+
+- **`aria-expanded`**: Indicates whether the checkbox controls the visibility of another element. This should be a boolean value (`true` or `false`).
+- **`aria-controls`**: Specifies the ID of the element that the checkbox controls.
+- **`aria-owns`**: Specifies the ID of the element that the checkbox visually owns.

--- a/src/angular/checkbox/checkbox.spec.ts
+++ b/src/angular/checkbox/checkbox.spec.ts
@@ -610,6 +610,93 @@ describe('SbbCheckbox', () => {
     });
   });
 
+  describe('with provided aria-expanded', () => {
+    let checkboxDebugElement: DebugElement;
+    let checkboxNativeElement: HTMLElement;
+    let inputElement: HTMLInputElement;
+
+    it('should use the provided postive aria-expanded', () => {
+      fixture = createComponent(CheckboxWithPositiveAriaExpanded);
+      checkboxDebugElement = fixture.debugElement.query(By.directive(SbbCheckbox))!;
+      checkboxNativeElement = checkboxDebugElement.nativeElement;
+      inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+
+      fixture.detectChanges();
+      expect(inputElement.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('should use the provided negative aria-expanded', () => {
+      fixture = createComponent(CheckboxWithNegativeAriaExpanded);
+      checkboxDebugElement = fixture.debugElement.query(By.directive(SbbCheckbox))!;
+      checkboxNativeElement = checkboxDebugElement.nativeElement;
+      inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+
+      fixture.detectChanges();
+      expect(inputElement.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('should not assign aria-expanded if none is provided', () => {
+      fixture = createComponent(SingleCheckbox);
+      checkboxDebugElement = fixture.debugElement.query(By.directive(SbbCheckbox))!;
+      checkboxNativeElement = checkboxDebugElement.nativeElement;
+      inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+
+      fixture.detectChanges();
+      expect(inputElement.getAttribute('aria-expanded')).toBe(null);
+    });
+  });
+
+  describe('with provided aria-controls', () => {
+    let checkboxDebugElement: DebugElement;
+    let checkboxNativeElement: HTMLElement;
+    let inputElement: HTMLInputElement;
+
+    it('should use the provided aria-controls', () => {
+      fixture = createComponent(CheckboxWithAriaControls);
+      checkboxDebugElement = fixture.debugElement.query(By.directive(SbbCheckbox))!;
+      checkboxNativeElement = checkboxDebugElement.nativeElement;
+      inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+
+      fixture.detectChanges();
+      expect(inputElement.getAttribute('aria-controls')).toBe('some-id');
+    });
+
+    it('should not assign aria-controls if none is provided', () => {
+      fixture = createComponent(SingleCheckbox);
+      checkboxDebugElement = fixture.debugElement.query(By.directive(SbbCheckbox))!;
+      checkboxNativeElement = checkboxDebugElement.nativeElement;
+      inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+
+      fixture.detectChanges();
+      expect(inputElement.getAttribute('aria-controls')).toBe(null);
+    });
+  });
+  describe('with provided aria-owns', () => {
+    let checkboxDebugElement: DebugElement;
+    let checkboxNativeElement: HTMLElement;
+    let inputElement: HTMLInputElement;
+
+    it('should use the provided aria-owns', () => {
+      fixture = createComponent(CheckboxWithAriaOwns);
+      checkboxDebugElement = fixture.debugElement.query(By.directive(SbbCheckbox))!;
+      checkboxNativeElement = checkboxDebugElement.nativeElement;
+      inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+
+      fixture.detectChanges();
+      expect(inputElement.getAttribute('aria-owns')).toBe('some-id');
+    });
+
+    it('should not assign aria-owns if none is provided', () => {
+      fixture = createComponent(SingleCheckbox);
+      checkboxDebugElement = fixture.debugElement.query(By.directive(SbbCheckbox))!;
+      checkboxNativeElement = checkboxDebugElement.nativeElement;
+      inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+
+      fixture.detectChanges();
+      expect(inputElement.getAttribute('aria-owns')).toBe(null);
+    });
+  });
+
   describe('with provided tabIndex', () => {
     let checkboxDebugElement: DebugElement;
     let checkboxNativeElement: HTMLElement;
@@ -1031,6 +1118,38 @@ class CheckboxWithAriaLabelledby {}
   standalone: true,
 })
 class CheckboxWithAriaDescribedby {}
+
+/** Simple test component with an aria-expanded set with true. */
+@Component({
+  template: `<sbb-checkbox aria-expanded="true"></sbb-checkbox>`,
+  standalone: true,
+  imports: [SbbCheckbox],
+})
+class CheckboxWithPositiveAriaExpanded {}
+
+/** Simple test component with an aria-expanded set with false. */
+@Component({
+  template: `<sbb-checkbox aria-expanded="false"><sbb-checkbox></sbb-checkbox></sbb-checkbox>`,
+  standalone: true,
+  imports: [SbbCheckbox],
+})
+class CheckboxWithNegativeAriaExpanded {}
+
+/** Simple test component with an aria-controls set. */
+@Component({
+  template: `<sbb-checkbox aria-controls="some-id"></sbb-checkbox>`,
+  standalone: true,
+  imports: [SbbCheckbox],
+})
+class CheckboxWithAriaControls {}
+
+/** Simple test component with an aria-owns set. */
+@Component({
+  template: `<sbb-checkbox aria-owns="some-id"></sbb-checkbox>`,
+  standalone: true,
+  imports: [SbbCheckbox],
+})
+class CheckboxWithAriaOwns {}
 
 /** Simple test component with name attribute */
 @Component({

--- a/src/angular/checkbox/checkbox.ts
+++ b/src/angular/checkbox/checkbox.ts
@@ -85,6 +85,19 @@ export class _SbbCheckboxBase
   /** The 'aria-describedby' attribute is read after the element's label and field type. */
   @Input('aria-describedby') ariaDescribedby: string;
 
+  /**
+   * Users can specify the `aria-expanded` attribute which will be forwarded to the input element
+   */
+  @Input({ alias: 'aria-expanded', transform: booleanAttribute }) ariaExpanded: boolean;
+
+  /**
+   * Users can specify the `aria-controls` attribute which will be forwarded to the input element
+   */
+  @Input('aria-controls') ariaControls: string;
+
+  /** Users can specify the `aria-owns` attribute which will be forwarded to the input element */
+  @Input('aria-owns') ariaOwns: string;
+
   private _uniqueId: string = `sbb-checkbox-${++nextUniqueId}`;
 
   /** A unique id for the checkbox input. If none is supplied, it will be auto-generated. */


### PR DESCRIPTION
Added three new aria properties to SbbCheckbox:
`aria-expanded`: Indicates whether the checkbox controls the visibility of another element. This should be a boolean value (true or false). `aria-controls`: Specifies the ID of the element that the checkbox controls. `aria-owns`: Specifies the ID of the element that the checkbox visually owns.

These attributes will be added to the generated checkbox element if they are specified and won't be present in the HTML if not provided.