### PR TITLE
fix(angular/tooltip): correct icon styling when placed inside label

### DIFF
--- a/src/angular/form-field/form-field.scss
+++ b/src/angular/form-field/form-field.scss
@@ -82,7 +82,7 @@
 }
 
 // Scale down icons in the label and error to be the same size as the text.
-:is(.sbb-form-field-error-wrapper, .sbb-form-field-label-wrapper) {
+:is(.sbb-form-field-error-wrapper, .sbb-form-field-label-wrapper, .sbb-label) {
   :is(.sbb-icon, .sbb-tooltip-icon),
   .sbb-icon svg {
     vertical-align: bottom;


### PR DESCRIPTION
Fixes the size of the tooltip icon if it's placed inside an `<sbb-label />` that's not wrapped by an `<sbb-form-field />`.

Example before this change: 
![image](https://github.com/user-attachments/assets/2fa5dfe1-e303-4255-abdd-db4690749ec3)
