### PR TITLE
fix(angular/sidebar): remove IE animation workaround

### DIFF
--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -182,7 +182,7 @@
         <source>Close Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">131</context>
+          <context context-type="linenumber">123</context>
         </context-group>
         <note priority="1" from="description">Button label to close the sidebar</note>
       </trans-unit>
@@ -190,7 +190,7 @@
         <source>Open Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">583</context>
+          <context context-type="linenumber">567</context>
         </context-group>
         <note priority="1" from="description">Button label to open the sidebar</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -194,7 +194,7 @@
     </unit>
     <unit id="sbbSidebarCloseSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:131</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:123</note>
         <note category="description">Button label to close the sidebar</note>
       </notes>
       <segment>
@@ -203,7 +203,7 @@
     </unit>
     <unit id="sbbSidebarOpenSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:583</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:567</note>
         <note category="description">Button label to open the sidebar</note>
       </notes>
       <segment>

--- a/src/angular/sidebar/sidebar/sidebar.ts
+++ b/src/angular/sidebar/sidebar/sidebar.ts
@@ -41,15 +41,7 @@ import {
 import { NavigationStart, Router } from '@angular/router';
 import { SbbIcon } from '@sbb-esta/angular/icon';
 import { BehaviorSubject, combineLatest, fromEvent, merge, NEVER, Observable, Subject } from 'rxjs';
-import {
-  distinctUntilChanged,
-  filter,
-  map,
-  mapTo,
-  startWith,
-  take,
-  takeUntil,
-} from 'rxjs/operators';
+import { filter, map, mapTo, startWith, take, takeUntil } from 'rxjs/operators';
 
 import {
   SbbSidebarBase,
@@ -329,24 +321,16 @@ export class SbbSidebar
         );
     });
 
-    // We need a Subject with distinctUntilChanged, because the `done` event
-    // fires twice on some browsers. See https://github.com/angular/angular/issues/24084
-    this._animationEnd
-      .pipe(
-        distinctUntilChanged((x, y) => {
-          return x.fromState === y.fromState && x.toState === y.toState;
-        }),
-      )
-      .subscribe((event: AnimationEvent) => {
-        const { fromState, toState } = event;
+    this._animationEnd.subscribe((event: AnimationEvent) => {
+      const { fromState, toState } = event;
 
-        if (
-          (toState.indexOf('open') === 0 && fromState === 'void') ||
-          (toState === 'void' && fromState.indexOf('open') === 0)
-        ) {
-          this.openedChange.emit(this._opened);
-        }
-      });
+      if (
+        (toState.indexOf('open') === 0 && fromState === 'void') ||
+        (toState === 'void' && fromState.indexOf('open') === 0)
+      ) {
+        this.openedChange.emit(this._opened);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
Removes a workaround that's no longer necessary now that we don't support IE.