### PR TITLE
fix(angular/select): add opt-in input that allows selection of nullable options

### DIFF
--- a/src/angular/select/select.spec.ts
+++ b/src/angular/select/select.spec.ts
@@ -463,7 +463,11 @@ class BasicSelectNoPlaceholder {}
   selector: 'sbb-reset-values-select',
   template: `
     <sbb-form-field>
-      <sbb-select placeholder="Food" [formControl]="control">
+      <sbb-select
+        placeholder="Food"
+        [formControl]="control"
+        [canSelectNullableOptions]="canSelectNullableOptions"
+      >
         @for (food of foods; track food) {
           <sbb-option [value]="food.value">
             {{ food.viewValue }}
@@ -484,7 +488,8 @@ class ResetValuesSelect {
     { viewValue: 'Undefined' },
     { value: null, viewValue: 'Null' },
   ];
-  control = new FormControl('' as string | boolean | null);
+  control = new FormControl('' as string | boolean | null | undefined);
+  canSelectNullableOptions = false;
 
   @ViewChild(SbbSelect) select: SbbSelect;
 }
@@ -4114,7 +4119,7 @@ describe('SbbSelect', () => {
       expect(select.textContent).not.toContain('None');
     }));
 
-    it('should not mark the reset option as selected ', fakeAsync(() => {
+    it('should not mark the reset option as selected', fakeAsync(() => {
       options[5].click();
       fixture.detectChanges();
       flush();
@@ -4144,6 +4149,91 @@ describe('SbbSelect', () => {
       expect(fixture.componentInstance.select.selected).toBeFalsy();
       expect(select.textContent).not.toContain('Null');
       expect(select.textContent).not.toContain('Undefined');
+    });
+  });
+
+  describe('allowing selection of nullable options', () => {
+    beforeEach(waitForAsync(() => configureSbbSelectTestingModule([ResetValuesSelect])));
+
+    let fixture: ComponentFixture<ResetValuesSelect>;
+    let trigger: HTMLElement;
+    let options: NodeListOf<HTMLElement>;
+
+    beforeEach(fakeAsync(() => {
+      fixture = TestBed.createComponent(ResetValuesSelect);
+      fixture.componentInstance.canSelectNullableOptions = true;
+      fixture.detectChanges();
+      trigger = fixture.debugElement.query(By.css('.sbb-select'))!.nativeElement;
+
+      trigger.click();
+      fixture.detectChanges();
+      flush();
+
+      options = overlayContainerElement.querySelectorAll('sbb-option') as NodeListOf<HTMLElement>;
+      options[0].click();
+      fixture.detectChanges();
+      flush();
+    }));
+
+    it('should select an option with an undefined value', fakeAsync(() => {
+      options[4].click();
+      fixture.detectChanges();
+      flush();
+
+      expect(fixture.componentInstance.control.value).toBe(undefined);
+      expect(fixture.componentInstance.select.selected).toBeTruthy();
+      expect(trigger.textContent).toContain('Undefined');
+    }));
+
+    it('should select an option with a null value', fakeAsync(() => {
+      options[5].click();
+      fixture.detectChanges();
+      flush();
+
+      expect(fixture.componentInstance.control.value).toBe(null);
+      expect(fixture.componentInstance.select.selected).toBeTruthy();
+      expect(trigger.textContent).toContain('Null');
+    }));
+
+    it('should select a blank option', fakeAsync(() => {
+      options[6].click();
+      fixture.detectChanges();
+      flush();
+
+      expect(fixture.componentInstance.control.value).toBe(undefined);
+      expect(fixture.componentInstance.select.selected).toBeTruthy();
+      expect(trigger.textContent).toContain('None');
+    }));
+
+    it('should mark a nullable option as selected', fakeAsync(() => {
+      options[5].click();
+      fixture.detectChanges();
+      flush();
+
+      fixture.componentInstance.select.open();
+      fixture.detectChanges();
+      flush();
+
+      expect(options[5].classList).toContain('sbb-selected');
+    }));
+
+    it('should not reset when any other falsy option is selected', fakeAsync(() => {
+      options[3].click();
+      fixture.detectChanges();
+      flush();
+
+      expect(fixture.componentInstance.control.value).toBe(false);
+      expect(fixture.componentInstance.select.selected).toBeTruthy();
+      expect(trigger.textContent).toContain('Falsy');
+    }));
+
+    it('should consider the nullable values as selected when resetting the form control', () => {
+      fixture.componentInstance.control.reset();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.control.value).toBe(null);
+      expect(fixture.componentInstance.select.selected).toBeTruthy();
+      expect(trigger.textContent).toContain('Null');
     });
   });
 

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -110,6 +110,12 @@ export interface SbbSelectConfig {
 
   /** Class or list of classes to be applied to the menu's overlay panel. */
   overlayPanelClass?: string | string[];
+
+  /**
+   * Whether nullable options can be selected by default.
+   * See `MatSelect.canSelectNullableOptions` for more information.
+   */
+  canSelectNullableOptions?: boolean;
 }
 
 /** Injection token that can be used to provide the default options the select module. */
@@ -194,6 +200,7 @@ export class SbbSelect
   ngControl: NgControl = inject(NgControl, { self: true, optional: true })!;
   private _liveAnnouncer = inject(LiveAnnouncer);
   private _defaultOptions = inject<SbbSelectConfig>(SBB_SELECT_CONFIG, { optional: true });
+  private _initialized = new Subject<void>();
 
   /** The scroll position of the overlay panel, calculated to center the selected option. */
   private _scrollTop = 0;
@@ -462,7 +469,14 @@ export class SbbSelect
     this._errorStateTracker.errorState = value;
   }
 
-  private _initialized = new Subject<void>();
+  /**
+   * By default selecting an option with a `null` or `undefined` value will reset the select's
+   * value. Enable this option if the reset behavior doesn't match your requirements and instead
+   * the nullable options should become selected. The value of this input can be controlled app-wide
+   * using the `MAT_SELECT_CONFIG` injection token.
+   */
+  @Input({ transform: booleanAttribute })
+  canSelectNullableOptions: boolean = this._defaultOptions?.canSelectNullableOptions ?? false;
 
   /** Combined stream of all of the child options' change events. */
   readonly optionSelectionChanges: Observable<SbbOptionSelectionChange> = defer(() => {
@@ -947,7 +961,10 @@ export class SbbSelect
 
       try {
         // Treat null as a special reset value.
-        return option.value != null && this._compareWith(option.value, value);
+        return (
+          (option.value != null || this.canSelectNullableOptions) &&
+          this._compareWith(option.value, value)
+        );
       } catch (error) {
         if (typeof ngDevMode === 'undefined' || ngDevMode) {
           // Notify developers of errors in their comparator.
@@ -1042,7 +1059,7 @@ export class SbbSelect
   private _onSelect(option: SbbOption, isUserInput: boolean): void {
     const wasSelected = this._selectionModel.isSelected(option);
 
-    if (option.value == null && !this._multiple) {
+    if (!this.canSelectNullableOptions && option.value == null && !this._multiple) {
       option.deselect();
       this._selectionModel.clear();
 

--- a/src/components-examples/angular/select/index.ts
+++ b/src/components-examples/angular/select/index.ts
@@ -4,3 +4,4 @@ export { SelectNativeExample } from './select-native/select-native-example';
 export { SelectOptionGroupsMultiSelectionExample } from './select-option-groups-multi-selection/select-option-groups-multi-selection-example';
 export { SelectOptionGroupsExample } from './select-option-groups/select-option-groups-example';
 export { SelectReactiveFormsExample } from './select-reactive-forms/select-reactive-forms-example';
+export { SelectSelectableNullExample } from './select-selectable-null/select-selectable-null-example';

--- a/src/components-examples/angular/select/select-selectable-null/select-selectable-null-example.html
+++ b/src/components-examples/angular/select/select-selectable-null/select-selectable-null-example.html
@@ -1,0 +1,19 @@
+<h4>Select allowing selection of nullable options</h4>
+<sbb-form-field>
+  <sbb-label>Number</sbb-label>
+  <sbb-select [(ngModel)]="value" canSelectNullableOptions>
+    @for (option of options; track option) {
+      <sbb-option [value]="option.value">{{ option.label }}</sbb-option>
+    }
+  </sbb-select>
+</sbb-form-field>
+
+<h4>Select with default configuration</h4>
+<sbb-form-field>
+  <sbb-label>Number</sbb-label>
+  <sbb-select [(ngModel)]="value">
+    @for (option of options; track option) {
+      <sbb-option [value]="option.value">{{ option.label }}</sbb-option>
+    }
+  </sbb-select>
+</sbb-form-field>

--- a/src/components-examples/angular/select/select-selectable-null/select-selectable-null-example.ts
+++ b/src/components-examples/angular/select/select-selectable-null/select-selectable-null-example.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SbbFormFieldModule } from '@sbb-esta/angular/form-field';
+import { SbbSelectModule } from '@sbb-esta/angular/select';
+
+/**
+ * @title Select with selectable null options
+ * @order 70
+ */
+@Component({
+  selector: 'sbb-select-selectable-null-example',
+  templateUrl: 'select-selectable-null-example.html',
+  imports: [FormsModule, SbbFormFieldModule, SbbSelectModule],
+})
+export class SelectSelectableNullExample {
+  value: number | null = null;
+
+  options = [
+    { label: 'None', value: null },
+    { label: 'One', value: 1 },
+    { label: 'Two', value: 2 },
+    { label: 'Three', value: 3 },
+  ];
+}


### PR DESCRIPTION
By default, `sbb-select` treats options with nullable values as "reset options", meaning that they can't be selected, but rather they clear the select's value. This behavior is based on how the native `select` works, however in some cases it's not desirable. These changes add an input that users can use to opt out of the default behavior.