### PR TITLE
build: fix preview deployment

### DIFF
--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -83,6 +83,7 @@ jobs:
             ...payload,
             ref: context.payload.workflow_run.head_sha,
             auto_merge: false,
+            required_contexts: ['build', 'packages', 'showcase']
           });
           await github.rest.repos.createDeploymentStatus({
             ...payload,


### PR DESCRIPTION
The call to `github.rest.repos.createDeployment()` fails if any required commit status checks do not have a "success" state (e.g., when "preview-deployment" has a "skipped" state). This change ensures that only relevant contexts are considered, ignoring the others.