### PR TITLE
fix(angular): remove final references to ComponentFactoryResolver

### DIFF
--- a/src/angular/dialog/dialog-config.ts
+++ b/src/angular/dialog/dialog-config.ts
@@ -1,5 +1,5 @@
 import { ScrollStrategy } from '@angular/cdk/overlay';
-import { ComponentFactoryResolver, Injector, ViewContainerRef } from '@angular/core';
+import { Injector, ViewContainerRef } from '@angular/core';
 
 import { sbbDialogAnimationsDefaultParams } from './dialog-animations';
 
@@ -115,8 +115,11 @@ export class SbbDialogConfig<D = any> {
    */
   closeOnNavigation?: boolean = true;
 
-  /** Alternate `ComponentFactoryResolver` to use when resolving the associated component. */
-  componentFactoryResolver?: ComponentFactoryResolver;
+  /** Alternate `ComponentFactoryResolver` to use when resolving the associated component.
+   * @deprecated No longer used. Will be removed.
+   * @breaking-change 20.0.0
+   */
+  componentFactoryResolver?: unknown;
 
   /** Duration of the enter animation. Has to be a valid CSS value (e.g. 100ms). */
   enterAnimationDuration?: string = sbbDialogAnimationsDefaultParams.params.enterAnimationDuration;

--- a/src/angular/lightbox/lightbox-config.ts
+++ b/src/angular/lightbox/lightbox-config.ts
@@ -1,5 +1,5 @@
 import { ScrollStrategy } from '@angular/cdk/overlay';
-import { ComponentFactoryResolver, Injector, ViewContainerRef } from '@angular/core';
+import { Injector, ViewContainerRef } from '@angular/core';
 import { SbbDialogRole } from '@sbb-esta/angular/dialog';
 
 import { sbbLightboxAnimationsDefaultParams } from './lightbox-animations';
@@ -68,8 +68,11 @@ export class SbbLightboxConfig<D = any> {
    */
   closeOnNavigation?: boolean = true;
 
-  /** Alternate `ComponentFactoryResolver` to use when resolving the associated component. */
-  componentFactoryResolver?: ComponentFactoryResolver;
+  /** Alternate `ComponentFactoryResolver` to use when resolving the associated component.
+   * @deprecated No longer used. Will be removed.
+   * @breaking-change 20.0.0
+   */
+  componentFactoryResolver?: unknown;
 
   /** Duration of the enter animation. Has to be a valid CSS value (e.g. 100ms). */
   enterAnimationDuration?: string =

--- a/src/angular/menu/menu-content.ts
+++ b/src/angular/menu/menu-content.ts
@@ -3,7 +3,6 @@ import { DOCUMENT } from '@angular/common';
 import {
   ApplicationRef,
   ChangeDetectorRef,
-  ComponentFactoryResolver,
   Directive,
   inject,
   InjectionToken,
@@ -31,7 +30,6 @@ export const SBB_MENU_CONTENT = new InjectionToken<SbbMenuContent>('SbbMenuConte
 })
 export class SbbMenuContent implements OnDestroy {
   private _template = inject<TemplateRef<any>>(TemplateRef);
-  private _componentFactoryResolver = inject(ComponentFactoryResolver);
   private _appRef = inject(ApplicationRef);
   private _injector = inject(Injector);
   private _viewContainerRef = inject(ViewContainerRef);
@@ -61,7 +59,7 @@ export class SbbMenuContent implements OnDestroy {
     if (!this._outlet) {
       this._outlet = new DomPortalOutlet(
         this._document.createElement('div'),
-        this._componentFactoryResolver,
+        null,
         this._appRef,
         this._injector,
       );

--- a/src/angular/tabs/BUILD.bazel
+++ b/src/angular/tabs/BUILD.bazel
@@ -27,7 +27,6 @@ ng_module(
         "//src/angular/icon",
         "@npm//@angular/animations",
         "@npm//@angular/cdk",
-        "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//rxjs",
     ],

--- a/src/angular/tabs/tab-body.ts
+++ b/src/angular/tabs/tab-body.ts
@@ -1,22 +1,18 @@
 import { AnimationEvent } from '@angular/animations';
 import { CdkPortalOutlet, TemplatePortal } from '@angular/cdk/portal';
 import { CdkScrollable } from '@angular/cdk/scrolling';
-import { DOCUMENT } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
-  ComponentFactoryResolver,
   Directive,
   ElementRef,
   EventEmitter,
-  forwardRef,
-  Inject,
+  inject,
   Input,
   OnDestroy,
   OnInit,
   Output,
   ViewChild,
-  ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
 import { Subject, Subscription } from 'rxjs';
@@ -38,18 +34,15 @@ export type SbbTabBodyPositionState = 'hidden' | 'show';
   standalone: true,
 })
 export class SbbTabBodyPortal extends CdkPortalOutlet implements OnInit, OnDestroy {
+  private _host = inject(SbbTabBody);
+
   /** Subscription to events for when the tab body begins centering. */
   private _centeringSub = Subscription.EMPTY;
   /** Subscription to events for when the tab body finishes leaving from center position. */
   private _leavingSub = Subscription.EMPTY;
 
-  constructor(
-    componentFactoryResolver: ComponentFactoryResolver,
-    viewContainerRef: ViewContainerRef,
-    @Inject(forwardRef(() => SbbTabBody)) private _host: SbbTabBody,
-    @Inject(DOCUMENT) _document: any,
-  ) {
-    super(componentFactoryResolver, viewContainerRef, _document);
+  constructor() {
+    super();
   }
 
   /** Set initial visibility or set up subscription for changing visibility. */


### PR DESCRIPTION
Removes the final places where we were referring to `ComponentFactoryResolver` in our SBB Angular code.