### PR TITLE
test(angular/table): fix table tests after CDK update

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "schematics": "./tools/schematics/collection.json",
   "dependencies": {
     "@angular/animations": "19.0.0-rc.0",
-    "@angular/cdk": "19.0.0-next.10",
+    "@angular/cdk": "19.0.0-rc.0",
     "@angular/common": "19.0.0-rc.0",
     "@angular/core": "19.0.0-rc.0",
     "@angular/elements": "19.0.0-rc.0",

--- a/src/angular/table/table.spec.ts
+++ b/src/angular/table/table.spec.ts
@@ -28,6 +28,10 @@ describe('SbbTable', () => {
     change: () => viewPortRulerMockChangeTrigger,
   };
 
+  async function waitForLayout(milliseconds = 0): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
+  }
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, SbbIconTestingModule],
@@ -662,11 +666,10 @@ describe('SbbTable', () => {
     expect(parseInt(columnBLeftOffset, 10)).toBeCloseTo(parseInt(columnAComputedStyles.width, 10));
   }));
 
-  it('should update sticky left offset on viewport change', fakeAsync(() => {
+  it('should update sticky left offset on viewport change', waitForAsync(async () => {
     const fixture = TestBed.createComponent(TableWithTwoStickyColumnsTestComponent);
     fixture.detectChanges();
-    fixture.detectChanges(); // Second change detection needed
-    tick();
+    await fixture.whenStable();
 
     const tableElement = fixture.nativeElement.querySelector('.sbb-table');
 
@@ -682,8 +685,10 @@ describe('SbbTable', () => {
     tableElement.style.width = '200px';
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
+    await waitForLayout(150); // wait for viewportRulerChange
+
     viewPortRulerMockChangeTrigger.next(); // Manually trigger viewportRulerChange
-    tick();
+    await waitForLayout(150); // wait for viewportRulerChange
 
     // Then the left offset should be updated
     columnAComputedStyles = getComputedStyle(

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,10 +324,10 @@
   optionalDependencies:
     lmdb "3.1.3"
 
-"@angular/cdk@19.0.0-next.10":
-  version "19.0.0-next.10"
-  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-19.0.0-next.10.tgz#eea33103c61bd63aebe4af5d3b8eac51ed547291"
-  integrity sha512-yewcnBgaifnpmV92qW9FEUvsuGQDSAfP7kaCRAFgiam458gAnjK0M8gJWzinyHRvH41ytM6/rgpApSj4vXSRMw==
+"@angular/cdk@19.0.0-rc.0":
+  version "19.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-19.0.0-rc.0.tgz#16fec79726f493f6c47b6aa8b3592891aba74fde"
+  integrity sha512-PH1je7FXoooCuzEplz4rCwf5Bri53pdIgQhD162rxFBnwukvaU84jszss1EF0ERqsqGuLAehy4eAeY+GQhHKeQ==
   dependencies:
     tslib "^2.3.0"
   optionalDependencies:


### PR DESCRIPTION
Fix table tests after Angular CDK update. These changes are necessary because the Angular CDK now uses the ResizeObserver for updating sticky columns.

See https://github.com/angular/components/commit/8c52b6d8f14516db3873b6626902ffdf348c006a