### PR TITLE
fix(angular/accordion): prevent focus from entering the panel while it's animating

### DIFF
--- a/src/angular/accordion/expansion-panel.html
+++ b/src/angular/accordion/expansion-panel.html
@@ -3,7 +3,8 @@
   class="sbb-expansion-panel-content"
   role="region"
   [@bodyExpansion]="_getExpandedState()"
-  (@bodyExpansion.done)="_bodyAnimationDone.next($event)"
+  (@bodyExpansion.start)="_animationStarted($event)"
+  (@bodyExpansion.done)="_animationDone($event)"
   [attr.aria-labelledby]="_headerId"
   [id]="id"
   #body


### PR DESCRIPTION
Currently, the expansion panel prevents focus from entering it using `visibility: hidden`, but that only works when it's closed. This means that if the user tabs into it while it's animating, they may scroll the content make the component look broken.

These changes resolve the issue by setting `inert` on the panel content while it's animating. Also cleans up an old workaround for IE.