### PR TITLE
fix(angular/input): show spin buttons for number input

### DIFF
--- a/src/angular/styles/_typography.scss
+++ b/src/angular/styles/_typography.scss
@@ -1508,8 +1508,6 @@ textarea {
 input:where([type='number'], [type='time'], [type='datetime'], [type='datetime-local']) {
   -moz-appearance: textfield;
 
-  &::-webkit-inner-spin-button,
-  &::-webkit-outer-spin-button,
   &::-webkit-clear-button {
     appearance: none;
     margin: 0;

--- a/src/components-examples/angular/input/input-form/input-form-example.html
+++ b/src/components-examples/angular/input/input-form/input-form-example.html
@@ -32,6 +32,6 @@
   </sbb-form-field>
   <sbb-form-field class="sbb-form-field-long">
     <sbb-label>Postal Code</sbb-label>
-    <input sbbInput maxlength="4" placeholder="Ex. 3000" value="3000" />
+    <input sbbInput maxlength="4" placeholder="Ex. 3000" type="number" value="3000" />
   </sbb-form-field>
 </form>


### PR DESCRIPTION
For accessibility reasons, we want to show the spin buttons in `input[type='number']`

Closes #2380