### PR TITLE
fix(angular/menu): handle keyboard events through dispatcher

### DIFF
--- a/src/angular/menu/menu-trigger.ts
+++ b/src/angular/menu/menu-trigger.ts
@@ -493,10 +493,11 @@ export class SbbMenuTrigger
       );
       this._overlayRef = this._overlay.create(config);
 
-      // Consume the `keydownEvents` in order to prevent them from going to another overlay.
-      // Ideally we'd also have our keyboard event logic in here, however doing so will
-      // break anybody that may have implemented the `SbbMenuPanel` themselves.
-      this._overlayRef.keydownEvents().subscribe();
+      this._overlayRef.keydownEvents().subscribe((event) => {
+        if (this.menu instanceof SbbMenu) {
+          this.menu._handleKeydown(event);
+        }
+      });
     }
 
     return this._overlayRef;

--- a/src/angular/menu/menu.html
+++ b/src/angular/menu/menu.html
@@ -3,7 +3,6 @@
     class="sbb-menu-panel-wrapper"
     [id]="panelId"
     [class]="_classList"
-    (keydown)="_handleKeydown($event)"
     (click)="closed.emit('click')"
     [@transformMenu]="_panelAnimationState"
     (@transformMenu.start)="_onAnimationStart($event)"

--- a/src/angular/menu/menu.spec.ts
+++ b/src/angular/menu/menu.spec.ts
@@ -490,16 +490,13 @@ describe('SbbMenu', () => {
     fixture.componentInstance.trigger.openMenu();
 
     const panel = overlayContainerElement.querySelector('.sbb-menu-panel-wrapper')!;
-    const event = createKeyboardEvent('keydown', ESCAPE);
-    spyOn(event, 'stopPropagation').and.callThrough();
+    const event = dispatchKeyboardEvent(panel, 'keydown', ESCAPE);
 
-    dispatchEvent(panel, event);
     fixture.detectChanges();
     tick(500);
 
     expect(overlayContainerElement.textContent).toBe('');
     expect(event.defaultPrevented).toBe(true);
-    expect(event.stopPropagation).toHaveBeenCalled();
   }));
 
   it('should not close the menu when pressing ESCAPE with a modifier', fakeAsync(() => {

--- a/src/angular/menu/menu.ts
+++ b/src/angular/menu/menu.ts
@@ -339,10 +339,6 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
         manager.onKeydown(event);
         return;
     }
-
-    // Don't allow the event to propagate if we've already handled it, or it may
-    // end up reaching other overlays that were opened earlier (see angular/components#22694).
-    event.stopPropagation();
   }
 
   /** Whether to display the menu header which mirrors the trigger content. */


### PR DESCRIPTION
Currently `sbb-menu` handles its keyboard events in the template, however this ignores the overlay's stacking context which can capture some events that it shouldn't.

These changes switch the menu to handling the events through the common dispatcher instead.