### PR TITLE
fix(angular/select): remove incompatible aria-autocomplete attribute

### DIFF
--- a/src/angular/select/select.spec.ts
+++ b/src/angular/select/select.spec.ts
@@ -989,7 +989,6 @@ describe('SbbSelect', () => {
 
         it('should set the role of the select to combobox', () => {
           expect(select.getAttribute('role')).toEqual('combobox');
-          expect(select.getAttribute('aria-autocomplete')).toBe('none');
           expect(select.getAttribute('aria-haspopup')).toBe('listbox');
         });
 

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -153,7 +153,6 @@ const _SbbSelectMixinBase = mixinVariant(
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     role: 'combobox',
-    'aria-autocomplete': 'none',
     'aria-haspopup': 'listbox',
     class: 'sbb-select sbb-input-element',
     '[attr.id]': 'id',


### PR DESCRIPTION
Fixes a bug where the usage of aria-autocomplete is not a valid attribute that can be used with aria role=listbox. Removes the aria-autocomplete attribute to fix the violation: aria-allowed-attr.