### PR TITLE
docs: remove standalone flag from examples

### DIFF
--- a/src/components-examples/angular-experimental/example/basic/basic-example.ts
+++ b/src/components-examples/angular-experimental/example/basic/basic-example.ts
@@ -8,6 +8,5 @@ import { Component } from '@angular/core';
   selector: 'sbb-basic-example',
   templateUrl: 'basic-example.html',
   styleUrls: ['basic-example.css'],
-  standalone: true,
 })
 export class BasicExample {}

--- a/src/components-examples/angular/accordion/accordion-basic/accordion-basic-example.ts
+++ b/src/components-examples/angular/accordion/accordion-basic/accordion-basic-example.ts
@@ -12,7 +12,6 @@ import { SbbCheckboxModule } from '@sbb-esta/angular/checkbox';
   selector: 'sbb-accordion-basic-example',
   templateUrl: 'accordion-basic-example.html',
   styleUrls: ['accordion-basic-example.css'],
-  standalone: true,
   imports: [
     SbbAccordionModule,
     SbbCheckboxModule,

--- a/src/components-examples/angular/accordion/accordion-custom-html/accordion-custom-html-example.ts
+++ b/src/components-examples/angular/accordion/accordion-custom-html/accordion-custom-html-example.ts
@@ -10,7 +10,6 @@ import { SbbButtonModule } from '@sbb-esta/angular/button';
   selector: 'sbb-accordion-custom-html-example',
   templateUrl: 'accordion-custom-html-example.html',
   styleUrls: ['accordion-custom-html-example.css'],
-  standalone: true,
   imports: [SbbAccordionModule, SbbButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/accordion/accordion-nested-panel-lazy-content/accordion-nested-panel-lazy-content-example.ts
+++ b/src/components-examples/angular/accordion/accordion-nested-panel-lazy-content/accordion-nested-panel-lazy-content-example.ts
@@ -8,7 +8,6 @@ import { SbbAccordionModule } from '@sbb-esta/angular/accordion';
 @Component({
   selector: 'sbb-accordion-nested-panel-lazy-content-example',
   templateUrl: 'accordion-nested-panel-lazy-content-example.html',
-  standalone: true,
   imports: [SbbAccordionModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/accordion/accordion-simple-panel/accordion-simple-panel-example.ts
+++ b/src/components-examples/angular/accordion/accordion-simple-panel/accordion-simple-panel-example.ts
@@ -8,7 +8,6 @@ import { SbbAccordionModule } from '@sbb-esta/angular/accordion';
 @Component({
   selector: 'sbb-accordion-simple-panel-example',
   templateUrl: 'accordion-simple-panel-example.html',
-  standalone: true,
   imports: [SbbAccordionModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/accordion/accordion-wizard/accordion-wizard-example.ts
+++ b/src/components-examples/angular/accordion/accordion-wizard/accordion-wizard-example.ts
@@ -10,7 +10,6 @@ import { SbbButtonModule } from '@sbb-esta/angular/button';
   selector: 'sbb-accordion-wizard-example',
   templateUrl: 'accordion-wizard-example.html',
   styleUrls: ['accordion-wizard-example.css'],
-  standalone: true,
   imports: [SbbAccordionModule, SbbButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/alert/alert-external-link/alert-external-link-example.ts
+++ b/src/components-examples/angular/alert/alert-external-link/alert-external-link-example.ts
@@ -8,7 +8,6 @@ import { SbbAlertModule } from '@sbb-esta/angular/alert';
 @Component({
   selector: 'sbb-alert-external-link-example',
   templateUrl: 'alert-external-link-example.html',
-  standalone: true,
   imports: [SbbAlertModule],
 })
 export class AlertExternalLinkExample {}

--- a/src/components-examples/angular/alert/alert-outlet/alert-outlet-example.ts
+++ b/src/components-examples/angular/alert/alert-outlet/alert-outlet-example.ts
@@ -12,7 +12,6 @@ let nextId = 1;
 @Component({
   selector: 'sbb-alert-outlet-example',
   templateUrl: 'alert-outlet-example.html',
-  standalone: true,
   imports: [SbbAlertModule, SbbButtonModule],
 })
 export class AlertOutletExample implements OnInit {

--- a/src/components-examples/angular/alert/alert-router-link/alert-router-link-example.ts
+++ b/src/components-examples/angular/alert/alert-router-link/alert-router-link-example.ts
@@ -9,7 +9,6 @@ import { SbbAlertModule } from '@sbb-esta/angular/alert';
 @Component({
   selector: 'sbb-alert-router-link-example',
   templateUrl: 'alert-router-link-example.html',
-  standalone: true,
   imports: [SbbAlertModule, RouterLink],
 })
 export class AlertRouterLinkExample {}

--- a/src/components-examples/angular/alert/alert-simple/alert-simple-example.ts
+++ b/src/components-examples/angular/alert/alert-simple/alert-simple-example.ts
@@ -8,7 +8,6 @@ import { SbbAlertModule } from '@sbb-esta/angular/alert';
 @Component({
   selector: 'sbb-alert-simple-example',
   templateUrl: 'alert-simple-example.html',
-  standalone: true,
   imports: [SbbAlertModule],
 })
 export class AlertSimpleExample {}

--- a/src/components-examples/angular/autocomplete/autocomplete-display-with/autocomplete-display-with-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-display-with/autocomplete-display-with-example.ts
@@ -20,7 +20,6 @@ interface ExampleOption {
 @Component({
   selector: 'sbb-autocomplete-display-with-example',
   templateUrl: 'autocomplete-display-with-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbInputModule,

--- a/src/components-examples/angular/autocomplete/autocomplete-forms/autocomplete-forms-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-forms/autocomplete-forms-example.ts
@@ -13,7 +13,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-autocomplete-forms-example',
   templateUrl: 'autocomplete-forms-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbInputModule,

--- a/src/components-examples/angular/autocomplete/autocomplete-hint/autocomplete-hint-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-hint/autocomplete-hint-example.ts
@@ -15,7 +15,6 @@ import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 @Component({
   selector: 'sbb-autocomplete-hint-example',
   templateUrl: 'autocomplete-hint-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbInputModule,

--- a/src/components-examples/angular/autocomplete/autocomplete-locale-normalizer/autocomplete-locale-normalizer-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-locale-normalizer/autocomplete-locale-normalizer-example.ts
@@ -12,7 +12,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-autocomplete-locale-normalizer-example',
   templateUrl: 'autocomplete-locale-normalizer-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbInputModule,

--- a/src/components-examples/angular/autocomplete/autocomplete-option-group/autocomplete-option-group-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-option-group/autocomplete-option-group-example.ts
@@ -15,7 +15,6 @@ import { debounceTime, distinctUntilChanged, map, startWith } from 'rxjs/operato
 @Component({
   selector: 'sbb-autocomplete-option-group-example',
   templateUrl: 'autocomplete-option-group-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbInputModule,

--- a/src/components-examples/angular/autocomplete/autocomplete-reactive-forms/autocomplete-reactive-forms-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-reactive-forms/autocomplete-reactive-forms-example.ts
@@ -15,7 +15,6 @@ import { takeUntil } from 'rxjs/operators';
 @Component({
   selector: 'sbb-autocomplete-reactive-forms-example',
   templateUrl: 'autocomplete-reactive-forms-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbInputModule,

--- a/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
+++ b/src/components-examples/angular/autocomplete/autocomplete-require-selection/autocomplete-require-selection-example.ts
@@ -12,7 +12,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-autocomplete-require-selection-example',
   templateUrl: 'autocomplete-require-selection-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbInputModule,

--- a/src/components-examples/angular/badge/badge-overview/badge-overview-example.ts
+++ b/src/components-examples/angular/badge/badge-overview/badge-overview-example.ts
@@ -9,7 +9,6 @@ import { SbbIcon } from '@sbb-esta/angular/icon';
 @Component({
   selector: 'sbb-badge-overview-example',
   templateUrl: 'badge-overview-example.html',
-  standalone: true,
   imports: [SbbBadgeModule, SbbButtonModule, SbbIcon],
 })
 export class BadgeOverviewExample {

--- a/src/components-examples/angular/breadcrumb/breadcrumb-custom-root/breadcrumb-custom-root-example.ts
+++ b/src/components-examples/angular/breadcrumb/breadcrumb-custom-root/breadcrumb-custom-root-example.ts
@@ -9,7 +9,6 @@ import { SbbBreadcrumbModule } from '@sbb-esta/angular/breadcrumb';
 @Component({
   selector: 'sbb-breadcrumb-custom-root-example',
   templateUrl: 'breadcrumb-custom-root-example.html',
-  standalone: true,
   imports: [SbbBreadcrumbModule, RouterLink, RouterLinkActive],
 })
 export class BreadcrumbCustomRootExample {}

--- a/src/components-examples/angular/breadcrumb/breadcrumb-dynamic/breadcrumb-dynamic-example.ts
+++ b/src/components-examples/angular/breadcrumb/breadcrumb-dynamic/breadcrumb-dynamic-example.ts
@@ -20,7 +20,6 @@ interface GroupItem {
 @Component({
   selector: 'sbb-breadcrumb-dynamic-example',
   templateUrl: 'breadcrumb-dynamic-example.html',
-  standalone: true,
   imports: [SbbBreadcrumbModule, RouterLink, SbbMenuModule, RouterLinkActive],
 })
 export class BreadcrumbDynamicExample {

--- a/src/components-examples/angular/breadcrumb/breadcrumb-menu/breadcrumb-menu-example.ts
+++ b/src/components-examples/angular/breadcrumb/breadcrumb-menu/breadcrumb-menu-example.ts
@@ -10,7 +10,6 @@ import { SbbMenuModule } from '@sbb-esta/angular/menu';
 @Component({
   selector: 'sbb-breadcrumb-menu-example',
   templateUrl: 'breadcrumb-menu-example.html',
-  standalone: true,
   imports: [SbbBreadcrumbModule, RouterLink, RouterLinkActive, SbbMenuModule],
 })
 export class BreadcrumbMenuExample {}

--- a/src/components-examples/angular/breadcrumb/breadcrumb/breadcrumb-example.ts
+++ b/src/components-examples/angular/breadcrumb/breadcrumb/breadcrumb-example.ts
@@ -9,7 +9,6 @@ import { SbbBreadcrumbModule } from '@sbb-esta/angular/breadcrumb';
 @Component({
   selector: 'sbb-breadcrumb-example',
   templateUrl: 'breadcrumb-example.html',
-  standalone: true,
   imports: [SbbBreadcrumbModule, RouterLink, RouterLinkActive],
 })
 export class BreadcrumbExample {}

--- a/src/components-examples/angular/button/button-overview/button-overview-example.ts
+++ b/src/components-examples/angular/button/button-overview/button-overview-example.ts
@@ -10,7 +10,6 @@ import { SbbCheckboxModule } from '@sbb-esta/angular/checkbox';
 @Component({
   selector: 'sbb-button-overview-example',
   templateUrl: 'button-overview-example.html',
-  standalone: true,
   imports: [SbbButtonModule, SbbCheckboxModule, FormsModule],
 })
 export class ButtonOverviewExample {

--- a/src/components-examples/angular/button/button-with-icon/button-with-icon-example.ts
+++ b/src/components-examples/angular/button/button-with-icon/button-with-icon-example.ts
@@ -10,7 +10,6 @@ import { SbbIconModule } from '@sbb-esta/angular/icon';
   selector: 'sbb-button-with-icon-example',
   templateUrl: 'button-with-icon-example.html',
   styleUrls: ['button-with-icon-example.css'],
-  standalone: true,
   imports: [SbbButtonModule, SbbIconModule],
 })
 export class ButtonWithIconExample {}

--- a/src/components-examples/angular/button/icon-button/icon-button-example.ts
+++ b/src/components-examples/angular/button/icon-button/icon-button-example.ts
@@ -11,7 +11,6 @@ import { SbbIconModule } from '@sbb-esta/angular/icon';
 @Component({
   selector: 'sbb-icon-button-example',
   templateUrl: 'icon-button-example.html',
-  standalone: true,
   imports: [SbbButtonModule, SbbIconModule, SbbCheckboxModule, FormsModule],
 })
 export class IconButtonExample {

--- a/src/components-examples/angular/button/link-group/link-group-example.ts
+++ b/src/components-examples/angular/button/link-group/link-group-example.ts
@@ -8,7 +8,6 @@ import { SbbButtonModule } from '@sbb-esta/angular/button';
 @Component({
   selector: 'sbb-link-group-example',
   templateUrl: 'link-group-example.html',
-  standalone: true,
   imports: [SbbButtonModule],
 })
 export class LinkGroupExample {}

--- a/src/components-examples/angular/button/link/link-example.ts
+++ b/src/components-examples/angular/button/link/link-example.ts
@@ -8,7 +8,6 @@ import { SbbButtonModule } from '@sbb-esta/angular/button';
 @Component({
   selector: 'sbb-link-example',
   templateUrl: 'link-example.html',
-  standalone: true,
   imports: [SbbButtonModule],
 })
 export class LinkExample {}

--- a/src/components-examples/angular/captcha/captcha-reactive-forms/captcha-reactive-forms-example.ts
+++ b/src/components-examples/angular/captcha/captcha-reactive-forms/captcha-reactive-forms-example.ts
@@ -11,7 +11,6 @@ import { SbbCaptchaModule } from '@sbb-esta/angular/captcha';
   selector: 'sbb-captcha-reactive-forms-example',
   templateUrl: 'captcha-reactive-forms-example.html',
   styleUrls: ['captcha-reactive-forms-example.css'],
-  standalone: true,
   imports: [SbbCaptchaModule, FormsModule, ReactiveFormsModule, JsonPipe],
 })
 export class CaptchaReactiveFormsExample {

--- a/src/components-examples/angular/captcha/captcha-simple/captcha-simple-example.ts
+++ b/src/components-examples/angular/captcha/captcha-simple/captcha-simple-example.ts
@@ -11,7 +11,6 @@ import { SbbCaptchaModule } from '@sbb-esta/angular/captcha';
   selector: 'sbb-captcha-simple-example',
   templateUrl: 'captcha-simple-example.html',
   styleUrls: ['captcha-simple-example.css'],
-  standalone: true,
   imports: [SbbCaptchaModule, SbbButtonModule, JsonPipe],
 })
 export class CaptchaSimpleExample {

--- a/src/components-examples/angular/captcha/captcha-template-driven-forms/captcha-template-driven-forms-example.ts
+++ b/src/components-examples/angular/captcha/captcha-template-driven-forms/captcha-template-driven-forms-example.ts
@@ -11,7 +11,6 @@ import { SbbCaptchaModule } from '@sbb-esta/angular/captcha';
   selector: 'sbb-captcha-template-driven-forms-example',
   templateUrl: 'captcha-template-driven-forms-example.html',
   styleUrls: ['captcha-template-driven-forms-example.css'],
-  standalone: true,
   imports: [SbbCaptchaModule, FormsModule, JsonPipe],
 })
 export class CaptchaTemplateDrivenFormsExample {

--- a/src/components-examples/angular/checkbox-panel/checkbox-panel-content/checkbox-panel-content-example.ts
+++ b/src/components-examples/angular/checkbox-panel/checkbox-panel-content/checkbox-panel-content-example.ts
@@ -10,7 +10,6 @@ import { SbbCheckboxPanelModule } from '@sbb-esta/angular/checkbox-panel';
 @Component({
   selector: 'sbb-checkbox-panel-content-example',
   templateUrl: 'checkbox-panel-content-example.html',
-  standalone: true,
   imports: [SbbCheckboxPanelModule, SbbCheckboxModule, FormsModule],
 })
 export class CheckboxPanelContentExample {

--- a/src/components-examples/angular/checkbox-panel/checkbox-panel-group/checkbox-panel-group-example.ts
+++ b/src/components-examples/angular/checkbox-panel/checkbox-panel-group/checkbox-panel-group-example.ts
@@ -23,7 +23,6 @@ import { startWith, takeUntil } from 'rxjs/operators';
   selector: 'sbb-checkbox-panel-group-example',
   templateUrl: 'checkbox-panel-group-example.html',
   styleUrls: ['checkbox-panel-group-example.css'],
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/checkbox-panel/checkbox-panel-icon/checkbox-panel-icon-example.ts
+++ b/src/components-examples/angular/checkbox-panel/checkbox-panel-icon/checkbox-panel-icon-example.ts
@@ -9,7 +9,6 @@ import { SbbIconModule } from '@sbb-esta/angular/icon';
 @Component({
   selector: 'sbb-checkbox-panel-icon-example',
   templateUrl: 'checkbox-panel-icon-example.html',
-  standalone: true,
   imports: [SbbCheckboxPanelModule, SbbIconModule],
 })
 export class CheckboxPanelIconExample {}

--- a/src/components-examples/angular/checkbox-panel/checkbox-panel-simple/checkbox-panel-simple-example.ts
+++ b/src/components-examples/angular/checkbox-panel/checkbox-panel-simple/checkbox-panel-simple-example.ts
@@ -10,7 +10,6 @@ import { SbbCheckboxPanelModule } from '@sbb-esta/angular/checkbox-panel';
 @Component({
   selector: 'sbb-checkbox-panel-simple-example',
   templateUrl: 'checkbox-panel-simple-example.html',
-  standalone: true,
   imports: [SbbCheckboxPanelModule, FormsModule, ReactiveFormsModule, JsonPipe],
 })
 export class CheckboxPanelSimpleExample {

--- a/src/components-examples/angular/checkbox/checkbox-group-horizontal/checkbox-group-horizontal-example.ts
+++ b/src/components-examples/angular/checkbox/checkbox-group-horizontal/checkbox-group-horizontal-example.ts
@@ -10,7 +10,6 @@ import { SbbCheckboxModule } from '@sbb-esta/angular/checkbox';
 @Component({
   selector: 'sbb-checkbox-group-horizontal-example',
   templateUrl: 'checkbox-group-horizontal-example.html',
-  standalone: true,
   imports: [SbbCheckboxModule, FormsModule, JsonPipe],
 })
 export class CheckboxGroupHorizontalExample {

--- a/src/components-examples/angular/checkbox/checkbox-group-reactive-forms-vertical/checkbox-group-reactive-forms-vertical-example.ts
+++ b/src/components-examples/angular/checkbox/checkbox-group-reactive-forms-vertical/checkbox-group-reactive-forms-vertical-example.ts
@@ -10,7 +10,6 @@ import { SbbCheckboxModule } from '@sbb-esta/angular/checkbox';
 @Component({
   selector: 'sbb-checkbox-group-reactive-forms-vertical-example',
   templateUrl: 'checkbox-group-reactive-forms-vertical-example.html',
-  standalone: true,
   imports: [FormsModule, ReactiveFormsModule, SbbCheckboxModule, JsonPipe, KeyValuePipe],
 })
 export class CheckboxGroupReactiveFormsVerticalExample {

--- a/src/components-examples/angular/checkbox/checkbox-indeterminate-state/checkbox-indeterminate-state-example.ts
+++ b/src/components-examples/angular/checkbox/checkbox-indeterminate-state/checkbox-indeterminate-state-example.ts
@@ -9,7 +9,6 @@ import { SbbCheckboxModule } from '@sbb-esta/angular/checkbox';
 @Component({
   selector: 'sbb-checkbox-indeterminate-state-example',
   templateUrl: 'checkbox-indeterminate-state-example.html',
-  standalone: true,
   imports: [SbbCheckboxModule],
 })
 export class CheckboxIndeterminateStateExample {

--- a/src/components-examples/angular/checkbox/checkbox/checkbox-example.ts
+++ b/src/components-examples/angular/checkbox/checkbox/checkbox-example.ts
@@ -9,7 +9,6 @@ import { SbbCheckboxModule } from '@sbb-esta/angular/checkbox';
 @Component({
   selector: 'sbb-checkbox-example',
   templateUrl: 'checkbox-example.html',
-  standalone: true,
   imports: [SbbCheckboxModule, FormsModule],
 })
 export class CheckboxExample {

--- a/src/components-examples/angular/chips/chips-autocomplete/chips-autocomplete-example.ts
+++ b/src/components-examples/angular/chips/chips-autocomplete/chips-autocomplete-example.ts
@@ -16,7 +16,6 @@ import { map, startWith } from 'rxjs/operators';
 @Component({
   selector: 'sbb-chips-autocomplete-example',
   templateUrl: 'chips-autocomplete-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbChipsModule,

--- a/src/components-examples/angular/chips/chips-drag-drop/chips-drag-drop-example.ts
+++ b/src/components-examples/angular/chips/chips-drag-drop/chips-drag-drop-example.ts
@@ -14,7 +14,6 @@ export interface Fruit {
   selector: 'sbb-chips-drag-drop-example',
   templateUrl: 'chips-drag-drop-example.html',
   styleUrls: ['chips-drag-drop-example.css'],
-  standalone: true,
   imports: [SbbChipsModule, CdkDropList, CdkDrag],
 })
 export class ChipsDragDropExample {

--- a/src/components-examples/angular/chips/chips-input-custom-handler-autocomplete/chips-input-custom-handler-autocomplete-example.ts
+++ b/src/components-examples/angular/chips/chips-input-custom-handler-autocomplete/chips-input-custom-handler-autocomplete-example.ts
@@ -20,7 +20,6 @@ export interface Fruit {
 @Component({
   selector: 'sbb-chips-input-custom-handler-autocomplete-example',
   templateUrl: 'chips-input-custom-handler-autocomplete-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbChipsModule,

--- a/src/components-examples/angular/chips/chips-input-custom-handler/chips-input-custom-handler-example.ts
+++ b/src/components-examples/angular/chips/chips-input-custom-handler/chips-input-custom-handler-example.ts
@@ -24,7 +24,6 @@ const availableFruits: Fruit[] = [
 @Component({
   selector: 'sbb-chips-input-custom-handler-example',
   templateUrl: 'chips-input-custom-handler-example.html',
-  standalone: true,
   imports: [SbbFormFieldModule, SbbChipsModule, FormsModule, ReactiveFormsModule, JsonPipe],
 })
 export class ChipsInputCustomHandlerExample {

--- a/src/components-examples/angular/chips/chips-reactive-forms/chips-reactive-forms-example.ts
+++ b/src/components-examples/angular/chips/chips-reactive-forms/chips-reactive-forms-example.ts
@@ -12,7 +12,6 @@ import { SbbFormFieldModule } from '@sbb-esta/angular/form-field';
 @Component({
   selector: 'sbb-chips-reactive-forms-example',
   templateUrl: 'chips-reactive-forms-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbChipsModule,

--- a/src/components-examples/angular/chips/chips-template-driven-forms/chips-template-driven-forms-example.ts
+++ b/src/components-examples/angular/chips/chips-template-driven-forms/chips-template-driven-forms-example.ts
@@ -12,7 +12,6 @@ import { SbbFormFieldModule } from '@sbb-esta/angular/form-field';
 @Component({
   selector: 'sbb-chips-template-driven-forms-example',
   templateUrl: 'chips-template-driven-forms-example.html',
-  standalone: true,
   imports: [SbbFormFieldModule, SbbChipsModule, FormsModule, SbbButtonModule, JsonPipe],
 })
 export class ChipsTemplateDrivenFormsExample {

--- a/src/components-examples/angular/datepicker/calendar-configuration/calendar-configuration-example.ts
+++ b/src/components-examples/angular/datepicker/calendar-configuration/calendar-configuration-example.ts
@@ -19,7 +19,6 @@ import { filter, map, startWith, takeUntil } from 'rxjs/operators';
   templateUrl: 'calendar-configuration-example.html',
   styleUrls: ['calendar-configuration-example.css'],
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [
     SbbDatepickerModule,
     FormsModule,

--- a/src/components-examples/angular/datepicker/datepicker-date-filter/datepicker-date-filter-example.ts
+++ b/src/components-examples/angular/datepicker/datepicker-date-filter/datepicker-date-filter-example.ts
@@ -12,7 +12,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-datepicker-date-filter-example',
   templateUrl: 'datepicker-date-filter-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbDatepickerModule,

--- a/src/components-examples/angular/datepicker/datepicker-date-range/datepicker-date-range-example.ts
+++ b/src/components-examples/angular/datepicker/datepicker-date-range/datepicker-date-range-example.ts
@@ -12,7 +12,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-datepicker-date-range-example',
   templateUrl: 'datepicker-date-range-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbDatepickerModule,

--- a/src/components-examples/angular/datepicker/datepicker-lean-date-adapter/datepicker-lean-date-adapter-example.ts
+++ b/src/components-examples/angular/datepicker/datepicker-lean-date-adapter/datepicker-lean-date-adapter-example.ts
@@ -14,7 +14,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
   selector: 'sbb-datepicker-lean-date-adapter-example',
   templateUrl: 'datepicker-lean-date-adapter-example.html',
   providers: [provideLeanDateAdapter()],
-  standalone: true,
   imports: [SbbFormFieldModule, SbbDatepickerModule, SbbInputModule, FormsModule, DatePipe],
 })
 export class DatepickerLeanDateAdapterExample {

--- a/src/components-examples/angular/datepicker/datepicker-simple-reactive/datepicker-simple-reactive-example.ts
+++ b/src/components-examples/angular/datepicker/datepicker-simple-reactive/datepicker-simple-reactive-example.ts
@@ -17,7 +17,6 @@ import { takeUntil } from 'rxjs/operators';
 @Component({
   selector: 'sbb-datepicker-simple-reactive-example',
   templateUrl: 'datepicker-simple-reactive-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbDatepickerModule,

--- a/src/components-examples/angular/datepicker/datepicker-standalone-forms/datepicker-standalone-forms-example.ts
+++ b/src/components-examples/angular/datepicker/datepicker-standalone-forms/datepicker-standalone-forms-example.ts
@@ -12,7 +12,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-datepicker-standalone-forms-example',
   templateUrl: 'datepicker-standalone-forms-example.html',
-  standalone: true,
   imports: [SbbFormFieldModule, SbbDatepickerModule, SbbInputModule, FormsModule, DatePipe],
 })
 export class DatepickerStandaloneFormsExample {

--- a/src/components-examples/angular/dialog/component-data-dialog/component-data-dialog-example.ts
+++ b/src/components-examples/angular/dialog/component-data-dialog/component-data-dialog-example.ts
@@ -9,7 +9,6 @@ import { SbbDialog, SbbDialogModule } from '@sbb-esta/angular/dialog';
 @Component({
   selector: 'sbb-component-data-dialog-example',
   templateUrl: 'component-data-dialog-example.html',
-  standalone: true,
   imports: [SbbButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -120,7 +119,6 @@ export class ComponentDataDialogExample {
       <button sbb-secondary-button sbbDialogClose>Cancel</button>
     </div>
   `,
-  standalone: true,
   imports: [SbbDialogModule, SbbButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.ts
+++ b/src/components-examples/angular/dialog/dialog-animations/dialog-animations-example.ts
@@ -10,7 +10,6 @@ import { SbbDialog, SbbDialogModule } from '@sbb-esta/angular/dialog';
   selector: 'sbb-dialog-animations-example',
   styleUrls: ['dialog-animations-example.css'],
   templateUrl: 'dialog-animations-example.html',
-  standalone: true,
   imports: [SbbButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -36,7 +35,6 @@ export class DialogAnimationsExample {
       <button sbb-secondary-button sbbDialogClose>No</button>
     </div>
   `,
-  standalone: true,
   imports: [SbbDialogModule, SbbButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/dialog/shared-data-dialog/shared-data-dialog-example.ts
+++ b/src/components-examples/angular/dialog/shared-data-dialog/shared-data-dialog-example.ts
@@ -22,7 +22,6 @@ export interface DialogData {
 @Component({
   selector: 'sbb-shared-data-dialog-example',
   templateUrl: 'shared-data-dialog-example.html',
-  standalone: true,
   imports: [FormsModule, SbbButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -62,7 +61,6 @@ export class SharedDataDialogExample {
       <button sbb-secondary-button (click)="noThanks()">No Thanks</button>
     </div>
   `,
-  standalone: true,
   imports: [SbbDialogModule, SbbFormFieldModule, SbbInputModule, FormsModule, SbbButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/dialog/template-dialog/template-dialog-example.ts
+++ b/src/components-examples/angular/dialog/template-dialog/template-dialog-example.ts
@@ -9,7 +9,6 @@ import { SbbDialog, SbbDialogModule } from '@sbb-esta/angular/dialog';
 @Component({
   selector: 'sbb-template-dialog-example',
   templateUrl: 'template-dialog-example.html',
-  standalone: true,
   imports: [SbbButtonModule, SbbDialogModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/file-selector/multiple-mode-default-file-selector/multiple-mode-default-file-selector-example.ts
+++ b/src/components-examples/angular/file-selector/multiple-mode-default-file-selector/multiple-mode-default-file-selector-example.ts
@@ -15,7 +15,6 @@ import { takeUntil } from 'rxjs/operators';
 @Component({
   selector: 'sbb-multiple-mode-default-file-selector-example',
   templateUrl: 'multiple-mode-default-file-selector-example.html',
-  standalone: true,
   imports: [SbbFileSelectorModule, FormsModule, ReactiveFormsModule, SbbCheckboxModule, JsonPipe],
 })
 export class MultipleModeDefaultFileSelectorExample implements OnInit, OnDestroy {

--- a/src/components-examples/angular/file-selector/multiple-mode-persistent-file-selector/multiple-mode-persistent-file-selector-example.ts
+++ b/src/components-examples/angular/file-selector/multiple-mode-persistent-file-selector/multiple-mode-persistent-file-selector-example.ts
@@ -11,7 +11,6 @@ import { SbbFileSelectorModule } from '@sbb-esta/angular/file-selector';
 @Component({
   selector: 'sbb-multiple-mode-persistent-file-selector-example',
   templateUrl: 'multiple-mode-persistent-file-selector-example.html',
-  standalone: true,
   imports: [SbbFileSelectorModule, FormsModule, SbbCheckboxModule, JsonPipe],
 })
 export class MultipleModePersistentFileSelectorExample {

--- a/src/components-examples/angular/file-selector/simple-file-selector/simple-file-selector-example.ts
+++ b/src/components-examples/angular/file-selector/simple-file-selector/simple-file-selector-example.ts
@@ -9,7 +9,6 @@ import { SbbFileSelectorModule } from '@sbb-esta/angular/file-selector';
 @Component({
   selector: 'sbb-simple-file-selector-example',
   templateUrl: 'simple-file-selector-example.html',
-  standalone: true,
   imports: [SbbFileSelectorModule, JsonPipe],
 })
 export class SimpleFileSelectorExample {

--- a/src/components-examples/angular/form-field/form-field-datepicker/form-field-datepicker-example.ts
+++ b/src/components-examples/angular/form-field/form-field-datepicker/form-field-datepicker-example.ts
@@ -11,7 +11,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-form-field-datepicker-example',
   templateUrl: 'form-field-datepicker-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbDatepickerModule,

--- a/src/components-examples/angular/form-field/form-field-dirty-error-state/form-field-dirty-error-state-example.ts
+++ b/src/components-examples/angular/form-field/form-field-dirty-error-state/form-field-dirty-error-state-example.ts
@@ -11,7 +11,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-form-field-dirty-error-state-example',
   templateUrl: 'form-field-dirty-error-state-example.html',
-  standalone: true,
   providers: [SbbShowOnDirtyErrorStateMatcher],
   imports: [SbbFormFieldModule, SbbInputModule, FormsModule, ReactiveFormsModule],
 })

--- a/src/components-examples/angular/form-field/form-field-group-vertical/form-field-group-vertical-example.ts
+++ b/src/components-examples/angular/form-field/form-field-group-vertical/form-field-group-vertical-example.ts
@@ -13,7 +13,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-form-field-group-vertical-example',
   templateUrl: 'form-field-group-vertical-example.html',
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/form-field/form-field-group/form-field-group-example.ts
+++ b/src/components-examples/angular/form-field/form-field-group/form-field-group-example.ts
@@ -13,7 +13,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-form-field-group-example',
   templateUrl: 'form-field-group-example.html',
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/form-field/form-field-sbb-select/form-field-sbb-select-example.ts
+++ b/src/components-examples/angular/form-field/form-field-sbb-select/form-field-sbb-select-example.ts
@@ -11,7 +11,6 @@ import { SbbSelectModule } from '@sbb-esta/angular/select';
 @Component({
   selector: 'sbb-form-field-sbb-select-example',
   templateUrl: 'form-field-sbb-select-example.html',
-  standalone: true,
   imports: [SbbFormFieldModule, SbbSelectModule, FormsModule, ReactiveFormsModule, SbbOptionModule],
 })
 export class FormFieldSbbSelectExample {

--- a/src/components-examples/angular/form-field/form-field-select/form-field-select-example.ts
+++ b/src/components-examples/angular/form-field/form-field-select/form-field-select-example.ts
@@ -10,7 +10,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-form-field-select-example',
   templateUrl: 'form-field-select-example.html',
-  standalone: true,
   imports: [SbbFormFieldModule, SbbInputModule, FormsModule, ReactiveFormsModule],
 })
 export class FormFieldSelectExample {

--- a/src/components-examples/angular/form-field/form-field-text-input-attribute-label/form-field-text-input-attribute-label-example.ts
+++ b/src/components-examples/angular/form-field/form-field-text-input-attribute-label/form-field-text-input-attribute-label-example.ts
@@ -13,7 +13,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-form-field-text-input-attribute-label-example',
   templateUrl: 'form-field-text-input-attribute-label-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     NgClass,

--- a/src/components-examples/angular/form-field/form-field-text-input-sbb-label/form-field-text-input-sbb-label-example.ts
+++ b/src/components-examples/angular/form-field/form-field-text-input-sbb-label/form-field-text-input-sbb-label-example.ts
@@ -12,7 +12,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-form-field-text-input-sbb-label-example',
   templateUrl: 'form-field-text-input-sbb-label-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbInputModule,

--- a/src/components-examples/angular/form-field/form-field-textarea-tooltip/form-field-textarea-tooltip-example.ts
+++ b/src/components-examples/angular/form-field/form-field-textarea-tooltip/form-field-textarea-tooltip-example.ts
@@ -10,7 +10,6 @@ import { SbbTooltipModule } from '@sbb-esta/angular/tooltip';
 @Component({
   selector: 'sbb-form-field-textarea-tooltip-example',
   templateUrl: 'form-field-textarea-tooltip-example.html',
-  standalone: true,
   imports: [SbbFormFieldModule, SbbTooltipModule, SbbInputModule],
 })
 export class FormFieldTextareaTooltipExample {}

--- a/src/components-examples/angular/form-field/form-field-time-input/form-field-time-input-example.ts
+++ b/src/components-examples/angular/form-field/form-field-time-input/form-field-time-input-example.ts
@@ -10,7 +10,6 @@ import { SbbTimeInputModule } from '@sbb-esta/angular/time-input';
 @Component({
   selector: 'sbb-form-field-time-input-example',
   templateUrl: 'form-field-time-input-example.html',
-  standalone: true,
   imports: [SbbFormFieldModule, SbbInputModule, SbbTimeInputModule],
 })
 export class FormFieldTimeInputExample {}

--- a/src/components-examples/angular/icon/icon-simple/icon-simple-example.ts
+++ b/src/components-examples/angular/icon/icon-simple/icon-simple-example.ts
@@ -8,7 +8,6 @@ import { SbbIconModule } from '@sbb-esta/angular/icon';
 @Component({
   selector: 'sbb-icon-simple-example',
   templateUrl: 'icon-simple-example.html',
-  standalone: true,
   imports: [SbbIconModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/input/input-error-state-matcher/input-error-state-matcher-example.ts
+++ b/src/components-examples/angular/input/input-error-state-matcher/input-error-state-matcher-example.ts
@@ -27,7 +27,6 @@ export class MyErrorStateMatcher implements SbbErrorStateMatcher {
   selector: 'sbb-input-error-state-matcher-example',
   templateUrl: 'input-error-state-matcher-example.html',
   styleUrls: ['input-error-state-matcher-example.css'],
-  standalone: true,
   imports: [FormsModule, SbbFormFieldModule, SbbInputModule, ReactiveFormsModule],
 })
 export class InputErrorStateMatcherExample {

--- a/src/components-examples/angular/input/input-errors/input-errors-example.ts
+++ b/src/components-examples/angular/input/input-errors/input-errors-example.ts
@@ -11,7 +11,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
   selector: 'sbb-input-errors-example',
   templateUrl: 'input-errors-example.html',
   styleUrls: ['input-errors-example.css'],
-  standalone: true,
   imports: [FormsModule, SbbFormFieldModule, SbbInputModule, ReactiveFormsModule],
 })
 export class InputErrorsExample {

--- a/src/components-examples/angular/input/input-form/input-form-example.ts
+++ b/src/components-examples/angular/input/input-form/input-form-example.ts
@@ -11,7 +11,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
   selector: 'sbb-input-form-example',
   templateUrl: 'input-form-example.html',
   styleUrls: ['input-form-example.css'],
-  standalone: true,
   imports: [FormsModule, SbbFormFieldModule, SbbInputModule],
 })
 export class InputFormExample {}

--- a/src/components-examples/angular/input/input-overview/input-overview-example.ts
+++ b/src/components-examples/angular/input/input-overview/input-overview-example.ts
@@ -11,7 +11,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
   selector: 'sbb-input-overview-example',
   styleUrls: ['input-overview-example.css'],
   templateUrl: 'input-overview-example.html',
-  standalone: true,
   imports: [FormsModule, SbbFormFieldModule, SbbInputModule],
 })
 export class InputOverviewExample {}

--- a/src/components-examples/angular/lightbox/lightbox-animations/lightbox-animations-example.ts
+++ b/src/components-examples/angular/lightbox/lightbox-animations/lightbox-animations-example.ts
@@ -11,7 +11,6 @@ import { SbbLightboxModule } from '@sbb-esta/angular/lightbox';
   selector: 'sbb-lightbox-animations-example',
   styleUrls: ['lightbox-animations-example.css'],
   templateUrl: 'lightbox-animations-example.html',
-  standalone: true,
   imports: [SbbLightboxModule, SbbButtonModule],
 })
 export class LightboxAnimationsExample {
@@ -37,7 +36,6 @@ export class LightboxAnimationsExample {
       <button sbb-secondary-button sbbLightboxClose>No</button>
     </sbb-lightbox-actions>
   `,
-  standalone: true,
   imports: [SbbLightboxModule, SbbButtonModule],
 })
 export class LightboxAnimationsExampleContent {}

--- a/src/components-examples/angular/lightbox/lightbox-component/lightbox-component-example.ts
+++ b/src/components-examples/angular/lightbox/lightbox-component/lightbox-component-example.ts
@@ -10,7 +10,6 @@ import { SbbLightboxModule } from '@sbb-esta/angular/lightbox';
 @Component({
   selector: 'sbb-lightbox-component-example',
   templateUrl: 'lightbox-component-example.html',
-  standalone: true,
   imports: [SbbLightboxModule, SbbButtonModule],
 })
 export class LightboxComponentExample {
@@ -28,7 +27,6 @@ export class LightboxComponentExample {
 @Component({
   selector: 'sbb-lightbox-component-example-content',
   templateUrl: 'lightbox-component-example-content.html',
-  standalone: true,
   imports: [SbbLightboxModule, SbbButtonModule],
 })
 export class LightboxComponentExampleContent {}

--- a/src/components-examples/angular/lightbox/lightbox-confirmation/lightbox-confirmation-example.ts
+++ b/src/components-examples/angular/lightbox/lightbox-confirmation/lightbox-confirmation-example.ts
@@ -16,7 +16,6 @@ import { SbbLightboxModule } from '@sbb-esta/angular/lightbox';
 @Component({
   selector: 'sbb-lightbox-confirmation-example',
   templateUrl: 'lightbox-confirmation-example.html',
-  standalone: true,
   imports: [SbbLightboxModule, SbbButtonModule],
 })
 export class LightboxConfirmationExample {
@@ -52,7 +51,6 @@ export class LightboxConfirmationExample {
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true,
   imports: [SbbLightboxModule, SbbButtonModule],
 })
 export class LightboxWithConfirmationOnClose implements OnInit {

--- a/src/components-examples/angular/lightbox/lightbox-template/lightbox-template-example.ts
+++ b/src/components-examples/angular/lightbox/lightbox-template/lightbox-template-example.ts
@@ -10,7 +10,6 @@ import { SbbLightboxModule } from '@sbb-esta/angular/lightbox';
 @Component({
   selector: 'sbb-lightbox-template-example',
   templateUrl: 'lightbox-template-example.html',
-  standalone: true,
   imports: [SbbButtonModule, SbbLightboxModule],
 })
 export class LightboxTemplateExample {

--- a/src/components-examples/angular/lightbox/lightbox/lightbox-example.ts
+++ b/src/components-examples/angular/lightbox/lightbox/lightbox-example.ts
@@ -22,7 +22,6 @@ export interface LightboxData {
 @Component({
   selector: 'sbb-lightbox-example',
   templateUrl: 'lightbox-example.html',
-  standalone: true,
   imports: [SbbLightboxModule, SbbFormFieldModule, SbbInputModule, FormsModule, SbbButtonModule],
 })
 export class LightboxExample {
@@ -46,7 +45,6 @@ export class LightboxExample {
 @Component({
   selector: 'sbb-lightbox-example-content',
   templateUrl: 'lightbox-example-content.html',
-  standalone: true,
   imports: [SbbLightboxModule, SbbFormFieldModule, SbbInputModule, FormsModule, SbbButtonModule],
 })
 export class LightboxExampleContent {

--- a/src/components-examples/angular/loading-indicator/loading-indicator-fullbox/loading-indicator-fullbox-example.ts
+++ b/src/components-examples/angular/loading-indicator/loading-indicator-fullbox/loading-indicator-fullbox-example.ts
@@ -9,7 +9,6 @@ import { SbbLoadingIndicatorModule } from '@sbb-esta/angular/loading-indicator';
 @Component({
   selector: 'sbb-loading-indicator-fullbox-example',
   templateUrl: 'loading-indicator-fullbox-example.html',
-  standalone: true,
   imports: [SbbLoadingIndicatorModule, SbbButtonModule],
 })
 export class LoadingIndicatorFullboxExample {

--- a/src/components-examples/angular/loading-indicator/loading-indicator-inline/loading-indicator-inline-example.ts
+++ b/src/components-examples/angular/loading-indicator/loading-indicator-inline/loading-indicator-inline-example.ts
@@ -8,7 +8,6 @@ import { SbbLoadingIndicatorModule } from '@sbb-esta/angular/loading-indicator';
 @Component({
   selector: 'sbb-loading-indicator-inline-example',
   templateUrl: 'loading-indicator-inline-example.html',
-  standalone: true,
   imports: [SbbLoadingIndicatorModule],
 })
 export class LoadingIndicatorInlineExample {}

--- a/src/components-examples/angular/loading-indicator/loading-indicator-simple/loading-indicator-simple-example.ts
+++ b/src/components-examples/angular/loading-indicator/loading-indicator-simple/loading-indicator-simple-example.ts
@@ -9,7 +9,6 @@ import { SbbLoadingIndicatorModule } from '@sbb-esta/angular/loading-indicator';
   selector: 'sbb-loading-indicator-simple-example',
   templateUrl: 'loading-indicator-simple-example.html',
   styleUrls: ['loading-indicator-simple-example.css'],
-  standalone: true,
   imports: [SbbLoadingIndicatorModule],
 })
 export class LoadingIndicatorSimpleExample {}

--- a/src/components-examples/angular/menu/menu-grouping/menu-grouping-example.ts
+++ b/src/components-examples/angular/menu/menu-grouping/menu-grouping-example.ts
@@ -8,7 +8,6 @@ import { SbbMenuModule } from '@sbb-esta/angular/menu';
 @Component({
   selector: 'sbb-menu-grouping-example',
   templateUrl: 'menu-grouping-example.html',
-  standalone: true,
   imports: [SbbMenuModule],
 })
 export class MenuGroupingExample {}

--- a/src/components-examples/angular/menu/menu-icons/menu-icons-example.ts
+++ b/src/components-examples/angular/menu/menu-icons/menu-icons-example.ts
@@ -9,7 +9,6 @@ import { SbbMenuModule } from '@sbb-esta/angular/menu';
 @Component({
   selector: 'sbb-menu-icons-example',
   templateUrl: 'menu-icons-example.html',
-  standalone: true,
   imports: [SbbMenuModule, SbbIconModule],
 })
 export class MenuIconsExample {}

--- a/src/components-examples/angular/menu/menu-lazy-rendering/menu-lazy-rendering-example.ts
+++ b/src/components-examples/angular/menu/menu-lazy-rendering/menu-lazy-rendering-example.ts
@@ -8,7 +8,6 @@ import { SbbMenuModule } from '@sbb-esta/angular/menu';
 @Component({
   selector: 'sbb-menu-lazy-rendering-example',
   templateUrl: 'menu-lazy-rendering-example.html',
-  standalone: true,
   imports: [SbbMenuModule],
 })
 export class MenuLazyRenderingExample {}

--- a/src/components-examples/angular/menu/menu-nested/menu-nested-example.ts
+++ b/src/components-examples/angular/menu/menu-nested/menu-nested-example.ts
@@ -8,7 +8,6 @@ import { SbbMenuModule } from '@sbb-esta/angular/menu';
 @Component({
   selector: 'sbb-menu-nested-example',
   templateUrl: 'menu-nested-example.html',
-  standalone: true,
   imports: [SbbMenuModule],
 })
 export class MenuNestedExample {}

--- a/src/components-examples/angular/menu/menu-overview/menu-overview-example.ts
+++ b/src/components-examples/angular/menu/menu-overview/menu-overview-example.ts
@@ -8,7 +8,6 @@ import { SbbMenuModule } from '@sbb-esta/angular/menu';
 @Component({
   selector: 'sbb-menu-overview-example',
   templateUrl: 'menu-overview-example.html',
-  standalone: true,
   imports: [SbbMenuModule],
 })
 export class MenuOverviewExample {}

--- a/src/components-examples/angular/notification-toast/notification-toast-component/notification-toast-component-example.ts
+++ b/src/components-examples/angular/notification-toast/notification-toast-component/notification-toast-component-example.ts
@@ -9,7 +9,6 @@ import { SbbNotificationToast } from '@sbb-esta/angular/notification-toast';
 @Component({
   selector: 'sbb-notification-toast-component-example',
   templateUrl: 'notification-toast-component-example.html',
-  standalone: true,
   imports: [SbbButtonModule],
 })
 export class NotificationToastComponentExample {
@@ -30,6 +29,5 @@ export class NotificationToastComponentExample {
       }
     `,
   ],
-  standalone: true,
 })
 export class ExampleToastComponent {}

--- a/src/components-examples/angular/notification-toast/notification-toast-duration/notification-toast-duration-example.ts
+++ b/src/components-examples/angular/notification-toast/notification-toast-duration/notification-toast-duration-example.ts
@@ -13,7 +13,6 @@ import { SbbNotificationToast } from '@sbb-esta/angular/notification-toast';
   selector: 'sbb-notification-toast-duration-example',
   templateUrl: 'notification-toast-duration-example.html',
   styleUrls: ['notification-toast-duration-example.css'],
-  standalone: true,
   imports: [SbbFormFieldModule, SbbInputModule, FormsModule, SbbButtonModule],
 })
 export class NotificationToastDurationExample {

--- a/src/components-examples/angular/notification-toast/notification-toast-template/notification-toast-template-example.ts
+++ b/src/components-examples/angular/notification-toast/notification-toast-template/notification-toast-template-example.ts
@@ -9,7 +9,6 @@ import { SbbNotificationToast } from '@sbb-esta/angular/notification-toast';
 @Component({
   selector: 'sbb-notification-toast-template-example',
   templateUrl: 'notification-toast-template-example.html',
-  standalone: true,
   imports: [SbbButtonModule],
 })
 export class NotificationToastTemplateExample {

--- a/src/components-examples/angular/notification-toast/simple-notification-toast/simple-notification-toast-example.ts
+++ b/src/components-examples/angular/notification-toast/simple-notification-toast/simple-notification-toast-example.ts
@@ -17,7 +17,6 @@ import {
   selector: 'sbb-simple-notification-toast-example',
   templateUrl: 'simple-notification-toast-example.html',
   styleUrls: ['simple-notification-toast-example.css'],
-  standalone: true,
   imports: [SbbFormFieldModule, SbbInputModule, FormsModule, SbbButtonModule],
 })
 export class SimpleNotificationToastExample {

--- a/src/components-examples/angular/notification/closable-notification/closable-notification-example.ts
+++ b/src/components-examples/angular/notification/closable-notification/closable-notification-example.ts
@@ -8,7 +8,6 @@ import { SbbNotificationModule } from '@sbb-esta/angular/notification';
 @Component({
   selector: 'sbb-closable-notification-example',
   templateUrl: 'closable-notification-example.html',
-  standalone: true,
   imports: [SbbNotificationModule],
 })
 export class ClosableNotificationExample {

--- a/src/components-examples/angular/notification/custom-icon-notification/custom-icon-notification-example.ts
+++ b/src/components-examples/angular/notification/custom-icon-notification/custom-icon-notification-example.ts
@@ -8,7 +8,6 @@ import { SbbNotificationModule } from '@sbb-esta/angular/notification';
 @Component({
   selector: 'sbb-custom-icon-notification-example',
   templateUrl: 'custom-icon-notification-example.html',
-  standalone: true,
   imports: [SbbNotificationModule],
 })
 export class CustomIconNotificationExample {}

--- a/src/components-examples/angular/notification/jumpmark-notification/jumpmark-notification-example.ts
+++ b/src/components-examples/angular/notification/jumpmark-notification/jumpmark-notification-example.ts
@@ -9,7 +9,6 @@ import { SbbNotificationModule } from '@sbb-esta/angular/notification';
 @Component({
   selector: 'sbb-jumpmark-notification-example',
   templateUrl: 'jumpmark-notification-example.html',
-  standalone: true,
   imports: [SbbNotificationModule],
 })
 export class JumpmarkNotificationExample {

--- a/src/components-examples/angular/notification/simple-notification/simple-notification-example.ts
+++ b/src/components-examples/angular/notification/simple-notification/simple-notification-example.ts
@@ -9,7 +9,6 @@ import { SbbNotificationModule } from '@sbb-esta/angular/notification';
   selector: 'sbb-simple-notification-example',
   templateUrl: 'simple-notification-example.html',
   styleUrls: ['simple-notification-example.css'],
-  standalone: true,
   imports: [SbbNotificationModule],
 })
 export class SimpleNotificationExample {}

--- a/src/components-examples/angular/pagination/navigation/navigation-example.ts
+++ b/src/components-examples/angular/pagination/navigation/navigation-example.ts
@@ -14,7 +14,6 @@ import { SbbPaginationModule } from '@sbb-esta/angular/pagination';
   selector: 'sbb-navigation-example',
   templateUrl: 'navigation-example.html',
   styleUrls: ['navigation-example.css'],
-  standalone: true,
   imports: [SbbPaginationModule, SbbFormFieldModule, SbbInputModule, FormsModule, SbbButtonModule],
 })
 export class NavigationExample {

--- a/src/components-examples/angular/pagination/paginator/paginator-example.ts
+++ b/src/components-examples/angular/pagination/paginator/paginator-example.ts
@@ -14,7 +14,6 @@ import { SbbPaginationModule } from '@sbb-esta/angular/pagination';
   selector: 'sbb-paginator-example',
   templateUrl: 'paginator-example.html',
   styleUrls: ['paginator-example.css'],
-  standalone: true,
   imports: [
     SbbPaginationModule,
     SbbFormFieldModule,

--- a/src/components-examples/angular/processflow/processflow-editable/processflow-editable-example.ts
+++ b/src/components-examples/angular/processflow/processflow-editable/processflow-editable-example.ts
@@ -14,7 +14,6 @@ import { SbbProcessflowModule } from '@sbb-esta/angular/processflow';
   selector: 'sbb-processflow-editable-example',
   templateUrl: 'processflow-editable-example.html',
   styleUrls: ['processflow-editable-example.css'],
-  standalone: true,
   imports: [
     SbbProcessflowModule,
     FormsModule,

--- a/src/components-examples/angular/processflow/processflow-lazy-content/processflow-lazy-content-example.ts
+++ b/src/components-examples/angular/processflow/processflow-lazy-content/processflow-lazy-content-example.ts
@@ -9,7 +9,6 @@ import { SbbProcessflowModule } from '@sbb-esta/angular/processflow';
 @Component({
   selector: 'sbb-processflow-lazy-content-example',
   templateUrl: 'processflow-lazy-content-example.html',
-  standalone: true,
   imports: [SbbProcessflowModule, SbbButtonModule],
 })
 export class ProcessflowLazyContentExample {}

--- a/src/components-examples/angular/processflow/processflow-overview/processflow-overview-example.ts
+++ b/src/components-examples/angular/processflow/processflow-overview/processflow-overview-example.ts
@@ -14,7 +14,6 @@ import { SbbProcessflowModule } from '@sbb-esta/angular/processflow';
   selector: 'sbb-processflow-overview-example',
   templateUrl: 'processflow-overview-example.html',
   styleUrls: ['processflow-overview-example.css'],
-  standalone: true,
   imports: [
     SbbProcessflowModule,
     FormsModule,

--- a/src/components-examples/angular/radio-button-panel/radio-button-panel-content/radio-button-panel-content-example.ts
+++ b/src/components-examples/angular/radio-button-panel/radio-button-panel-content/radio-button-panel-content-example.ts
@@ -11,7 +11,6 @@ import { SbbRadioButtonPanelModule } from '@sbb-esta/angular/radio-button-panel'
 @Component({
   selector: 'sbb-radio-button-panel-content-example',
   templateUrl: 'radio-button-panel-content-example.html',
-  standalone: true,
   imports: [SbbRadioButtonModule, SbbRadioButtonPanelModule, SbbCheckboxModule, FormsModule],
 })
 export class RadioButtonPanelContentExample {

--- a/src/components-examples/angular/radio-button-panel/radio-button-panel-group/radio-button-panel-group-example.ts
+++ b/src/components-examples/angular/radio-button-panel/radio-button-panel-group/radio-button-panel-group-example.ts
@@ -18,7 +18,6 @@ import { startWith, takeUntil } from 'rxjs/operators';
   selector: 'sbb-radio-button-panel-group-example',
   templateUrl: 'radio-button-panel-group-example.html',
   styleUrls: ['radio-button-panel-group-example.css'],
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/radio-button-panel/radio-button-panel-icon/radio-button-panel-icon-example.ts
+++ b/src/components-examples/angular/radio-button-panel/radio-button-panel-icon/radio-button-panel-icon-example.ts
@@ -9,7 +9,6 @@ import { SbbRadioButtonPanelModule } from '@sbb-esta/angular/radio-button-panel'
 @Component({
   selector: 'sbb-radio-button-panel-icon-example',
   templateUrl: 'radio-button-panel-icon-example.html',
-  standalone: true,
   imports: [SbbRadioButtonPanelModule, SbbIconModule],
 })
 export class RadioButtonPanelIconExample {}

--- a/src/components-examples/angular/radio-button-panel/radio-button-panel-simple/radio-button-panel-simple-example.ts
+++ b/src/components-examples/angular/radio-button-panel/radio-button-panel-simple/radio-button-panel-simple-example.ts
@@ -11,7 +11,6 @@ import { SbbRadioButtonPanelModule } from '@sbb-esta/angular/radio-button-panel'
 @Component({
   selector: 'sbb-radio-button-panel-simple-example',
   templateUrl: 'radio-button-panel-simple-example.html',
-  standalone: true,
   imports: [
     SbbRadioButtonModule,
     FormsModule,

--- a/src/components-examples/angular/radio-button/radio-button-group-horizontal/radio-button-group-horizontal-example.ts
+++ b/src/components-examples/angular/radio-button/radio-button-group-horizontal/radio-button-group-horizontal-example.ts
@@ -9,7 +9,6 @@ import { SbbRadioButtonModule } from '@sbb-esta/angular/radio-button';
 @Component({
   selector: 'sbb-radio-button-group-horizontal-example',
   templateUrl: 'radio-button-group-horizontal-example.html',
-  standalone: true,
   imports: [SbbRadioButtonModule, FormsModule],
 })
 export class RadioButtonGroupHorizontalExample {

--- a/src/components-examples/angular/radio-button/radio-button-group-reactive-forms-vertical/radio-button-group-reactive-forms-vertical-example.ts
+++ b/src/components-examples/angular/radio-button/radio-button-group-reactive-forms-vertical/radio-button-group-reactive-forms-vertical-example.ts
@@ -9,7 +9,6 @@ import { SbbRadioButtonModule } from '@sbb-esta/angular/radio-button';
 @Component({
   selector: 'sbb-radio-button-group-reactive-forms-vertical-example',
   templateUrl: 'radio-button-group-reactive-forms-vertical-example.html',
-  standalone: true,
   imports: [SbbRadioButtonModule, FormsModule, ReactiveFormsModule],
 })
 export class RadioButtonGroupReactiveFormsVerticalExample {

--- a/src/components-examples/angular/radio-button/radio-button/radio-button-example.ts
+++ b/src/components-examples/angular/radio-button/radio-button/radio-button-example.ts
@@ -12,7 +12,6 @@ import { SbbRadioButtonModule } from '@sbb-esta/angular/radio-button';
 @Component({
   selector: 'sbb-radio-button-example',
   templateUrl: 'radio-button-example.html',
-  standalone: true,
   imports: [SbbRadioButtonModule, SbbCheckboxModule, FormsModule, JsonPipe],
 })
 export class RadioButtonExample {

--- a/src/components-examples/angular/search/search-autocomplete/search-autocomplete-example.ts
+++ b/src/components-examples/angular/search/search-autocomplete/search-autocomplete-example.ts
@@ -13,7 +13,6 @@ import { SbbSearchModule } from '@sbb-esta/angular/search';
 @Component({
   selector: 'sbb-search-autocomplete-example',
   templateUrl: 'search-autocomplete-example.html',
-  standalone: true,
   imports: [
     SbbSearchModule,
     SbbInputModule,

--- a/src/components-examples/angular/search/search-custom-icon-autocomplete-static-options/search-custom-icon-autocomplete-static-options-example.ts
+++ b/src/components-examples/angular/search/search-custom-icon-autocomplete-static-options/search-custom-icon-autocomplete-static-options-example.ts
@@ -15,7 +15,6 @@ import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 @Component({
   selector: 'sbb-search-custom-icon-autocomplete-static-options-example',
   templateUrl: 'search-custom-icon-autocomplete-static-options-example.html',
-  standalone: true,
   imports: [
     SbbSearchModule,
     SbbInputModule,

--- a/src/components-examples/angular/search/search-header-autocomplete/search-header-autocomplete-example.ts
+++ b/src/components-examples/angular/search/search-header-autocomplete/search-header-autocomplete-example.ts
@@ -13,7 +13,6 @@ import { SbbSearchModule } from '@sbb-esta/angular/search';
 @Component({
   selector: 'sbb-search-header-autocomplete-example',
   templateUrl: 'search-header-autocomplete-example.html',
-  standalone: true,
   imports: [
     SbbSearchModule,
     SbbInputModule,

--- a/src/components-examples/angular/search/search-historic-railway-pictures/search-historic-railway-pictures-example.ts
+++ b/src/components-examples/angular/search/search-historic-railway-pictures/search-historic-railway-pictures-example.ts
@@ -26,7 +26,6 @@ interface ImageRecord {
   selector: 'sbb-search-historic-railway-pictures-example',
   templateUrl: 'search-historic-railway-pictures-example.html',
   styleUrls: ['search-historic-railway-pictures-example.css'],
-  standalone: true,
   imports: [
     SbbSearchModule,
     SbbInputModule,

--- a/src/components-examples/angular/search/search-simple-header-mode/search-simple-header-mode-example.ts
+++ b/src/components-examples/angular/search/search-simple-header-mode/search-simple-header-mode-example.ts
@@ -11,7 +11,6 @@ import { SbbSearchModule } from '@sbb-esta/angular/search';
 @Component({
   selector: 'sbb-search-simple-header-mode-example',
   templateUrl: 'search-simple-header-mode-example.html',
-  standalone: true,
   imports: [SbbSearchModule, SbbInputModule, FormsModule, ReactiveFormsModule, JsonPipe],
 })
 export class SearchSimpleHeaderModeExample {

--- a/src/components-examples/angular/search/search-simple-reactive-forms/search-simple-reactive-forms-example.ts
+++ b/src/components-examples/angular/search/search-simple-reactive-forms/search-simple-reactive-forms-example.ts
@@ -11,7 +11,6 @@ import { SbbSearchModule } from '@sbb-esta/angular/search';
 @Component({
   selector: 'sbb-search-simple-reactive-forms-example',
   templateUrl: 'search-simple-reactive-forms-example.html',
-  standalone: true,
   imports: [SbbSearchModule, SbbInputModule, FormsModule, ReactiveFormsModule, JsonPipe],
 })
 export class SearchSimpleReactiveFormsExample {

--- a/src/components-examples/angular/select/select-forms/select-forms-example.ts
+++ b/src/components-examples/angular/select/select-forms/select-forms-example.ts
@@ -13,7 +13,6 @@ import { SbbSelectModule } from '@sbb-esta/angular/select';
 @Component({
   selector: 'sbb-select-forms-example',
   templateUrl: 'select-forms-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbSelectModule,

--- a/src/components-examples/angular/select/select-multi-selection/select-multi-selection-example.ts
+++ b/src/components-examples/angular/select/select-multi-selection/select-multi-selection-example.ts
@@ -13,7 +13,6 @@ import { SbbSelectModule } from '@sbb-esta/angular/select';
 @Component({
   selector: 'sbb-select-multi-selection-example',
   templateUrl: 'select-multi-selection-example.html',
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/select/select-native/select-native-example.ts
+++ b/src/components-examples/angular/select/select-native/select-native-example.ts
@@ -13,7 +13,6 @@ import { SbbTooltipModule } from '@sbb-esta/angular/tooltip';
 @Component({
   selector: 'sbb-select-native-example',
   templateUrl: 'select-native-example.html',
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/select/select-option-groups-multi-selection/select-option-groups-multi-selection-example.ts
+++ b/src/components-examples/angular/select/select-option-groups-multi-selection/select-option-groups-multi-selection-example.ts
@@ -13,7 +13,6 @@ import { SbbSelectModule } from '@sbb-esta/angular/select';
 @Component({
   selector: 'sbb-select-option-groups-multi-selection-example',
   templateUrl: 'select-option-groups-multi-selection-example.html',
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/select/select-option-groups/select-option-groups-example.ts
+++ b/src/components-examples/angular/select/select-option-groups/select-option-groups-example.ts
@@ -13,7 +13,6 @@ import { SbbSelectModule } from '@sbb-esta/angular/select';
 @Component({
   selector: 'sbb-select-option-groups-example',
   templateUrl: 'select-option-groups-example.html',
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/select/select-reactive-forms/select-reactive-forms-example.ts
+++ b/src/components-examples/angular/select/select-reactive-forms/select-reactive-forms-example.ts
@@ -13,7 +13,6 @@ import { SbbSelectModule } from '@sbb-esta/angular/select';
 @Component({
   selector: 'sbb-select-reactive-forms-example',
   templateUrl: 'select-reactive-forms-example.html',
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.ts
+++ b/src/components-examples/angular/sidebar/collapsible-sidebar/collapsible-sidebar-example.ts
@@ -26,7 +26,6 @@ import { startWith, takeUntil } from 'rxjs/operators';
     { provide: MediaMatcher, useExisting: FakeMediaMatcher },
     BreakpointObserver,
   ],
-  standalone: true,
   imports: [
     SbbSidebarModule,
     SbbIconModule,

--- a/src/components-examples/angular/sidebar/icon-sidebar/icon-sidebar-example.ts
+++ b/src/components-examples/angular/sidebar/icon-sidebar/icon-sidebar-example.ts
@@ -24,7 +24,6 @@ import { startWith, takeUntil } from 'rxjs/operators';
     { provide: MediaMatcher, useExisting: FakeMediaMatcher },
     BreakpointObserver,
   ],
-  standalone: true,
   imports: [
     SbbSidebarModule,
     SbbIconModule,

--- a/src/components-examples/angular/sidebar/multiple-sidebars/multiple-sidebars-example.ts
+++ b/src/components-examples/angular/sidebar/multiple-sidebars/multiple-sidebars-example.ts
@@ -23,7 +23,6 @@ import { startWith, takeUntil } from 'rxjs/operators';
     { provide: MediaMatcher, useExisting: FakeMediaMatcher },
     BreakpointObserver,
   ],
-  standalone: true,
   imports: [
     SbbSidebarModule,
     SbbAccordionModule,

--- a/src/components-examples/angular/sidebar/sidebar/sidebar-example.ts
+++ b/src/components-examples/angular/sidebar/sidebar/sidebar-example.ts
@@ -25,7 +25,6 @@ import { startWith, takeUntil } from 'rxjs/operators';
     { provide: MediaMatcher, useExisting: FakeMediaMatcher },
     BreakpointObserver,
   ],
-  standalone: true,
   imports: [
     SbbSidebarModule,
     SbbAccordionModule,

--- a/src/components-examples/angular/status/status-with-message/status-with-message-example.ts
+++ b/src/components-examples/angular/status/status-with-message/status-with-message-example.ts
@@ -8,7 +8,6 @@ import { SbbStatusModule } from '@sbb-esta/angular/status';
 @Component({
   selector: 'sbb-status-with-message-example',
   templateUrl: 'status-with-message-example.html',
-  standalone: true,
   imports: [SbbStatusModule],
 })
 export class StatusWithMessageExample {}

--- a/src/components-examples/angular/status/status/status-example.ts
+++ b/src/components-examples/angular/status/status/status-example.ts
@@ -8,7 +8,6 @@ import { SbbStatusModule } from '@sbb-esta/angular/status';
 @Component({
   selector: 'sbb-status-example',
   templateUrl: 'status-example.html',
-  standalone: true,
   imports: [SbbStatusModule],
 })
 export class StatusExample {}

--- a/src/components-examples/angular/table/buttons-in-table/buttons-in-table-example.ts
+++ b/src/components-examples/angular/table/buttons-in-table/buttons-in-table-example.ts
@@ -11,7 +11,6 @@ import { SbbMenuModule } from '@sbb-esta/angular/menu';
 @Component({
   selector: 'sbb-buttons-in-table-example',
   templateUrl: 'buttons-in-table-example.html',
-  standalone: true,
   imports: [SbbMenuModule, SbbIconModule, SbbButtonModule],
 })
 export class ButtonsInTableExample {}

--- a/src/components-examples/angular/table/cell-actions-table/cell-actions-table-example.ts
+++ b/src/components-examples/angular/table/cell-actions-table/cell-actions-table-example.ts
@@ -17,7 +17,6 @@ interface FocusableRow extends FocusableOption {
 @Component({
   selector: 'sbb-cell-actions-table-example',
   templateUrl: 'cell-actions-table-example.html',
-  standalone: true,
   imports: [SbbTableModule, SbbButtonModule, SbbIconModule],
 })
 export class CellActionsTableExample implements AfterViewInit {

--- a/src/components-examples/angular/table/expandable-table/expandable-table-example.ts
+++ b/src/components-examples/angular/table/expandable-table/expandable-table-example.ts
@@ -10,7 +10,6 @@ import { SbbTableModule } from '@sbb-esta/angular/table';
   selector: 'sbb-expandable-table-example',
   templateUrl: 'expandable-table-example.html',
   styleUrls: ['expandable-table-example.css'],
-  standalone: true,
   imports: [SbbTableModule, SbbIconModule],
 })
 export class ExpandableTableExample {

--- a/src/components-examples/angular/table/filter-sort-paginator-table/filter-sort-paginator-table-example.ts
+++ b/src/components-examples/angular/table/filter-sort-paginator-table/filter-sort-paginator-table-example.ts
@@ -42,7 +42,6 @@ interface VehicleFilter extends SbbTableFilter {
   selector: 'sbb-filter-sort-paginator-table-example',
   styleUrls: ['filter-sort-paginator-table-example.css'],
   templateUrl: 'filter-sort-paginator-table-example.html',
-  standalone: true,
   imports: [
     FormsModule,
     ReactiveFormsModule,

--- a/src/components-examples/angular/table/grouped-columns-table/grouped-columns-table-example.ts
+++ b/src/components-examples/angular/table/grouped-columns-table/grouped-columns-table-example.ts
@@ -9,7 +9,6 @@ import { SbbTableModule } from '@sbb-esta/angular/table';
 @Component({
   selector: 'sbb-grouped-columns-table-example',
   templateUrl: 'grouped-columns-table-example.html',
-  standalone: true,
   imports: [SbbTableModule],
 })
 export class GroupedColumnsTableExample {

--- a/src/components-examples/angular/table/grouped-rows-and-columns-table/grouped-rows-and-columns-table-example.ts
+++ b/src/components-examples/angular/table/grouped-rows-and-columns-table/grouped-rows-and-columns-table-example.ts
@@ -9,7 +9,6 @@ import { SbbTableModule } from '@sbb-esta/angular/table';
 @Component({
   selector: 'sbb-grouped-rows-and-columns-table-example',
   templateUrl: 'grouped-rows-and-columns-table-example.html',
-  standalone: true,
   imports: [SbbTableModule],
 })
 export class GroupedRowsAndColumnsTableExample {

--- a/src/components-examples/angular/table/native-table/native-table-example.ts
+++ b/src/components-examples/angular/table/native-table/native-table-example.ts
@@ -23,7 +23,6 @@ interface RowEntry {
   selector: 'sbb-native-table-example',
   templateUrl: 'native-table-example.html',
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [SbbTableModule, SbbFormFieldModule, SbbInputModule, FormsModule, ReactiveFormsModule],
 })
 export class NativeTableExample implements OnDestroy {

--- a/src/components-examples/angular/table/paginator-table/paginator-table-example.ts
+++ b/src/components-examples/angular/table/paginator-table/paginator-table-example.ts
@@ -24,7 +24,6 @@ interface VehicleExampleItem {
 @Component({
   selector: 'sbb-paginator-table-example',
   templateUrl: 'paginator-table-example.html',
-  standalone: true,
   imports: [SbbTableModule, SbbPaginationModule, SbbFormFieldModule, SbbInputModule, FormsModule],
 })
 export class PaginatorTableExample implements OnInit, OnDestroy {

--- a/src/components-examples/angular/table/selectable-table/selectable-table-example.ts
+++ b/src/components-examples/angular/table/selectable-table/selectable-table-example.ts
@@ -20,7 +20,6 @@ interface VehicleExampleItem {
 @Component({
   selector: 'sbb-selectable-table-example',
   templateUrl: 'selectable-table-example.html',
-  standalone: true,
   imports: [SbbTableModule, SbbCheckboxModule, JsonPipe],
 })
 export class SelectableTableExample {

--- a/src/components-examples/angular/table/simple-table/simple-table-example.ts
+++ b/src/components-examples/angular/table/simple-table/simple-table-example.ts
@@ -9,7 +9,6 @@ import { SbbTableModule } from '@sbb-esta/angular/table';
 @Component({
   selector: 'sbb-simple-table-example',
   templateUrl: 'simple-table-example.html',
-  standalone: true,
   imports: [SbbTableModule],
 })
 export class SimpleTableExample {

--- a/src/components-examples/angular/table/sortable-table/sortable-table-example.ts
+++ b/src/components-examples/angular/table/sortable-table/sortable-table-example.ts
@@ -11,7 +11,6 @@ import { SbbTableModule } from '@sbb-esta/angular/table';
 @Component({
   selector: 'sbb-sortable-table-example',
   templateUrl: 'sortable-table-example.html',
-  standalone: true,
   imports: [SbbTableModule, DatePipe],
 })
 export class SortableTableExample implements AfterViewInit {

--- a/src/components-examples/angular/table/sticky-table/sticky-table-example.ts
+++ b/src/components-examples/angular/table/sticky-table/sticky-table-example.ts
@@ -13,7 +13,6 @@ import { SbbTableModule } from '@sbb-esta/angular/table';
   selector: 'sbb-sticky-table-example',
   styleUrls: ['sticky-table-example.css'],
   templateUrl: 'sticky-table-example.html',
-  standalone: true,
   imports: [SbbTableModule, SbbLoadingIndicatorModule],
 })
 export class StickyTableExample {

--- a/src/components-examples/angular/tabs/tab-group-async/tab-group-async-example.ts
+++ b/src/components-examples/angular/tabs/tab-group-async/tab-group-async-example.ts
@@ -15,7 +15,6 @@ export interface ExampleTab {
 @Component({
   selector: 'sbb-tab-group-async-example',
   templateUrl: 'tab-group-async-example.html',
-  standalone: true,
   imports: [SbbTabsModule, AsyncPipe],
 })
 export class TabGroupAsyncExample {

--- a/src/components-examples/angular/tabs/tab-group-badge/tab-group-badge-example.ts
+++ b/src/components-examples/angular/tabs/tab-group-badge/tab-group-badge-example.ts
@@ -9,7 +9,6 @@ import { SbbTabsModule } from '@sbb-esta/angular/tabs';
 @Component({
   selector: 'sbb-tab-group-badge-example',
   templateUrl: 'tab-group-badge-example.html',
-  standalone: true,
   imports: [SbbTabsModule, SbbBadgeModule],
 })
 export class TabGroupBadgeExample {}

--- a/src/components-examples/angular/tabs/tab-group-basic/tab-group-basic-example.ts
+++ b/src/components-examples/angular/tabs/tab-group-basic/tab-group-basic-example.ts
@@ -8,7 +8,6 @@ import { SbbTabsModule } from '@sbb-esta/angular/tabs';
 @Component({
   selector: 'sbb-tab-group-basic-example',
   templateUrl: 'tab-group-basic-example.html',
-  standalone: true,
   imports: [SbbTabsModule],
 })
 export class TabGroupBasicExample {}

--- a/src/components-examples/angular/tabs/tab-group-custom-label/tab-group-custom-label-example.ts
+++ b/src/components-examples/angular/tabs/tab-group-custom-label/tab-group-custom-label-example.ts
@@ -10,7 +10,6 @@ import { SbbTabsModule } from '@sbb-esta/angular/tabs';
   selector: 'sbb-tab-group-custom-label-example',
   templateUrl: 'tab-group-custom-label-example.html',
   styleUrls: ['tab-group-custom-label-example.css'],
-  standalone: true,
   imports: [SbbTabsModule, SbbIconModule],
 })
 export class TabGroupCustomLabelExample {}

--- a/src/components-examples/angular/tabs/tab-group-dynamic-height/tab-group-dynamic-height-example.ts
+++ b/src/components-examples/angular/tabs/tab-group-dynamic-height/tab-group-dynamic-height-example.ts
@@ -9,7 +9,6 @@ import { SbbTabsModule } from '@sbb-esta/angular/tabs';
   selector: 'sbb-tab-group-dynamic-height-example',
   templateUrl: 'tab-group-dynamic-height-example.html',
   styleUrls: ['tab-group-dynamic-height-example.css'],
-  standalone: true,
   imports: [SbbTabsModule],
 })
 export class TabGroupDynamicHeightExample {}

--- a/src/components-examples/angular/tabs/tab-group-dynamic/tab-group-dynamic-example.ts
+++ b/src/components-examples/angular/tabs/tab-group-dynamic/tab-group-dynamic-example.ts
@@ -14,7 +14,6 @@ import { SbbTabsModule } from '@sbb-esta/angular/tabs';
   selector: 'sbb-tab-group-dynamic-example',
   templateUrl: 'tab-group-dynamic-example.html',
   styleUrls: ['tab-group-dynamic-example.css'],
-  standalone: true,
   imports: [
     SbbTabsModule,
     SbbButtonModule,

--- a/src/components-examples/angular/tabs/tab-group-lazy-loaded/tab-group-lazy-loaded-example.ts
+++ b/src/components-examples/angular/tabs/tab-group-lazy-loaded/tab-group-lazy-loaded-example.ts
@@ -9,7 +9,6 @@ import { SbbTabsModule } from '@sbb-esta/angular/tabs';
 @Component({
   selector: 'sbb-tab-group-lazy-loaded-example',
   templateUrl: 'tab-group-lazy-loaded-example.html',
-  standalone: true,
   imports: [SbbTabsModule, DatePipe],
 })
 export class TabGroupLazyLoadedExample {

--- a/src/components-examples/angular/tabs/tab-group-preserve-content/tab-group-preserve-content-example.ts
+++ b/src/components-examples/angular/tabs/tab-group-preserve-content/tab-group-preserve-content-example.ts
@@ -8,7 +8,6 @@ import { SbbTabsModule } from '@sbb-esta/angular/tabs';
 @Component({
   selector: 'sbb-tab-group-preserve-content-example',
   templateUrl: 'tab-group-preserve-content-example.html',
-  standalone: true,
   imports: [SbbTabsModule],
 })
 export class TabGroupPreserveContentExample {}

--- a/src/components-examples/angular/tabs/tab-nav-bar-basic/tab-nav-bar-basic-example.ts
+++ b/src/components-examples/angular/tabs/tab-nav-bar-basic/tab-nav-bar-basic-example.ts
@@ -10,7 +10,6 @@ import { SbbTabsModule } from '@sbb-esta/angular/tabs';
   selector: 'sbb-tab-nav-bar-basic-example',
   templateUrl: 'tab-nav-bar-basic-example.html',
   styleUrls: ['tab-nav-bar-basic-example.css'],
-  standalone: true,
   imports: [SbbTabsModule, SbbButtonModule],
 })
 export class TabNavBarBasicExample {

--- a/src/components-examples/angular/tag/tag-advanced/tag-advanced-example.ts
+++ b/src/components-examples/angular/tag/tag-advanced/tag-advanced-example.ts
@@ -42,7 +42,6 @@ const tagItems: Tag[] = [
 @Component({
   selector: 'sbb-tag-advanced-example',
   templateUrl: 'tag-advanced-example.html',
-  standalone: true,
   imports: [
     SbbTagModule,
     SbbButtonModule,

--- a/src/components-examples/angular/tag/tag-link/tag-link-example.ts
+++ b/src/components-examples/angular/tag/tag-link/tag-link-example.ts
@@ -9,7 +9,6 @@ import { SbbTagModule } from '@sbb-esta/angular/tag';
 @Component({
   selector: 'sbb-tag-link-example',
   templateUrl: 'tag-link-example.html',
-  standalone: true,
   imports: [SbbTagModule, RouterLink],
 })
 export class TagLinkExample {}

--- a/src/components-examples/angular/tag/tag-reactive-forms/tag-reactive-forms-example.ts
+++ b/src/components-examples/angular/tag/tag-reactive-forms/tag-reactive-forms-example.ts
@@ -10,7 +10,6 @@ import { SbbTagModule } from '@sbb-esta/angular/tag';
 @Component({
   selector: 'sbb-tag-reactive-forms-example',
   templateUrl: 'tag-reactive-forms-example.html',
-  standalone: true,
   imports: [SbbTagModule, FormsModule, ReactiveFormsModule, JsonPipe],
 })
 export class TagReactiveFormsExample {

--- a/src/components-examples/angular/tag/tag-template-forms/tag-template-forms-example.ts
+++ b/src/components-examples/angular/tag/tag-template-forms/tag-template-forms-example.ts
@@ -9,7 +9,6 @@ import { SbbTagModule } from '@sbb-esta/angular/tag';
 @Component({
   selector: 'sbb-tag-template-forms-example',
   templateUrl: 'tag-template-forms-example.html',
-  standalone: true,
   imports: [SbbTagModule, FormsModule],
 })
 export class TagTemplateFormsExample {

--- a/src/components-examples/angular/tag/tag-with-icon/tag-with-icon-example.ts
+++ b/src/components-examples/angular/tag/tag-with-icon/tag-with-icon-example.ts
@@ -9,7 +9,6 @@ import { SbbTagModule } from '@sbb-esta/angular/tag';
 @Component({
   selector: 'sbb-tag-with-icon-example',
   templateUrl: 'tag-with-icon-example.html',
-  standalone: true,
   imports: [SbbTagModule, SbbButtonModule],
 })
 export class TagWithIconExample {}

--- a/src/components-examples/angular/textarea/textarea-forms/textarea-forms-example.ts
+++ b/src/components-examples/angular/textarea/textarea-forms/textarea-forms-example.ts
@@ -14,7 +14,6 @@ import { SbbTextareaModule } from '@sbb-esta/angular/textarea';
   selector: 'sbb-textarea-forms-example',
   templateUrl: 'textarea-forms-example.html',
   styleUrls: ['textarea-forms-example.css'],
-  standalone: true,
   imports: [
     SbbTextareaModule,
     FormsModule,

--- a/src/components-examples/angular/textarea/textarea-native/textarea-native-example.ts
+++ b/src/components-examples/angular/textarea/textarea-native/textarea-native-example.ts
@@ -11,7 +11,6 @@ import { SbbInputModule } from '@sbb-esta/angular/input';
 @Component({
   selector: 'sbb-textarea-native-example',
   templateUrl: 'textarea-native-example.html',
-  standalone: true,
   imports: [SbbFormFieldModule, SbbInputModule, FormsModule, JsonPipe],
 })
 export class TextareaNativeExample {

--- a/src/components-examples/angular/textarea/textarea-reactive-forms-with-sbb-form-field/textarea-reactive-forms-with-sbb-form-field-example.ts
+++ b/src/components-examples/angular/textarea/textarea-reactive-forms-with-sbb-form-field/textarea-reactive-forms-with-sbb-form-field-example.ts
@@ -18,7 +18,6 @@ import { SbbTextareaModule } from '@sbb-esta/angular/textarea';
   selector: 'sbb-textarea-reactive-forms-with-sbb-form-field-example',
   templateUrl: 'textarea-reactive-forms-with-sbb-form-field-example.html',
   styleUrls: ['textarea-reactive-forms-with-sbb-form-field-example.css'],
-  standalone: true,
   imports: [FormsModule, ReactiveFormsModule, SbbFormFieldModule, SbbTextareaModule, JsonPipe],
 })
 export class TextareaReactiveFormsWithSbbFormFieldExample {

--- a/src/components-examples/angular/textexpand/textexpand/textexpand-example.ts
+++ b/src/components-examples/angular/textexpand/textexpand/textexpand-example.ts
@@ -8,7 +8,6 @@ import { SbbTextexpandModule } from '@sbb-esta/angular/textexpand';
 @Component({
   selector: 'sbb-textexpand-example',
   templateUrl: 'textexpand-example.html',
-  standalone: true,
   imports: [SbbTextexpandModule],
 })
 export class TextexpandExample {}

--- a/src/components-examples/angular/time-input/simple-time-input/simple-time-input-example.ts
+++ b/src/components-examples/angular/time-input/simple-time-input/simple-time-input-example.ts
@@ -8,7 +8,6 @@ import { SbbTimeInputModule } from '@sbb-esta/angular/time-input';
 @Component({
   selector: 'sbb-simple-time-input-example',
   templateUrl: 'simple-time-input-example.html',
-  standalone: true,
   imports: [SbbTimeInputModule],
 })
 export class SimpleTimeInputExample {}

--- a/src/components-examples/angular/time-input/time-input-forms/time-input-forms-example.ts
+++ b/src/components-examples/angular/time-input/time-input-forms/time-input-forms-example.ts
@@ -11,7 +11,6 @@ import { SbbTimeInputModule } from '@sbb-esta/angular/time-input';
 @Component({
   selector: 'sbb-time-input-forms-example',
   templateUrl: 'time-input-forms-example.html',
-  standalone: true,
   imports: [SbbFormFieldModule, SbbTimeInputModule, SbbInputModule, FormsModule],
 })
 export class TimeInputFormsExample {

--- a/src/components-examples/angular/time-input/time-input-reactive-forms/time-input-reactive-forms-example.ts
+++ b/src/components-examples/angular/time-input/time-input-reactive-forms/time-input-reactive-forms-example.ts
@@ -12,7 +12,6 @@ import { SbbTimeInputModule } from '@sbb-esta/angular/time-input';
 @Component({
   selector: 'sbb-time-input-reactive-forms-example',
   templateUrl: 'time-input-reactive-forms-example.html',
-  standalone: true,
   imports: [
     SbbFormFieldModule,
     SbbTimeInputModule,

--- a/src/components-examples/angular/toggle/toggle-reactive/toggle-reactive-example.ts
+++ b/src/components-examples/angular/toggle/toggle-reactive/toggle-reactive-example.ts
@@ -15,7 +15,6 @@ import { SbbToggleModule } from '@sbb-esta/angular/toggle';
   selector: 'sbb-toggle-reactive-example',
   templateUrl: 'toggle-reactive-example.html',
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [
     SbbToggleModule,
     FormsModule,

--- a/src/components-examples/angular/toggle/toggle-template-driven/toggle-template-driven-example.ts
+++ b/src/components-examples/angular/toggle/toggle-template-driven/toggle-template-driven-example.ts
@@ -15,7 +15,6 @@ import { SbbToggleModule } from '@sbb-esta/angular/toggle';
   selector: 'sbb-toggle-template-driven-example',
   templateUrl: 'toggle-template-driven-example.html',
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [
     SbbToggleModule,
     FormsModule,

--- a/src/components-examples/angular/toggle/toggle-triple/toggle-triple-example.ts
+++ b/src/components-examples/angular/toggle/toggle-triple/toggle-triple-example.ts
@@ -11,7 +11,6 @@ import { SbbToggleModule } from '@sbb-esta/angular/toggle';
   selector: 'sbb-toggle-triple-example',
   templateUrl: 'toggle-triple-example.html',
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [SbbToggleModule, FormsModule, ReactiveFormsModule, JsonPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/toggle/toggle-without-form/toggle-without-form-example.ts
+++ b/src/components-examples/angular/toggle/toggle-without-form/toggle-without-form-example.ts
@@ -11,7 +11,6 @@ import { SbbToggleModule } from '@sbb-esta/angular/toggle';
   selector: 'sbb-toggle-without-form-example',
   templateUrl: 'toggle-without-form-example.html',
   encapsulation: ViewEncapsulation.None,
-  standalone: true,
   imports: [SbbToggleModule, JsonPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/components-examples/angular/tooltip/tooltip-custom-content/tooltip-custom-content-example.ts
+++ b/src/components-examples/angular/tooltip/tooltip-custom-content/tooltip-custom-content-example.ts
@@ -9,7 +9,6 @@ import { SbbTooltipModule } from '@sbb-esta/angular/tooltip';
 @Component({
   selector: 'sbb-tooltip-custom-content-example',
   templateUrl: 'tooltip-custom-content-example.html',
-  standalone: true,
   imports: [SbbTooltipModule, SbbButtonModule],
 })
 export class TooltipCustomContentExample {}

--- a/src/components-examples/angular/tooltip/tooltip-custom-icon/tooltip-custom-icon-example.ts
+++ b/src/components-examples/angular/tooltip/tooltip-custom-icon/tooltip-custom-icon-example.ts
@@ -8,7 +8,6 @@ import { SbbTooltipModule } from '@sbb-esta/angular/tooltip';
 @Component({
   selector: 'sbb-tooltip-custom-icon-example',
   templateUrl: 'tooltip-custom-icon-example.html',
-  standalone: true,
   imports: [SbbTooltipModule],
 })
 export class TooltipCustomIconExample {}

--- a/src/components-examples/angular/tooltip/tooltip-hover/tooltip-hover-example.ts
+++ b/src/components-examples/angular/tooltip/tooltip-hover/tooltip-hover-example.ts
@@ -11,7 +11,6 @@ import { SbbTooltipModule } from '@sbb-esta/angular/tooltip';
 @Component({
   selector: 'sbb-tooltip-hover-example',
   templateUrl: 'tooltip-hover-example.html',
-  standalone: true,
   imports: [SbbTooltipModule, SbbFormFieldModule, SbbInputModule, FormsModule],
 })
 export class TooltipHoverExample {

--- a/src/components-examples/angular/tooltip/tooltip-simple/tooltip-simple-example.ts
+++ b/src/components-examples/angular/tooltip/tooltip-simple/tooltip-simple-example.ts
@@ -13,7 +13,6 @@ import { SbbTooltipModule, TooltipPosition } from '@sbb-esta/angular/tooltip';
 @Component({
   selector: 'sbb-tooltip-simple-example',
   templateUrl: 'tooltip-simple-example.html',
-  standalone: true,
   imports: [
     SbbTooltipModule,
     SbbFormFieldModule,

--- a/src/components-examples/angular/usermenu/usermenu-custom-icon/usermenu-custom-icon-example.ts
+++ b/src/components-examples/angular/usermenu/usermenu-custom-icon/usermenu-custom-icon-example.ts
@@ -11,7 +11,6 @@ import { SbbUsermenuModule } from '@sbb-esta/angular/usermenu';
 @Component({
   selector: 'sbb-usermenu-custom-icon-example',
   templateUrl: 'usermenu-custom-icon-example.html',
-  standalone: true,
   imports: [SbbUsermenuModule, SbbIconModule, SbbMenuModule, RouterLink, RouterLinkActive],
 })
 export class UsermenuCustomIconExample {

--- a/src/components-examples/angular/usermenu/usermenu-custom-image/usermenu-custom-image-example.ts
+++ b/src/components-examples/angular/usermenu/usermenu-custom-image/usermenu-custom-image-example.ts
@@ -9,7 +9,6 @@ import { SbbUsermenuModule } from '@sbb-esta/angular/usermenu';
 @Component({
   selector: 'sbb-usermenu-custom-image-example',
   templateUrl: 'usermenu-custom-image-example.html',
-  standalone: true,
   imports: [SbbUsermenuModule, SbbMenuModule],
 })
 export class UsermenuCustomImageExample {

--- a/src/components-examples/angular/usermenu/usermenu-display-name-and-user-name/usermenu-display-name-and-user-name-example.ts
+++ b/src/components-examples/angular/usermenu/usermenu-display-name-and-user-name/usermenu-display-name-and-user-name-example.ts
@@ -11,7 +11,6 @@ import { SbbUsermenuModule } from '@sbb-esta/angular/usermenu';
 @Component({
   selector: 'sbb-usermenu-display-name-and-user-name-example',
   templateUrl: 'usermenu-display-name-and-user-name-example.html',
-  standalone: true,
   imports: [SbbUsermenuModule, SbbMenuModule, RouterLink, RouterLinkActive, SbbIconModule],
 })
 export class UsermenuDisplayNameAndUserNameExample {

--- a/src/components-examples/angular/usermenu/usermenu-display-name/usermenu-display-name-example.ts
+++ b/src/components-examples/angular/usermenu/usermenu-display-name/usermenu-display-name-example.ts
@@ -11,7 +11,6 @@ import { SbbUsermenuModule } from '@sbb-esta/angular/usermenu';
 @Component({
   selector: 'sbb-usermenu-display-name-example',
   templateUrl: 'usermenu-display-name-example.html',
-  standalone: true,
   imports: [SbbUsermenuModule, SbbMenuModule, RouterLink, RouterLinkActive, SbbIconModule],
 })
 export class UsermenuDisplayNameExample {

--- a/src/components-examples/angular/usermenu/usermenu-user-name/usermenu-user-name-example.ts
+++ b/src/components-examples/angular/usermenu/usermenu-user-name/usermenu-user-name-example.ts
@@ -11,7 +11,6 @@ import { SbbUsermenuModule } from '@sbb-esta/angular/usermenu';
 @Component({
   selector: 'sbb-usermenu-user-name-example',
   templateUrl: 'usermenu-user-name-example.html',
-  standalone: true,
   imports: [SbbUsermenuModule, SbbMenuModule, RouterLink, RouterLinkActive, SbbIconModule],
 })
 export class UsermenuUserNameExample {

--- a/src/components-examples/journey-maps/angular/journey-maps-basic/journey-maps-basic-example.ts
+++ b/src/components-examples/journey-maps/angular/journey-maps-basic/journey-maps-basic-example.ts
@@ -16,7 +16,6 @@ declare global {
   selector: 'sbb-journey-maps-basic-example',
   templateUrl: 'journey-maps-basic-example.html',
   styleUrls: ['journey-maps-basic-example.css'],
-  standalone: true,
   imports: [SbbJourneyMapsModule, SbbNotificationModule],
 })
 export class JourneyMapsBasicExample {

--- a/src/components-examples/journey-maps/angular/journey-maps-map-navigation/journey-maps-map-navigation-example.ts
+++ b/src/components-examples/journey-maps/angular/journey-maps-map-navigation/journey-maps-map-navigation-example.ts
@@ -30,7 +30,6 @@ declare global {
   selector: 'sbb-journey-maps-map-navigation-example',
   templateUrl: 'journey-maps-map-navigation-example.html',
   styleUrls: ['journey-maps-map-navigation-example.css'],
-  standalone: true,
   imports: [
     SbbJourneyMapsModule,
     SbbNotificationModule,

--- a/src/components-examples/journey-maps/angular/journey-maps-pois-markers/journey-maps-pois-markers-example.ts
+++ b/src/components-examples/journey-maps/angular/journey-maps-pois-markers/journey-maps-pois-markers-example.ts
@@ -34,7 +34,6 @@ declare global {
   selector: 'sbb-journey-maps-pois-markers-example',
   templateUrl: 'journey-maps-pois-markers-example.html',
   styleUrls: ['journey-maps-pois-markers-example.css'],
-  standalone: true,
   imports: [
     SbbJourneyMapsModule,
     SbbNotificationModule,

--- a/src/components-examples/journey-maps/angular/journey-maps-routes-zones/journey-maps-routes-zones-example.ts
+++ b/src/components-examples/journey-maps/angular/journey-maps-routes-zones/journey-maps-routes-zones-example.ts
@@ -46,7 +46,6 @@ declare global {
   selector: 'sbb-journey-maps-routes-zones-example',
   templateUrl: 'journey-maps-routes-zones-example.html',
   styleUrls: ['journey-maps-routes-zones-example.css'],
-  standalone: true,
   imports: [
     SbbJourneyMapsModule,
     SbbNotificationModule,

--- a/src/components-examples/journey-maps/angular/journey-maps-style-options/journey-maps-style-options-example.ts
+++ b/src/components-examples/journey-maps/angular/journey-maps-style-options/journey-maps-style-options-example.ts
@@ -27,7 +27,6 @@ declare global {
   selector: 'sbb-journey-maps-style-options-example',
   templateUrl: 'journey-maps-style-options-example.html',
   styleUrls: ['journey-maps-style-options-example.css'],
-  standalone: true,
   imports: [
     SbbJourneyMapsModule,
     SbbNotificationModule,

--- a/src/components-examples/journey-maps/angular/journey-maps-ui-options/journey-maps-ui-options-example.ts
+++ b/src/components-examples/journey-maps/angular/journey-maps-ui-options/journey-maps-ui-options-example.ts
@@ -29,7 +29,6 @@ declare global {
   selector: 'sbb-journey-maps-ui-options-example',
   templateUrl: 'journey-maps-ui-options-example.html',
   styleUrls: ['journey-maps-ui-options-example.css'],
-  standalone: true,
   imports: [
     SbbJourneyMapsModule,
     SbbNotificationModule,

--- a/src/components-examples/journey-maps/esri-plugin/esri-plugin/esri-plugin-example.ts
+++ b/src/components-examples/journey-maps/esri-plugin/esri-plugin/esri-plugin-example.ts
@@ -20,7 +20,6 @@ declare global {
   selector: 'sbb-esri-plugin-example',
   templateUrl: 'esri-plugin-example.html',
   styleUrls: ['esri-plugin-example.css'],
-  standalone: true,
   imports: [SbbJourneyMapsModule, SbbNotificationModule, SbbEsriPluginModule],
 })
 export class EsriPluginExample {


### PR DESCRIPTION
As of Angular 19, components are standalone by default.