### PR TITLE
refactor(angular/input): support signal-based input accessor

### DIFF
--- a/src/angular/input/input-value-accessor.ts
+++ b/src/angular/input/input-value-accessor.ts
@@ -1,4 +1,4 @@
-import { InjectionToken } from '@angular/core';
+import { InjectionToken, WritableSignal } from '@angular/core';
 
 /**
  * This token is used to inject the object whose value should be set into `InputDirective`.
@@ -6,6 +6,6 @@ import { InjectionToken } from '@angular/core';
  * themselves for this token, in order to make `InputDirective` delegate the getting and setting of the
  * value to them.
  */
-export const SBB_INPUT_VALUE_ACCESSOR = new InjectionToken<{ value: any }>(
+export const SBB_INPUT_VALUE_ACCESSOR = new InjectionToken<{ value: any | WritableSignal<any> }>(
   'SBB_INPUT_VALUE_ACCESSOR',
 );


### PR DESCRIPTION
Expands the `SBB_INPUT_VALUE_ACCESSOR` to support a signal-based accessor.