### PR TITLE
test: remove compileComponent calls

### DIFF
--- a/src/angular/accordion/accordion.spec.ts
+++ b/src/angular/accordion/accordion.spec.ts
@@ -25,7 +25,6 @@ describe('AccordionDirective', () => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, SbbIconTestingModule],
     });
-    TestBed.compileComponents();
 
     inject([FocusMonitor], (fm: FocusMonitor) => {
       focusMonitor = fm;

--- a/src/angular/accordion/expansion-panel.spec.ts
+++ b/src/angular/accordion/expansion-panel.spec.ts
@@ -36,7 +36,6 @@ describe('SbbExpansionPanel', () => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, SbbIconTestingModule],
     });
-    TestBed.compileComponents();
   }));
 
   it('should expand and collapse the panel', fakeAsync(() => {

--- a/src/angular/alert/alert.spec.ts
+++ b/src/angular/alert/alert.spec.ts
@@ -11,7 +11,7 @@ describe('SbbAlert', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule, NoopAnimationsModule, SbbIconTestingModule],
-    }).compileComponents();
+    });
   }));
 
   describe('normal variant', () => {
@@ -108,7 +108,7 @@ describe('SbbAlertOutlet', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -227,7 +227,7 @@ describe('SbbAlertOutlet', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [AlertOutletWithInnerAlert, NoopAnimationsModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -265,7 +265,7 @@ describe('SbbAlertOutlet', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule],
-      }).compileComponents();
+      });
     }));
 
     it('should throw', () => {
@@ -280,7 +280,7 @@ describe('SbbAlertOutlet', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/angular/autocomplete/autocomplete.spec.ts
+++ b/src/angular/autocomplete/autocomplete.spec.ts
@@ -597,8 +597,6 @@ describe('SbbAutocomplete', () => {
       providers,
     });
 
-    TestBed.compileComponents();
-
     inject([OverlayContainer], (oc: OverlayContainer) => {
       overlayContainer = oc;
       overlayContainerElement = oc.getContainerElement();

--- a/src/angular/autocomplete/autocomplete.zone.spec.ts
+++ b/src/angular/autocomplete/autocomplete.zone.spec.ts
@@ -126,8 +126,6 @@ describe('SbbAutocomplete Zone.js integration', () => {
       providers: [provideZoneChangeDetection(), ...providers],
     });
 
-    TestBed.compileComponents();
-
     return TestBed.createComponent<T>(component);
   }
 

--- a/src/angular/breadcrumb/breadcrumbs.spec.ts
+++ b/src/angular/breadcrumb/breadcrumbs.spec.ts
@@ -76,7 +76,7 @@ describe('SbbBreadcrumbs', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [SbbIconTestingModule, NoopAnimationsModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -96,7 +96,7 @@ describe('SbbBreadcrumbs', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [BreadcrumbsSimpleTest, SbbIconTestingModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -157,7 +157,7 @@ describe('SbbBreadcrumbs', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [SbbIconTestingModule, NoopAnimationsModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/angular/button/button.spec.ts
+++ b/src/angular/button/button.spec.ts
@@ -12,8 +12,6 @@ describe('SbbButton', () => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule],
     });
-
-    TestBed.compileComponents();
   }));
 
   // General button tests

--- a/src/angular/checkbox-panel/checkbox-panel.spec.ts
+++ b/src/angular/checkbox-panel/checkbox-panel.spec.ts
@@ -74,7 +74,7 @@ describe('SbbCheckboxPanel', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule],
-    }).compileComponents();
+    });
   }));
 
   describe('multi selection', () => {

--- a/src/angular/checkbox/checkbox.spec.ts
+++ b/src/angular/checkbox/checkbox.spec.ts
@@ -23,7 +23,7 @@ describe('SbbCheckbox', () => {
   function createComponent<T>(componentType: Type<T>) {
     TestBed.configureTestingModule({
       imports: [componentType],
-    }).compileComponents();
+    });
 
     return TestBed.createComponent<T>(componentType);
   }

--- a/src/angular/chips/chip-input.spec.ts
+++ b/src/angular/chips/chip-input.spec.ts
@@ -33,8 +33,6 @@ describe('SbbChipInput', () => {
       ],
       declarations: [TestChipInput],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(waitForAsync(() => {

--- a/src/angular/chips/chip-list.spec.ts
+++ b/src/angular/chips/chip-list.spec.ts
@@ -1059,7 +1059,7 @@ describe('SbbChipList', () => {
         component,
       ],
       providers: [...providers],
-    }).compileComponents();
+    });
 
     return TestBed.createComponent<T>(component);
   }

--- a/src/angular/chips/chip-remove.spec.ts
+++ b/src/angular/chips/chip-remove.spec.ts
@@ -19,8 +19,6 @@ describe('Chip Remove', () => {
         ChipWithoutRemoveIcon,
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('basic behavior', () => {

--- a/src/angular/core/option/option.spec.ts
+++ b/src/angular/core/option/option.spec.ts
@@ -34,7 +34,7 @@ describe('SbbOption component', () => {
     TestBed.configureTestingModule({
       imports: [SbbOptionModule],
       declarations: [BasicOption],
-    }).compileComponents();
+    });
   }));
 
   it('should complete the `stateChanges` stream on destroy', () => {
@@ -181,7 +181,7 @@ describe('SbbOption component', () => {
             useValue: { inertGroups: true },
           },
         ],
-      }).compileComponents();
+      });
 
       fixture = TestBed.createComponent(InsideGroup);
       fixture.detectChanges();

--- a/src/angular/datepicker/calendar/calendar-header.spec.ts
+++ b/src/angular/datepicker/calendar/calendar-header.spec.ts
@@ -22,7 +22,7 @@ describe('SbbCalendarHeader', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule],
-    }).compileComponents();
+    });
   }));
 
   describe('standard calendar', () => {

--- a/src/angular/datepicker/calendar/calendar.spec.ts
+++ b/src/angular/datepicker/calendar/calendar.spec.ts
@@ -105,7 +105,7 @@ class CalendarWithDateClassComponent {
 
 describe('SbbCalendar', () => {
   beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({ imports: [SbbIconTestingModule] }).compileComponents();
+    TestBed.configureTestingModule({ imports: [SbbIconTestingModule] });
   }));
 
   describe('standard calendar', () => {

--- a/src/angular/datepicker/month-view/month-view.spec.ts
+++ b/src/angular/datepicker/month-view/month-view.spec.ts
@@ -106,7 +106,7 @@ describe('SbbMonthView', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       providers: [provideNativeDateAdapter()],
-    }).compileComponents();
+    });
   }));
 
   describe('standard month view', () => {

--- a/src/angular/dialog/dialog.spec.ts
+++ b/src/angular/dialog/dialog.spec.ts
@@ -83,8 +83,6 @@ describe('SbbDialog', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject(
@@ -1829,8 +1827,6 @@ describe('SbbDialog with a parent SbbDialog', () => {
         { provide: Location, useClass: SpyLocation },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([SbbDialog], (d: SbbDialog) => {
@@ -1934,8 +1930,6 @@ describe('SbbDialog with default options', () => {
       imports: [DialogTestModule],
       providers: [{ provide: SBB_DIALOG_DEFAULT_OPTIONS, useValue: defaultConfig }],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([SbbDialog, OverlayContainer], (d: SbbDialog, oc: OverlayContainer) => {
@@ -2006,8 +2000,6 @@ describe('SbbDialog with animations enabled', () => {
     TestBed.configureTestingModule({
       imports: [DialogTestModule, BrowserAnimationsModule],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([SbbDialog, OverlayContainer], (d: SbbDialog, oc: OverlayContainer) => {
@@ -2056,8 +2048,6 @@ describe('SbbDialog with explicit injector provided', () => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, ModuleBoundDialogParentComponent],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
@@ -2085,7 +2075,6 @@ describe('SbbDialog with template only', () => {
     TestBed.configureTestingModule({
       imports: [DialogTestModule, BrowserAnimationsModule],
     });
-    TestBed.compileComponents();
   }));
 
   it('should display close button', fakeAsync(() => {
@@ -2103,7 +2092,6 @@ describe('SbbDialog with close button', () => {
     TestBed.configureTestingModule({
       imports: [DialogTestModule, BrowserAnimationsModule],
     });
-    TestBed.compileComponents();
   }));
 
   it('should have pre configured aria label', fakeAsync(() => {

--- a/src/angular/dialog/dialog.zone.spec.ts
+++ b/src/angular/dialog/dialog.zone.spec.ts
@@ -45,8 +45,6 @@ describe('SbbDialog Zone.js integration', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([SbbDialog], (d: SbbDialog) => {

--- a/src/angular/file-selector/file-selector.spec.ts
+++ b/src/angular/file-selector/file-selector.spec.ts
@@ -107,7 +107,7 @@ describe('SbbFileSelector using mock component', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -263,7 +263,7 @@ describe('SbbFileSelector using mock component and limited behaviour ', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/angular/header-lean/header.spec.ts
+++ b/src/angular/header-lean/header.spec.ts
@@ -27,8 +27,6 @@ describe('SbbHeaderLean', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('without app chooser', () => {

--- a/src/angular/i18n/sbb-ch-patch.spec.ts
+++ b/src/angular/i18n/sbb-ch-patch.spec.ts
@@ -35,7 +35,7 @@ describe('i18n sbb patch', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [DateFormat],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/angular/icon/icon.spec.ts
+++ b/src/angular/icon/icon.spec.ts
@@ -60,8 +60,6 @@ describe('SbbIcon', () => {
       ],
     });
 
-    TestBed.compileComponents();
-
     iconRegistry = TestBed.inject(SbbIconRegistry);
     http = TestBed.inject(HttpTestingController);
     sanitizer = TestBed.inject(DomSanitizer);
@@ -1218,8 +1216,6 @@ describe('SbbIcon without HttpClientModule', () => {
       imports: [SbbIconModule],
       declarations: [IconFromSvgName],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([SbbIconRegistry, DomSanitizer], (mir: SbbIconRegistry, ds: DomSanitizer) => {

--- a/src/angular/input/input.spec.ts
+++ b/src/angular/input/input.spec.ts
@@ -930,7 +930,7 @@ function createComponent<T>(
   TestBed.configureTestingModule({
     imports: [BrowserAnimationsModule, ...imports, component, ...declarations],
     providers,
-  }).compileComponents();
+  });
 
   return TestBed.createComponent<T>(component);
 }

--- a/src/angular/lightbox/lightbox.spec.ts
+++ b/src/angular/lightbox/lightbox.spec.ts
@@ -94,8 +94,6 @@ describe('SbbLightbox', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject(
@@ -1493,8 +1491,6 @@ describe('SbbLightbox with a parent SbbLightbox', () => {
         { provide: Location, useClass: SpyLocation },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([SbbLightbox], (d: SbbLightbox) => {
@@ -1598,8 +1594,6 @@ describe('SbbLightbox with default options', () => {
       imports: [DialogTestModule],
       providers: [{ provide: SBB_LIGHTBOX_DEFAULT_OPTIONS, useValue: defaultConfig }],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([SbbLightbox, OverlayContainer], (d: SbbLightbox, oc: OverlayContainer) => {
@@ -1667,8 +1661,6 @@ describe('SbbLightbox with animations enabled', () => {
     TestBed.configureTestingModule({
       imports: [DialogTestModule, BrowserAnimationsModule],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([SbbLightbox, OverlayContainer], (d: SbbLightbox, oc: OverlayContainer) => {
@@ -1717,8 +1709,6 @@ describe('SbbDialog with explicit injector provided', () => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, ModuleBoundLightboxParentComponent],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
@@ -1746,7 +1736,6 @@ describe('SbbLightbox with template only', () => {
     TestBed.configureTestingModule({
       imports: [DialogTestModule, BrowserAnimationsModule],
     });
-    TestBed.compileComponents();
   }));
 
   it('should display close button', fakeAsync(() => {
@@ -1764,7 +1753,6 @@ describe('SbbLightbox with close button', () => {
     TestBed.configureTestingModule({
       imports: [DialogTestModule, BrowserAnimationsModule],
     });
-    TestBed.compileComponents();
   }));
 
   it('should have pre configured aria label', fakeAsync(() => {

--- a/src/angular/lightbox/lightbox.zone.spec.ts
+++ b/src/angular/lightbox/lightbox.zone.spec.ts
@@ -30,8 +30,6 @@ describe('SbbLightbox Zone.js integration', () => {
       ],
       providers: [provideZoneChangeDetection()],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(inject([SbbLightbox], (d: SbbLightbox) => {

--- a/src/angular/menu/menu.spec.ts
+++ b/src/angular/menu/menu.spec.ts
@@ -84,7 +84,7 @@ describe('SbbMenu', () => {
       imports: [SbbMenuModule, NoopAnimationsModule, SbbIconModule, SbbIconTestingModule],
       declarations: [component, ...declarations],
       providers,
-    }).compileComponents();
+    });
 
     overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
     focusMonitor = TestBed.inject(FocusMonitor);
@@ -2579,7 +2579,7 @@ describe('SbbMenu default overrides', () => {
           useValue: { overlapTrigger: true, xPosition: 'before', yPosition: 'above' },
         },
       ],
-    }).compileComponents();
+    });
   }));
 
   it('should allow for the default menu options to be overridden', fakeAsync(() => {
@@ -2604,7 +2604,7 @@ describe('SbbMenu contextmenu', () => {
         ContextmenuDynamicTrigger,
         ContextmenuOnlyTextTrigger,
       ],
-    }).compileComponents();
+    });
 
     inject([DomSanitizer], (domSanitizer: DomSanitizer) => {
       securityBypassSpy = spyOn(domSanitizer, 'bypassSecurityTrustHtml').and.callThrough();
@@ -2682,7 +2682,7 @@ describe('SbbMenu headless trigger', () => {
     TestBed.configureTestingModule({
       imports: [SbbMenuModule, NoopAnimationsModule, SbbIconModule, SbbIconTestingModule],
       declarations: [HeadlessTrigger],
-    }).compileComponents();
+    });
   }));
 
   it('should apply sbb-menu-trigger-headless css class', () => {
@@ -2714,7 +2714,7 @@ describe('SbbMenu offset', () => {
         PROVIDE_FAKE_MEDIA_MATCHER,
         { provide: SBB_MENU_INHERITED_TRIGGER_CONTEXT, useValue: sbbMenuInheritedTriggerContext },
       ],
-    }).compileComponents();
+    });
   }));
 
   afterEach(() => {
@@ -2766,7 +2766,7 @@ describe('SbbMenu contextmenu trigger', () => {
     TestBed.configureTestingModule({
       imports: [SbbMenuModule, NoopAnimationsModule, SbbIconModule, SbbIconTestingModule],
       declarations: [ContextmenuTrigger, ContextmenuCustomIconTrigger],
-    }).compileComponents();
+    });
   }));
 
   it('should apply contextmenu classes and use correct icon', () => {

--- a/src/angular/notification-toast/notification-toast.spec.ts
+++ b/src/angular/notification-toast/notification-toast.spec.ts
@@ -53,7 +53,7 @@ describe('SbbNotificationToast icons', () => {
           },
         },
       ],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -635,7 +635,7 @@ describe('SbbNotificationToast with parent SbbNotificationToast', () => {
     TestBed.configureTestingModule({
       imports: [NotificationToastTestModule, NoopAnimationsModule, SbbIconTestingModule],
       declarations: [ComponentThatProvidesSbbNotificationToast],
-    }).compileComponents();
+    });
 
     parentNotificationToast = TestBed.inject(SbbNotificationToast);
     liveAnnouncer = TestBed.inject(LiveAnnouncer);

--- a/src/angular/notification-toast/notification-toast.zone.spec.ts
+++ b/src/angular/notification-toast/notification-toast.zone.spec.ts
@@ -33,7 +33,7 @@ describe('NotificationToast Zone.js integration', () => {
         DirectiveWithViewContainer,
       ],
       providers: [provideZoneChangeDetection()],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(inject([SbbNotificationToast], (nt: SbbNotificationToast) => {

--- a/src/angular/notification/notification.spec.ts
+++ b/src/angular/notification/notification.spec.ts
@@ -16,7 +16,7 @@ describe('SbbNotification', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, SbbIconTestingModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -37,7 +37,7 @@ describe('SbbNotification', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, SbbIconTestingModule, NotificationMockComponent],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/angular/pagination/navigation/navigation.spec.ts
+++ b/src/angular/pagination/navigation/navigation.spec.ts
@@ -67,7 +67,7 @@ describe('SbbNavigation', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule, RouterTestingModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -88,7 +88,7 @@ describe('SbbNavigation behaviour', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule, RouterTestingModule, NavigationTestComponent],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/angular/pagination/paginator/paginator.spec.ts
+++ b/src/angular/pagination/paginator/paginator.spec.ts
@@ -75,7 +75,7 @@ describe('SbbPaginator', () => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, SbbIconTestingModule, type],
       providers: [...providers],
-    }).compileComponents();
+    });
 
     const fixture = TestBed.createComponent(type);
     fixture.detectChanges();

--- a/src/angular/processflow/processflow.spec.ts
+++ b/src/angular/processflow/processflow.spec.ts
@@ -1361,7 +1361,7 @@ function createComponent<T>(
   TestBed.configureTestingModule({
     imports: [SbbIconTestingModule, NoopAnimationsModule, ...imports, component],
     providers: [{ provide: Directionality, useFactory: () => dir }, ...providers],
-  }).compileComponents();
+  });
 
   return TestBed.createComponent<T>(component);
 }

--- a/src/angular/radio-button-panel/radio-button-panel.spec.ts
+++ b/src/angular/radio-button-panel/radio-button-panel.spec.ts
@@ -74,7 +74,7 @@ describe('SbbRadioButtonPanel', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule],
-    }).compileComponents();
+    });
   }));
 
   describe('multi selection', () => {

--- a/src/angular/search/search.spec.ts
+++ b/src/angular/search/search.spec.ts
@@ -155,7 +155,7 @@ describe('SbbSearch', () => {
           SbbSearchModule,
           SimpleSearchComponent,
         ],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -210,7 +210,7 @@ describe('SbbSearch', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, SbbIconTestingModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -344,7 +344,7 @@ describe('SbbSearch', () => {
       beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
           imports: [NoopAnimationsModule, SbbIconTestingModule, SimpleSearchHeaderComponent],
-        }).compileComponents();
+        });
 
         const overlayContainer = TestBed.inject(OverlayContainer);
         overlayContainerElement = overlayContainer.getContainerElement();

--- a/src/angular/select/select.spec.ts
+++ b/src/angular/select/select.spec.ts
@@ -953,7 +953,7 @@ describe('SbbSelect', () => {
         },
         ...providers,
       ],
-    }).compileComponents();
+    });
 
     overlayContainer = TestBed.inject(OverlayContainer);
     overlayContainerElement = overlayContainer.getContainerElement();

--- a/src/angular/sidebar/icon-sidebar/icon-sidebar.spec.ts
+++ b/src/angular/sidebar/icon-sidebar/icon-sidebar.spec.ts
@@ -44,8 +44,6 @@ describe('SbbIconSidebar', () => {
       providers: [PROVIDE_FAKE_MEDIA_MATCHER],
     });
 
-    TestBed.compileComponents();
-
     inject([MediaMatcher], (fm: FakeMediaMatcher) => {
       mediaMatcher = fm;
     })();
@@ -407,8 +405,6 @@ describe('SbbIconSidebarContainer', () => {
       imports: [NoopAnimationsModule, SbbIconTestingModule],
       providers: [PROVIDE_FAKE_MEDIA_MATCHER],
     });
-
-    TestBed.compileComponents();
 
     inject([MediaMatcher], (fm: FakeMediaMatcher) => {
       mediaMatcher = fm;

--- a/src/angular/sidebar/sidebar/sidebar.spec.ts
+++ b/src/angular/sidebar/sidebar/sidebar.spec.ts
@@ -59,8 +59,6 @@ describe('SbbSidebar', () => {
       imports: [NoopAnimationsModule, SbbIconTestingModule],
       providers: [PROVIDE_FAKE_MEDIA_MATCHER],
     });
-
-    TestBed.compileComponents();
   }));
 
   registerClearMediaMatcher();
@@ -890,8 +888,6 @@ describe('SbbSidebarContainer', () => {
       imports: [NoopAnimationsModule, SbbIconTestingModule],
       providers: [PROVIDE_FAKE_MEDIA_MATCHER],
     });
-
-    TestBed.compileComponents();
   }));
 
   registerClearMediaMatcher();
@@ -1079,8 +1075,6 @@ describe('SbbSidebar Usage', () => {
       ],
       providers: [PROVIDE_FAKE_MEDIA_MATCHER],
     });
-
-    TestBed.compileComponents();
 
     fixture = TestBed.createComponent(SbbSidebarTestComponent);
     sidebar = fixture.debugElement.query(By.directive(SbbSidebar));

--- a/src/angular/status/status.spec.ts
+++ b/src/angular/status/status.spec.ts
@@ -44,7 +44,7 @@ describe('SbbStatus', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule],
-    }).compileComponents();
+    });
   }));
 
   describe('valid', () => {

--- a/src/angular/table/sort/sort.spec.ts
+++ b/src/angular/table/sort/sort.spec.ts
@@ -32,7 +32,7 @@ describe('SbbSort', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -515,7 +515,7 @@ describe('SbbSort', () => {
             },
           },
         ],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -551,7 +551,7 @@ describe('SbbSort', () => {
             },
           },
         ],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/angular/table/table.spec.ts
+++ b/src/angular/table/table.spec.ts
@@ -32,7 +32,7 @@ describe('SbbTable', () => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, SbbIconTestingModule],
       providers: [ViewportRuler, { provide: ViewportRuler, useValue: viewportRulerMock }],
-    }).compileComponents();
+    });
   }));
 
   describe('with basic data source', () => {

--- a/src/angular/table/table/table-data-source.spec.ts
+++ b/src/angular/table/table/table-data-source.spec.ts
@@ -11,7 +11,7 @@ describe('SbbTableDataSource', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, SbbSortApp],
-    }).compileComponents();
+    });
   }));
 
   describe('sort', () => {

--- a/src/angular/tabs/tab-body.spec.ts
+++ b/src/angular/tabs/tab-body.spec.ts
@@ -30,8 +30,6 @@ describe('SbbTabBody', () => {
         { provide: Directionality, useFactory: () => ({ value: dir, change: dirChange }) },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('when initialized as center', () => {

--- a/src/angular/tabs/tab-group.spec.ts
+++ b/src/angular/tabs/tab-group.spec.ts
@@ -25,8 +25,6 @@ describe('SbbTabGroup', () => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, SbbIconTestingModule],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('basic behavior', () => {
@@ -968,8 +966,6 @@ describe('SbbTabNavBar with a default config', () => {
       imports: [BrowserAnimationsModule, SbbIconTestingModule],
       providers: [{ provide: SBB_TABS_CONFIG, useValue: { dynamicHeight: true } }],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(() => {
@@ -987,8 +983,6 @@ describe('nested SbbTabGroup with enabled animations', () => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule, SbbIconTestingModule],
     });
-
-    TestBed.compileComponents();
   }));
 
   it('should not throw when creating a component with nested tab groups', fakeAsync(() => {

--- a/src/angular/tabs/tab-header.spec.ts
+++ b/src/angular/tabs/tab-header.spec.ts
@@ -34,8 +34,6 @@ describe('SbbTabHeader', () => {
       imports: [ScrollingModule, SbbIconTestingModule],
       providers: [ViewportRuler],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('focusing', () => {

--- a/src/angular/tabs/tab-nav-bar.spec.ts
+++ b/src/angular/tabs/tab-nav-bar.spec.ts
@@ -20,8 +20,6 @@ describe('SbbTabNavBar', () => {
         { provide: Directionality, useFactory: () => ({ value: dir, change: dirChange }) },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   describe('basic behavior', () => {

--- a/src/angular/tag/tags.spec.ts
+++ b/src/angular/tag/tags.spec.ts
@@ -563,7 +563,7 @@ describe('SBB Tag Link', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [TagLinkTestFixtureComponent],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -592,7 +592,7 @@ describe('SBB Tag with Icon', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [TagWithIconTextTestFixtureComponent],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/angular/toggle/toggle.spec.ts
+++ b/src/angular/toggle/toggle.spec.ts
@@ -257,7 +257,7 @@ describe('SbbToggle', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, SbbIconTestingModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -344,7 +344,7 @@ describe('SbbToggle', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, SbbIconTestingModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -370,7 +370,7 @@ describe('SbbToggle', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, SbbIconTestingModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -417,7 +417,7 @@ describe('SbbToggle', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, SbbIconTestingModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {
@@ -463,7 +463,7 @@ describe('SbbToggle', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [NoopAnimationsModule, SbbIconTestingModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/angular/tooltip/tooltip-wrapper.spec.ts
+++ b/src/angular/tooltip/tooltip-wrapper.spec.ts
@@ -33,7 +33,7 @@ describe('SbbTooltipWrapper', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [SbbIconTestingModule, NoopAnimationsModule],
-      }).compileComponents();
+      });
 
       inject([OverlayContainer], (oc: OverlayContainer) => {
         overlayContainer = oc;
@@ -266,7 +266,7 @@ describe('SbbTooltipWrapper', () => {
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [SbbIconTestingModule, NoopAnimationsModule],
-      }).compileComponents();
+      });
     }));
 
     beforeEach(() => {

--- a/src/angular/tooltip/tooltip.zone.spec.ts
+++ b/src/angular/tooltip/tooltip.zone.spec.ts
@@ -32,8 +32,6 @@ describe('SbbTooltip Zone.js integration', () => {
         },
       ],
     });
-
-    TestBed.compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/angular/usermenu/usermenu.spec.ts
+++ b/src/angular/usermenu/usermenu.spec.ts
@@ -48,7 +48,7 @@ describe('SbbUsermenu with userName and displayName without image', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule, RouterTestingModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -272,7 +272,7 @@ describe('SbbUsermenu with only displayName', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -303,7 +303,7 @@ describe('SbbUsermenu with only userName', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -334,7 +334,7 @@ describe('SbbUsermenu with custom image', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {
@@ -360,7 +360,7 @@ describe('SbbUsermenu with no connected menu', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [SbbIconTestingModule, NoopAnimationsModule],
-    }).compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/src/journey-maps/angular/components/leit-poi/leit-poi.spec.ts
+++ b/src/journey-maps/angular/components/leit-poi/leit-poi.spec.ts
@@ -6,10 +6,10 @@ describe('LeitPoiComponent', () => {
   let component: SbbLeitPoi;
   let fixture: ComponentFixture<SbbLeitPoi>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       declarations: [SbbLeitPoi],
-    }).compileComponents();
+    });
   });
 
   beforeEach(() => {

--- a/src/journey-maps/angular/components/level-switch/services/level-switcher.spec.ts
+++ b/src/journey-maps/angular/components/level-switch/services/level-switcher.spec.ts
@@ -15,7 +15,7 @@ describe('LevelSwitchService', () => {
   let mapMock: any = {};
   let onZoomChangedCallbackFn: any;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         SbbLevelSwitcher,

--- a/src/journey-maps/angular/journey-maps.spec.ts
+++ b/src/journey-maps/angular/journey-maps.spec.ts
@@ -14,8 +14,8 @@ let component: SbbJourneyMaps;
 let fixture: ComponentFixture<SbbJourneyMaps>;
 
 describe('JourneyMapsClientComponent#selectedMarkerId', () => {
-  beforeEach(async () => {
-    await configureTestingModule();
+  beforeEach(() => {
+    configureTestingModule();
   });
 
   beforeEach(() => {
@@ -47,8 +47,8 @@ describe('JourneyMapsClientComponent#selectedMarkerId', () => {
 
 if (window.TouchEvent) {
   describe('JourneyMapsClientComponent#touchEventCollector', () => {
-    beforeEach(async () => {
-      await configureTestingModule();
+    beforeEach(() => {
+      configureTestingModule();
     });
 
     beforeEach(() => {


### PR DESCRIPTION
Calls to `compileComponent` aren't necessary in the vast majority of cases. These changes clean them up frm our codebase.