### PR TITLE
refactor(multiple): remove CommonModule imports

### DIFF
--- a/src/angular/accordion/accordion.module.ts
+++ b/src/angular/accordion/accordion.module.ts
@@ -1,6 +1,5 @@
 import { CdkAccordionModule } from '@angular/cdk/accordion';
 import { PortalModule } from '@angular/cdk/portal';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
@@ -12,7 +11,6 @@ import { SbbExpansionPanelHeader } from './expansion-panel-header';
 
 @NgModule({
   imports: [
-    CommonModule,
     CdkAccordionModule,
     PortalModule,
     SbbCommonModule,

--- a/src/angular/autocomplete/autocomplete.module.ts
+++ b/src/angular/autocomplete/autocomplete.module.ts
@@ -1,6 +1,5 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule, SbbOptionModule } from '@sbb-esta/angular/core';
 
@@ -13,7 +12,6 @@ import {
 
 @NgModule({
   imports: [
-    CommonModule,
     A11yModule,
     OverlayModule,
     SbbCommonModule,

--- a/src/angular/button/button.module.ts
+++ b/src/angular/button/button.module.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
@@ -6,7 +5,7 @@ import { SbbIconModule } from '@sbb-esta/angular/icon';
 import { SbbAnchor, SbbButton } from './button';
 
 @NgModule({
-  imports: [CommonModule, SbbCommonModule, SbbIconModule, SbbButton, SbbAnchor],
+  imports: [SbbCommonModule, SbbIconModule, SbbButton, SbbAnchor],
   exports: [SbbButton, SbbAnchor],
 })
 export class SbbButtonModule {}

--- a/src/angular/datepicker/datepicker.module.ts
+++ b/src/angular/datepicker/datepicker.module.ts
@@ -1,7 +1,6 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { provideNativeDateAdapter } from '@sbb-esta/angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
@@ -20,7 +19,6 @@ import { SbbMonthView } from './month-view/month-view';
 
 @NgModule({
   imports: [
-    CommonModule,
     PortalModule,
     A11yModule,
     OverlayModule,

--- a/src/angular/header-lean/header.module.ts
+++ b/src/angular/header-lean/header.module.ts
@@ -1,7 +1,6 @@
 import { ObserversModule } from '@angular/cdk/observers';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
@@ -18,7 +17,6 @@ import {
 
 @NgModule({
   imports: [
-    CommonModule,
     ObserversModule,
     OverlayModule,
     PortalModule,

--- a/src/angular/menu/menu.module.ts
+++ b/src/angular/menu/menu.module.ts
@@ -1,7 +1,6 @@
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
 import { CdkScrollableModule } from '@angular/cdk/scrolling';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
@@ -15,7 +14,6 @@ import { SbbMenuTrigger, SBB_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER } from './men
 
 @NgModule({
   imports: [
-    CommonModule,
     OverlayModule,
     PortalModule,
     SbbCommonModule,

--- a/src/angular/notification/notification.module.ts
+++ b/src/angular/notification/notification.module.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
@@ -7,7 +6,7 @@ import { SbbNotification } from './notification';
 import { SbbNotificationIcon } from './notification-directives';
 
 @NgModule({
-  imports: [CommonModule, SbbCommonModule, SbbIconModule, SbbNotification, SbbNotificationIcon],
+  imports: [SbbCommonModule, SbbIconModule, SbbNotification, SbbNotificationIcon],
   exports: [SbbNotification, SbbNotificationIcon],
 })
 export class SbbNotificationModule {}

--- a/src/angular/processflow/processflow.module.ts
+++ b/src/angular/processflow/processflow.module.ts
@@ -1,6 +1,5 @@
 import { PortalModule } from '@angular/cdk/portal';
 import { CdkStepperModule } from '@angular/cdk/stepper';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
@@ -13,7 +12,6 @@ import { SbbStepLabel } from './step-label';
 
 @NgModule({
   imports: [
-    CommonModule,
     PortalModule,
     CdkStepperModule,
     SbbCommonModule,

--- a/src/angular/search/search.module.ts
+++ b/src/angular/search/search.module.ts
@@ -1,6 +1,5 @@
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbButtonModule } from '@sbb-esta/angular/button';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
@@ -11,7 +10,6 @@ import { SbbSearch } from './search';
 
 @NgModule({
   imports: [
-    CommonModule,
     PortalModule,
     OverlayModule,
     SbbCommonModule,

--- a/src/angular/select/select.module.ts
+++ b/src/angular/select/select.module.ts
@@ -1,5 +1,4 @@
 import { OverlayModule } from '@angular/cdk/overlay';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbOptionModule } from '@sbb-esta/angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
@@ -8,14 +7,7 @@ import { SbbIconModule } from '@sbb-esta/angular/icon';
 import { SbbSelect, SBB_SELECT_SCROLL_STRATEGY_PROVIDER } from './select';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    OverlayModule,
-    SbbCommonModule,
-    SbbIconModule,
-    SbbOptionModule,
-    SbbSelect,
-  ],
+  imports: [OverlayModule, SbbCommonModule, SbbIconModule, SbbOptionModule, SbbSelect],
   exports: [SbbOptionModule, OverlayModule, SbbSelect],
   providers: [SBB_SELECT_SCROLL_STRATEGY_PROVIDER],
 })

--- a/src/angular/status/status.module.ts
+++ b/src/angular/status/status.module.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
@@ -6,7 +5,7 @@ import { SbbIconModule } from '@sbb-esta/angular/icon';
 import { SbbStatus } from './status';
 
 @NgModule({
-  imports: [CommonModule, SbbCommonModule, SbbIconModule, SbbStatus],
+  imports: [SbbCommonModule, SbbIconModule, SbbStatus],
   exports: [SbbStatus],
 })
 export class SbbStatusModule {}

--- a/src/angular/tag/tag.module.ts
+++ b/src/angular/tag/tag.module.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbBadgeModule } from '@sbb-esta/angular/badge';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
@@ -8,7 +7,7 @@ import { SbbTagLink } from './tag-link';
 import { SbbTags } from './tags';
 
 @NgModule({
-  imports: [CommonModule, SbbCommonModule, SbbBadgeModule, SbbTag, SbbTags, SbbTagLink],
+  imports: [SbbCommonModule, SbbBadgeModule, SbbTag, SbbTags, SbbTagLink],
   exports: [SbbTag, SbbTags, SbbTagLink],
 })
 export class SbbTagModule {}

--- a/src/angular/toggle/toggle.spec.ts
+++ b/src/angular/toggle/toggle.spec.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, ContentChildren, QueryList } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -53,12 +53,12 @@ import { SbbToggleModule } from './toggle.module';
   standalone: true,
   imports: [
     SbbToggleModule,
-    CommonModule,
     SbbIconModule,
     SbbDatepickerModule,
     SbbInputModule,
     ReactiveFormsModule,
     SbbIconTestingModule,
+    AsyncPipe,
   ],
 })
 class ToggleReactiveTestComponent {
@@ -178,11 +178,11 @@ class ToggleReactiveDefaultValueTestComponent {
   standalone: true,
   imports: [
     SbbToggleModule,
-    CommonModule,
     SbbIconModule,
     SbbDatepickerModule,
     SbbInputModule,
     FormsModule,
+    AsyncPipe,
   ],
 })
 class ToggleTemplateDrivenTestComponent {

--- a/src/angular/tooltip/tooltip.module.ts
+++ b/src/angular/tooltip/tooltip.module.ts
@@ -2,7 +2,6 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
 import { CdkScrollableModule } from '@angular/cdk/scrolling';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
@@ -17,7 +16,6 @@ import { SbbTooltipWrapper } from './tooltip-wrapper';
 @NgModule({
   imports: [
     A11yModule,
-    CommonModule,
     OverlayModule,
     PortalModule,
     SbbCommonModule,

--- a/src/angular/usermenu/usermenu.module.ts
+++ b/src/angular/usermenu/usermenu.module.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
@@ -8,14 +7,7 @@ import { SbbUsermenu } from './usermenu';
 import { SbbUsermenuIcon } from './usermenu-icon';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    SbbCommonModule,
-    SbbIconModule,
-    SbbMenuModule,
-    SbbUsermenu,
-    SbbUsermenuIcon,
-  ],
+  imports: [SbbCommonModule, SbbIconModule, SbbMenuModule, SbbUsermenu, SbbUsermenuIcon],
   exports: [SbbUsermenu, SbbUsermenuIcon],
 })
 export class SbbUsermenuModule {}

--- a/src/showcase/app/angular/angular.module.ts
+++ b/src/showcase/app/angular/angular.module.ts
@@ -1,5 +1,4 @@
 import { PortalModule } from '@angular/cdk/portal';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { SbbButtonModule } from '@sbb-esta/angular/button';
@@ -29,7 +28,6 @@ import { IconOverviewComponent } from './icon-overview/icon-overview.component';
     CdnIconDialogComponent,
   ],
   imports: [
-    CommonModule,
     PortalModule,
     SharedModule,
     AngularRoutingModule,

--- a/src/showcase/app/shared/shared.module.ts
+++ b/src/showcase/app/shared/shared.module.ts
@@ -1,5 +1,4 @@
 import { PortalModule } from '@angular/cdk/portal';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { SbbAccordionModule } from '@sbb-esta/angular/accordion';
@@ -12,14 +11,7 @@ import { PackageViewerComponent } from './package-viewer/package-viewer.componen
 
 @NgModule({
   declarations: [MarkdownViewerComponent, ModeNotificationToastComponent, PackageViewerComponent],
-  imports: [
-    CommonModule,
-    PortalModule,
-    SbbButtonModule,
-    SbbSidebarModule,
-    SbbAccordionModule,
-    RouterModule,
-  ],
+  imports: [PortalModule, SbbButtonModule, SbbSidebarModule, SbbAccordionModule, RouterModule],
   exports: [MarkdownViewerComponent, PackageViewerComponent],
 })
 export class SharedModule {}


### PR DESCRIPTION
Removes all our imports of `CommonModule` since it wasn't being used for anything.