### PR TITLE
fix(angular/accordion): switch away from animations module

### DIFF
--- a/src/angular/accordion/accordion-animations.ts
+++ b/src/angular/accordion/accordion-animations.ts
@@ -32,6 +32,8 @@ export const SBB_EXPANSION_PANEL_ANIMATION_TIMING = '225ms cubic-bezier(0.4,0.0,
  * Angular Bug: https://github.com/angular/angular/issues/18847
  *
  * @docs-private
+ * @deprecated No longer being used, to be removed.
+ * @breaking-change 21.0.0
  */
 export const sbbExpansionAnimations: {
   readonly indicatorRotate: AnimationTriggerMetadata;

--- a/src/angular/accordion/expansion-panel-header.html
+++ b/src/angular/accordion/expansion-panel-header.html
@@ -15,7 +15,7 @@
         }
       }
       @default {
-        <sbb-icon [@indicatorRotate]="_getExpandedState()" svgIcon="chevron-right-small"></sbb-icon>
+        <sbb-icon svgIcon="chevron-right-small"></sbb-icon>
       }
     }
   </span>

--- a/src/angular/accordion/expansion-panel-header.ts
+++ b/src/angular/accordion/expansion-panel-header.ts
@@ -20,7 +20,6 @@ import { SbbIconModule } from '@sbb-esta/angular/icon';
 import { EMPTY, merge, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { sbbExpansionAnimations } from './accordion-animations';
 import { SbbExpansionPanel } from './expansion-panel';
 
 /**
@@ -32,7 +31,6 @@ import { SbbExpansionPanel } from './expansion-panel';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   inputs: ['tabIndex'],
-  animations: [sbbExpansionAnimations.indicatorRotate],
   host: {
     class: 'sbb-expansion-panel-header sbb-expansion-panel-horizontal-padding',
     role: 'button',

--- a/src/angular/accordion/expansion-panel.html
+++ b/src/angular/accordion/expansion-panel.html
@@ -1,16 +1,15 @@
 <ng-content select="sbb-expansion-panel-header"></ng-content>
-<div
-  class="sbb-expansion-panel-content"
-  role="region"
-  [@bodyExpansion]="_getExpandedState()"
-  (@bodyExpansion.start)="_animationStarted($event)"
-  (@bodyExpansion.done)="_animationDone($event)"
-  [attr.aria-labelledby]="_headerId"
-  [id]="id"
-  #body
->
-  <div class="sbb-expansion-panel-body sbb-expansion-panel-horizontal-padding">
-    <ng-content></ng-content>
-    <ng-template [cdkPortalOutlet]="_portal"></ng-template>
+<div class="sbb-expansion-panel-content-wrapper" [attr.inert]="expanded ? null : ''" #bodyWrapper>
+  <div
+    class="sbb-expansion-panel-content"
+    role="region"
+    [attr.aria-labelledby]="_headerId"
+    [id]="id"
+    #body
+  >
+    <div class="sbb-expansion-panel-body sbb-expansion-panel-horizontal-padding">
+      <ng-content></ng-content>
+      <ng-template [cdkPortalOutlet]="_portal"></ng-template>
+    </div>
   </div>
 </div>

--- a/src/angular/accordion/expansion-panel.scss
+++ b/src/angular/accordion/expansion-panel.scss
@@ -6,6 +6,7 @@
   margin: 0;
   transition: border-color var(--sbb-transition-fast-start);
   border: var(--sbb-border-width-thin) solid var(--sbb-expansion-panel-border-color-closed);
+  overflow: hidden;
 
   & + & {
     margin-top: calc(var(--sbb-border-width-thin) * 2);
@@ -72,6 +73,20 @@
   margin-top: -0.5em;
   margin-bottom: -0.5em;
 
+  :where(.sbb-expansion-panel.sbb-expansion-panel-animations-enabled) & {
+    transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  :where(html.sbb-lean) & {
+    transform: rotate(90deg);
+  }
+
+  :where(.sbb-expansion-panel.sbb-expanded > .sbb-expansion-panel-header) & {
+    :where(html.sbb-lean) & {
+      transform: rotate(-90deg);
+    }
+  }
+
   :where(html:not(.sbb-lean)) & {
     border: var(--sbb-border-width-thin) solid var(--sbb-color-storm);
     border-radius: 50%;
@@ -105,24 +120,41 @@
   line-height: var(--sbb-expansion-panel-line-height);
 }
 
+.sbb-expansion-panel-content-wrapper {
+  // Note: we can't use `overflow: hidden` here, because it can clip content with
+  // box shadows. Instead we transition t he `visibility` below.
+  // Based on https://css-tricks.com/css-grid-can-do-auto-height-transitions.
+  display: grid;
+  grid-template-rows: 0fr;
+  grid-template-columns: 100%;
+
+  :where(.sbb-expansion-panel.sbb-expansion-panel-animations-enabled) > & {
+    transition: grid-template-rows 225ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  :where(.sbb-expansion-panel.sbb-expanded) > & {
+    grid-template-rows: 1fr;
+  }
+}
+
 .sbb-expansion-panel-content {
   display: flex;
   flex-direction: column;
   overflow: visible;
+  min-height: 0;
 
-  // Usually the `visibility: hidden` added by the animation is enough to prevent focus from
-  // entering the collapsed content, but children with their own `visibility` can override it.
-  // In other components we set a `display: none` at the root to stop focus from reaching the
-  // elements, however we can't do that here, because the content can determine the width
-  // of an expansion panel. The most practical fallback is to use `!important` to override
-  // any custom visibility.
-  &[style*='visibility: hidden'] * {
-    visibility: hidden !important;
+  // The visibility here serves two purposes:
+  // 1. Hiding content from assistive technology.
+  // 2. Hiding any content that might be overflowing.
+  visibility: hidden;
+
+  :where(.sbb-expansion-panel-animations-enabled) & {
+    // The duration here is slightly lower so the content
+    // goes away quicker than the collapse transition.
+    transition: visibility 190ms linear;
   }
-
-  &.ng-animating,
-  .sbb-expansion-panel:not(.sbb-expanded) & {
-    overflow: hidden;
+  :where(.sbb-expansion-panel.sbb-expanded > .sbb-expansion-panel-content-wrapper) > & {
+    visibility: visible;
   }
 }
 

--- a/src/angular/accordion/expansion-panel.spec.ts
+++ b/src/angular/accordion/expansion-panel.spec.ts
@@ -14,7 +14,6 @@ import {
   createKeyboardEvent,
   dispatchEvent,
   dispatchKeyboardEvent,
-  switchToLean,
 } from '@sbb-esta/angular/core/testing';
 import { SbbIconTestingModule } from '@sbb-esta/angular/icon/testing';
 
@@ -231,29 +230,20 @@ describe('SbbExpansionPanel', () => {
     });
   });
 
-  it('should not be able to focus content while closed', fakeAsync(() => {
+  it('should not be able to focus content while closed', () => {
     const fixture = TestBed.createComponent(PanelWithContent);
     fixture.componentInstance.expanded = true;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    tick(250);
+    const wrapper = fixture.nativeElement.querySelector('.sbb-expansion-panel-content-wrapper');
+    expect(wrapper.hasAttribute('inert')).toBe(false);
 
-    const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
-
-    button.focus();
-    expect(document.activeElement)
-      .withContext('Expected button to start off focusable.')
-      .toBe(button);
-
-    button.blur();
     fixture.componentInstance.expanded = false;
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
-    tick(250);
 
-    button.focus();
-    expect(document.activeElement).not.toBe(button, 'Expected button to no longer be focusable.');
-  }));
+    expect(wrapper.hasAttribute('inert')).toBe(true);
+  });
 
   it('should restore focus to header if focused element is inside panel on close', fakeAsync(() => {
     const fixture = TestBed.createComponent(PanelWithContent);
@@ -314,34 +304,6 @@ describe('SbbExpansionPanel', () => {
     expect(header.querySelector('.sbb-expansion-panel-header-indicator'))
       .withContext('Expected indicator to be hidden.')
       .toBeFalsy();
-  });
-
-  describe('lean', () => {
-    switchToLean();
-
-    it('should update the indicator rotation when the expanded state is toggled programmatically', fakeAsync(() => {
-      const fixture = TestBed.createComponent(PanelWithContent);
-
-      fixture.detectChanges();
-      tick(250);
-
-      const arrow = fixture.debugElement.query(
-        By.css('.sbb-expansion-panel-header-indicator > sbb-icon'),
-      )!.nativeElement;
-
-      expect(arrow.style.transform)
-        .withContext('Expected 90 degree rotation.')
-        .toBe('rotate(90deg)');
-
-      fixture.componentInstance.expanded = true;
-      fixture.changeDetectorRef.markForCheck();
-      fixture.detectChanges();
-      tick(250);
-
-      expect(arrow.style.transform)
-        .withContext('Expected -90 degree rotation.')
-        .toBe('rotate(-90deg)');
-    }));
   });
 
   it('should make sure accordion item runs ngOnDestroy when expansion panel is destroyed', () => {

--- a/src/angular/accordion/expansion-panel.ts
+++ b/src/angular/accordion/expansion-panel.ts
@@ -14,6 +14,7 @@ import {
   EventEmitter,
   inject,
   Input,
+  NgZone,
   OnChanges,
   OnDestroy,
   Output,
@@ -27,7 +28,6 @@ import { Subject } from 'rxjs';
 import { filter, startWith, take } from 'rxjs/operators';
 
 import type { SbbAccordion } from './accordion';
-import { sbbExpansionAnimations } from './accordion-animations';
 import { SBB_ACCORDION } from './accordion-token';
 import { SBB_EXPANSION_PANEL } from './expansion-panel-base';
 import { SbbExpansionPanelContent } from './expansion-panel-content';
@@ -54,7 +54,6 @@ const _SbbExpansionPanelBase = mixinVariant(CdkAccordionItem);
     { name: 'expanded', transform: booleanAttribute },
     { name: 'disabled', transform: booleanAttribute },
   ],
-  animations: [sbbExpansionAnimations.bodyExpansion],
   // Provide SbbAccordion as undefined to prevent nested expansion panels from registering
   // to the same accordion.
   providers: [
@@ -79,8 +78,12 @@ export class SbbExpansionPanel
   _animationMode: 'NoopAnimations' | 'BrowserAnimations' | null = inject(ANIMATION_MODULE_TYPE, {
     optional: true,
   });
+  private readonly _animationsDisabled =
+    inject(ANIMATION_MODULE_TYPE, { optional: true }) === 'NoopAnimations';
+
   private _document = inject(DOCUMENT);
-  protected _animationsDisabled: boolean;
+  private _ngZone = inject(NgZone);
+  private _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   /** Whether the toggle indicator should be hidden. */
   @Input({ transform: booleanAttribute })
@@ -113,6 +116,10 @@ export class SbbExpansionPanel
   /** Element containing the panel's user-provided content. */
   @ViewChild('body') _body: ElementRef<HTMLElement>;
 
+  /** Element wrapping the panel body. */
+  @ViewChild('bodyWrapper')
+  protected _bodyWrapper: ElementRef<HTMLElement> | undefined;
+
   /** Portal holding the user's content. */
   _portal: TemplatePortal;
 
@@ -125,7 +132,6 @@ export class SbbExpansionPanel
   constructor(...args: unknown[]);
   constructor() {
     super();
-    this._animationsDisabled = this._animationMode === 'NoopAnimations';
   }
 
   /** Gets the expanded state string. */
@@ -161,6 +167,8 @@ export class SbbExpansionPanel
           this._portal = new TemplatePortal(this._lazyContent._template, this._viewContainerRef);
         });
     }
+
+    this._setupAnimationEvents();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -169,7 +177,39 @@ export class SbbExpansionPanel
 
   override ngOnDestroy() {
     super.ngOnDestroy();
+    this._bodyWrapper?.nativeElement.removeEventListener(
+      'transitionend',
+      this._transitionEndListener,
+    );
     this._inputChanges.complete();
+  }
+
+  private _transitionEndListener = ({ target, propertyName }: TransitionEvent) => {
+    if (target === this._bodyWrapper?.nativeElement && propertyName === 'grid-template-rows') {
+      this._ngZone.run(() => {
+        if (this.expanded) {
+          this.afterExpand.emit();
+        } else {
+          this.afterCollapse.emit();
+        }
+      });
+    }
+  };
+  protected _setupAnimationEvents() {
+    // This method is defined separately, because we need to
+    // disable this logic in some internal components.
+    this._ngZone.runOutsideAngular(() => {
+      if (this._animationsDisabled) {
+        this.opened.subscribe(() => this._ngZone.run(() => this.afterExpand.emit()));
+        this.closed.subscribe(() => this._ngZone.run(() => this.afterCollapse.emit()));
+      } else {
+        setTimeout(() => {
+          const element = this._elementRef.nativeElement;
+          element.addEventListener('transitionend', this._transitionEndListener);
+          element.classList.add('sbb-expansion-panel-animations-enabled');
+        }, 200);
+      }
+    });
   }
 
   /** Checks whether the expansion panel's content contains the currently-focused element. */


### PR DESCRIPTION
Reworks the accordion to animate purely with CSS, rather than going through the `@angular/animations` module to simplify the setup.

Fixes #2055