### PR TITLE
fix(angular/sidebar): switch away from animations module

### DIFF
--- a/src/angular/i18n/xlf/messages.xlf
+++ b/src/angular/i18n/xlf/messages.xlf
@@ -182,7 +182,7 @@
         <source>Close Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">113</context>
         </context-group>
         <note priority="1" from="description">Button label to close the sidebar</note>
       </trans-unit>
@@ -190,7 +190,7 @@
         <source>Open Sidebar</source>
         <context-group purpose="location">
           <context context-type="sourcefile">../../../../../../src/angular/sidebar/sidebar/sidebar.ts</context>
-          <context context-type="linenumber">564</context>
+          <context context-type="linenumber">554</context>
         </context-group>
         <note priority="1" from="description">Button label to open the sidebar</note>
       </trans-unit>

--- a/src/angular/i18n/xlf2/messages.xlf
+++ b/src/angular/i18n/xlf2/messages.xlf
@@ -194,7 +194,7 @@
     </unit>
     <unit id="sbbSidebarCloseSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:121</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:113</note>
         <note category="description">Button label to close the sidebar</note>
       </notes>
       <segment>
@@ -203,7 +203,7 @@
     </unit>
     <unit id="sbbSidebarOpenSidebar">
       <notes>
-        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:564</note>
+        <note category="location">../../../../../../src/angular/sidebar/sidebar/sidebar.ts:554</note>
         <note category="description">Button label to open the sidebar</note>
       </notes>
       <segment>

--- a/src/angular/sidebar/sidebar/sidebar-animations.ts
+++ b/src/angular/sidebar/sidebar/sidebar-animations.ts
@@ -10,6 +10,8 @@ import {
 /**
  * Animations used by the sbb angular sidebars.
  * @docs-private
+ * @deprecated No longer used, will be removed.
+ * @breaking-change 21.0.0
  */
 export const sbbSidebarAnimations: {
   readonly transformSidebar: AnimationTriggerMetadata;

--- a/src/angular/sidebar/sidebar/sidebar.scss
+++ b/src/angular/sidebar/sidebar/sidebar.scss
@@ -83,15 +83,24 @@
     transform: translate3d(100%, 0, 0);
   }
 
-  // Usually the `visibility: hidden` added by the animation is enough to prevent focus from
-  // entering the hidden sidebar content, but children with their own `visibility` can override it.
-  // This is a fallback that completely hides the content when the element becomes hidden.
-  // Note that we can't do this in the animation definition, because the style gets recomputed too
-  // late, breaking the animation because Angular didn't have time to figure out the target
-  // transform. This can also be achieved with JS, but it has issues when starting an
-  // animation before the previous one has finished.
-  &[style*='visibility: hidden'] {
-    display: none;
+  .sbb-sidebar-transition & {
+    transition: transform 400ms cubic-bezier(0.25, 0.8, 0.25, 1);
+  }
+  &:not(.sbb-sidebar-opened):not(.sbb-sidebar-animating) {
+    // Stops the sidenav from poking out (e.g. with the box shadow) while it's off-screen.
+    // We can't use `display` because it interrupts the transition and `transition-behavior`
+    // isn't available in all browsers.
+    visibility: hidden;
+    box-shadow: none;
+    // The `visibility` above should prevent focus from entering the sidenav, but if a child
+    // element has `visibility`, it'll override the inherited value. This guarantees that the
+    // content won't be focusable.
+    .sbb-sidebar-inner-container {
+      display: none;
+    }
+  }
+  &.sbb-sidebar-opened {
+    transform: none;
   }
 }
 

--- a/src/angular/sidebar/sidebar/sidebar.spec.ts
+++ b/src/angular/sidebar/sidebar/sidebar.spec.ts
@@ -71,24 +71,23 @@ describe('SbbSidebar', () => {
       fixture.detectChanges();
       tick();
 
-      // sidebar is opened after creation
-      expect(testComponent.openCount).toBe(1);
-      expect(testComponent.openStartCount).toBe(1);
-      expect(container.classList).toContain('sbb-sidebar-container-has-open');
+      expect(testComponent.openCount).toBe(0);
+      expect(testComponent.openStartCount).toBe(0);
+      expect(container.classList).not.toContain('sbb-sidebar-container-has-open');
 
       mediaMatcher.setMatchesQuery(Breakpoints.Mobile, true);
       tick();
 
-      expect(testComponent.openCount).toBe(1);
-      expect(testComponent.openStartCount).toBe(1);
+      expect(testComponent.openCount).toBe(0);
+      expect(testComponent.openStartCount).toBe(0);
       expect(container.classList).not.toContain('sbb-sidebar-container-has-open');
 
       fixture.debugElement.query(By.css('.open'))!.nativeElement.click();
       fixture.detectChanges();
       tick();
 
-      expect(testComponent.openCount).toBe(2);
-      expect(testComponent.openStartCount).toBe(2);
+      expect(testComponent.openCount).toBe(1);
+      expect(testComponent.openStartCount).toBe(1);
       expect(container.classList).toContain('sbb-sidebar-container-has-open');
     }));
 
@@ -159,15 +158,13 @@ describe('SbbSidebar', () => {
     it('should be able to close while the open animation is running', fakeAsync(() => {
       const fixture = TestBed.createComponent(BasicTestComponent);
       fixture.detectChanges();
-      mediaMatcher.setMatchesQuery(Breakpoints.Mobile, true);
-      tick();
 
       const testComponent: BasicTestComponent = fixture.debugElement.componentInstance;
       fixture.debugElement.query(By.css('.open'))!.nativeElement.click();
       fixture.detectChanges();
 
-      expect(testComponent.openCount).toBe(1);
-      expect(testComponent.closeCount).toBe(1);
+      expect(testComponent.openCount).toBe(0);
+      expect(testComponent.closeCount).toBe(0);
 
       tick();
       fixture.debugElement.query(By.css('.close'))!.nativeElement.click();
@@ -176,8 +173,8 @@ describe('SbbSidebar', () => {
       flush();
       fixture.detectChanges();
 
-      expect(testComponent.openCount).toBe(2);
-      expect(testComponent.closeCount).toBe(2);
+      expect(testComponent.openCount).toBe(0);
+      expect(testComponent.closeCount).toBe(1);
     }));
 
     it('does not throw when created without a sidebar', fakeAsync(() => {

--- a/src/angular/sidebar/sidebar/sidebar.ts
+++ b/src/angular/sidebar/sidebar/sidebar.ts
@@ -1,7 +1,6 @@
 // Workaround for: https://github.com/bazelbuild/rules_nodejs/issues/1265
 /// <reference types="@angular/localize/init" />
 
-import { AnimationEvent } from '@angular/animations';
 import {
   ConfigurableFocusTrapFactory,
   FocusMonitor,
@@ -14,7 +13,6 @@ import { Platform } from '@angular/cdk/platform';
 import { CdkScrollable, ViewportRuler } from '@angular/cdk/scrolling';
 import { AsyncPipe } from '@angular/common';
 import {
-  AfterContentChecked,
   AfterContentInit,
   afterNextRender,
   ANIMATION_MODULE_TYPE,
@@ -26,8 +24,6 @@ import {
   ContentChildren,
   ElementRef,
   EventEmitter,
-  HostBinding,
-  HostListener,
   inject,
   Injector,
   Input,
@@ -35,6 +31,7 @@ import {
   OnDestroy,
   Output,
   QueryList,
+  Renderer2,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -50,8 +47,6 @@ import {
   SbbSidebarMobileCapableContainer,
   SBB_SIDEBAR_CONTAINER,
 } from '../sidebar-base';
-
-import { sbbSidebarAnimations } from './sidebar-animations';
 
 /** Result of the toggle promise that indicates the state of the sidebar. */
 export type SbbSidebarToggleResult = 'open' | 'close';
@@ -91,7 +86,6 @@ export class SbbSidebarContent extends SbbSidebarContentBase implements AfterCon
   selector: 'sbb-sidebar',
   exportAs: 'sbbSidebar',
   templateUrl: './sidebar.html',
-  animations: [sbbSidebarAnimations.transformSidebar],
   host: {
     class: 'sbb-sidebar',
     tabIndex: '-1',
@@ -102,19 +96,17 @@ export class SbbSidebarContent extends SbbSidebarContentBase implements AfterCon
     '[class.sbb-sidebar-side]': 'mode === "side"',
     '[class.sbb-sidebar-opened]': 'opened',
     '[class.sbb-sidebar-collapsible]': 'collapsible',
+    '[style.visibility]': '(!_container && !opened) ? "hidden" : null',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [CdkScrollable, SbbIcon],
 })
-export class SbbSidebar
-  extends SbbSidebarBase
-  implements AfterContentInit, AfterContentChecked, OnDestroy
-{
+export class SbbSidebar extends SbbSidebarBase implements AfterContentInit, OnDestroy {
   private _focusTrapFactory = inject(ConfigurableFocusTrapFactory);
   private _focusMonitor = inject(FocusMonitor);
-  private _platform = inject(Platform);
   private _ngZone = inject(NgZone);
+  private _renderer = inject(Renderer2);
   override _container: SbbSidebarContainer = inject<SbbSidebarContainer>(SBB_SIDEBAR_CONTAINER);
   private _router = inject(Router, { optional: true });
 
@@ -122,9 +114,6 @@ export class SbbSidebar
 
   /** Whether the sidebar is in mobile mode. */
   _mobile: boolean = false;
-
-  /** Whether the sidebar is initialized. Used for disabling the initial animation. */
-  private _enableAnimations = false;
 
   /** Whether the sidebar is collapsible. */
   @Input({ transform: booleanAttribute })
@@ -173,6 +162,12 @@ export class SbbSidebar
    */
   private _openedViaInput: boolean = false;
 
+  /** Emits whenever the sidebar has started animating. */
+  readonly _animationStarted = new Subject<TransitionEvent | void>();
+
+  /** Emits whenever the sidebar is done animating. */
+  readonly _animationEnd = new Subject<TransitionEvent | void>();
+
   /**
    * Name of the svg icon for the trigger on mobile devices.
    */
@@ -186,42 +181,26 @@ export class SbbSidebar
 
   /** Event emitted when the sidebar has started opening. */
   @Output()
-  get openedStart(): Observable<void> {
-    return this._animationStarted.pipe(
-      filter((e) => e.fromState !== e.toState && e.toState.indexOf('open') === 0),
-      map(() => {}),
-    );
-  }
+  readonly openedStart: Observable<void> = this._animationStarted.pipe(
+    filter(() => this.opened),
+    mapTo(undefined),
+  );
 
   /** Event emitted when the sidebar has started closing. */
   @Output()
-  get closedStart(): Observable<void> {
-    return this._animationStarted.pipe(
-      filter((e) => e.fromState !== e.toState && e.toState === 'void'),
-      map(() => {}),
-    );
-  }
+  readonly closedStart: Observable<void> = this._animationStarted.pipe(
+    filter(() => !this.opened),
+    mapTo(undefined),
+  );
 
   private _focusTrap: FocusTrap;
   private _elementFocusedBeforeSidebarWasOpened: HTMLElement | null = null;
+  private _eventCleanups: (() => void)[];
 
   private _mode: SbbSidebarMode = 'side';
 
   /** How the sidebar was opened (keypress, mouse click etc.) */
   private _openedVia: FocusOrigin | null;
-
-  /** Emits whenever the sidebar has started animating. */
-  readonly _animationStarted: Subject<AnimationEvent> = new Subject<AnimationEvent>();
-
-  /** Emits whenever the sidebar is done animating. */
-  readonly _animationEnd: Subject<AnimationEvent> = new Subject<AnimationEvent>();
-
-  /** Current state of the sidebar animation. */
-  // @HostBinding is used in the class as it is expected to be extended.  Since @Component decorator
-  // metadata is not inherited by child classes, instead the host binding data is defined in a way
-  // that can be inherited.
-  @HostBinding('@transform')
-  _animationState: 'open-instant' | 'open' | 'void' = 'void';
 
   /** Event emitted when the sidebar open state is changed. */
   @Output() readonly openedChange: EventEmitter<boolean> =
@@ -290,8 +269,9 @@ export class SbbSidebar
      * Additionally listen to router navigation start events to close the sidebar.
      */
     this._ngZone.runOutsideAngular(() => {
+      const element = this._elementRef.nativeElement;
       merge(
-        (fromEvent(this._elementRef.nativeElement, 'keydown') as Observable<KeyboardEvent>).pipe(
+        (fromEvent(element, 'keydown') as Observable<KeyboardEvent>).pipe(
           filter((event) => {
             return event.keyCode === ESCAPE && !hasModifierKey(event);
           }),
@@ -317,17 +297,16 @@ export class SbbSidebar
             event.preventDefault();
           }),
         );
+
+      this._eventCleanups = [
+        this._renderer.listen(element, 'transitionrun', this._handleTransitionEvent),
+        this._renderer.listen(element, 'transitionend', this._handleTransitionEvent),
+        this._renderer.listen(element, 'transitioncancel', this._handleTransitionEvent),
+      ];
     });
 
-    this._animationEnd.subscribe((event: AnimationEvent) => {
-      const { fromState, toState } = event;
-
-      if (
-        (toState.indexOf('open') === 0 && fromState === 'void') ||
-        (toState === 'void' && fromState.indexOf('open') === 0)
-      ) {
-        this.openedChange.emit(this._opened);
-      }
+    this._animationEnd.subscribe(() => {
+      this.openedChange.emit(this._opened);
     });
   }
 
@@ -382,17 +361,8 @@ export class SbbSidebar
     this._updateFocusTrapState();
   }
 
-  ngAfterContentChecked() {
-    // Enable the animations after the lifecycle hooks have run, in order to avoid animating
-    // sidebars that are open by default. When we're on the server, we shouldn't enable the
-    // animations, because we don't want the sidebar to animate the first time the user sees
-    // the page.
-    if (this._platform.isBrowser) {
-      this._enableAnimations = true;
-    }
-  }
-
   override ngOnDestroy() {
+    this._eventCleanups.forEach((cleanup) => cleanup());
     super.ngOnDestroy();
     if (this._focusTrap) {
       this._focusTrap.destroy();
@@ -464,15 +434,28 @@ export class SbbSidebar
     restoreFocus: boolean,
     focusOrigin: Exclude<FocusOrigin, null>,
   ): Promise<SbbSidebarToggleResult> {
+    if (isOpen === this._opened) {
+      return Promise.resolve(isOpen ? 'open' : 'close');
+    }
+
     this._opened = isOpen;
 
-    if (isOpen) {
-      this._animationState = this._enableAnimations ? 'open' : 'open-instant';
+    if (this._container?._transitionsEnabled) {
+      // Note: it's importatnt to set this as early as possible,
+      // otherwise the animation can look glitchy in some cases.
+      this._setIsAnimating(true);
     } else {
-      this._animationState = 'void';
-      if (restoreFocus) {
-        this._restoreFocus(focusOrigin);
-      }
+      // Simulate the animation events if animations are disabled.
+      setTimeout(() => {
+        this._animationStarted.next();
+        this._animationEnd.next();
+      });
+    }
+
+    this._elementRef.nativeElement.classList.toggle('sbb-sidebar-opened', isOpen);
+
+    if (!isOpen && restoreFocus) {
+      this._restoreFocus(focusOrigin);
     }
 
     // Needed to ensure that the closing sequence fires off correctly.
@@ -484,8 +467,13 @@ export class SbbSidebar
     });
   }
 
+  /** Toggles whether the drawer is currently animating. */
+  private _setIsAnimating(isAnimating: boolean) {
+    this._elementRef.nativeElement.classList.toggle('sbb-sidebar-animating', isAnimating);
+  }
+
   _getWidth(): number {
-    return this._elementRef.nativeElement ? this._elementRef.nativeElement.offsetWidth || 0 : 0;
+    return this._elementRef.nativeElement.offsetWidth || 0;
   }
 
   /** Updates the enabled state of the focus trap. */
@@ -496,33 +484,13 @@ export class SbbSidebar
     }
   }
 
-  // We have to use a `HostListener` here in order to support both Ivy and ViewEngine.
-  // In Ivy the `host` bindings will be merged when this class is extended, whereas in
-  // ViewEngine they're overwritten.
-  // TODO(crisbeto): we move this back into `host` once Ivy is turned on by default.
-  // tslint:disable-next-line:no-host-decorator-in-concrete
-  @HostListener('@transform.start', ['$event'])
-  _animationStartListener(event: AnimationEvent) {
-    this._animationStarted.next(event);
-  }
-
-  // We have to use a `HostListener` here in order to support both Ivy and ViewEngine.
-  // In Ivy the `host` bindings will be merged when this class is extended, whereas in
-  // ViewEngine they're overwritten.
-  // TODO(crisbeto): we move this back into `host` once Ivy is turned on by default.
-  // tslint:disable-next-line:no-host-decorator-in-concrete
-  @HostListener('@transform.done', ['$event'])
-  _animationDoneListener(event: AnimationEvent) {
-    this._animationEnd.next(event);
-  }
-
   _mobileChanged(mobile: boolean): void {
     this._mobile = mobile;
     Promise.resolve().then(() => {
-      const wasAnimationsEnabled = this._enableAnimations;
+      const wereTransitionsEnabled = this._container._transitionsEnabled;
 
       // temporary disabled animations when changing mode
-      this._enableAnimations = false;
+      this._container._transitionsEnabled = false;
       this.mode = this.collapsible || mobile ? 'over' : 'side';
 
       if (!this._openedViaInput) {
@@ -530,9 +498,30 @@ export class SbbSidebar
       } else {
         this._changeDetectorRef.markForCheck();
       }
-      this._enableAnimations = wasAnimationsEnabled;
+      this._container._transitionsEnabled = wereTransitionsEnabled;
     });
   }
+
+  /** Event handler for animation events. */
+  private _handleTransitionEvent = (event: TransitionEvent) => {
+    const element = this._elementRef.nativeElement;
+
+    if (event.target === element) {
+      this._ngZone.run(() => {
+        if (event.type === 'transitionrun') {
+          this._animationStarted.next(event);
+        } else {
+          // Don't toggle the animating state on `transitioncancel` since another animation should
+          // start afterwards. This prevents the drawer from blinking if an animation is interrupted.
+          if (event.type === 'transitionend') {
+            this._setIsAnimating(false);
+          }
+
+          this._animationEnd.next(event);
+        }
+      });
+    }
+  };
 }
 
 @Component({
@@ -561,6 +550,7 @@ export class SbbSidebarContainer
   private _element = inject<ElementRef<HTMLElement>>(ElementRef);
   private _animationMode = inject(ANIMATION_MODULE_TYPE, { optional: true });
 
+  _transitionsEnabled: boolean = false;
   _labelOpenSidebar: string = $localize`:Button label to open the sidebar@@sbbSidebarOpenSidebar:Open Sidebar`;
 
   /** The sidebar child at the start/end position. */
@@ -578,6 +568,7 @@ export class SbbSidebarContainer
 
   constructor(...args: unknown[]);
   constructor() {
+    const platform = inject(Platform);
     const viewportRuler = inject(ViewportRuler);
 
     super();
@@ -588,6 +579,17 @@ export class SbbSidebarContainer
       .change()
       .pipe(takeUntil(this._destroyed))
       .subscribe(() => this.updateContentMargins());
+
+    if (this._animationMode !== 'NoopAnimations' && platform.isBrowser) {
+      this._ngZone.runOutsideAngular(() => {
+        // Enable the animations after a delay in order to skip
+        // the initial transition if a sidebar is open by default.
+        setTimeout(() => {
+          this._element.nativeElement.classList.add('sbb-sidebar-transition');
+          this._transitionsEnabled = true;
+        }, 300);
+      });
+    }
   }
 
   /** All sidebars in the container. Includes sidebars from inside nested containers. */
@@ -693,21 +695,10 @@ export class SbbSidebarContainer
    * is properly hidden.
    */
   private _watchSidebarToggle(sidebar: SbbSidebar): void {
-    sidebar._animationStarted
-      .pipe(
-        filter((event: AnimationEvent) => event.fromState !== event.toState),
-        takeUntil(this._sidebars.changes),
-      )
-      .subscribe((event: AnimationEvent) => {
-        // Set the transition class on the container so that the animations occur. This should not
-        // be set initially because animations should only be triggered via a change in state.
-        if (event.toState !== 'open-instant' && this._animationMode !== 'NoopAnimations') {
-          this._element.nativeElement.classList.add('sbb-sidebar-transition');
-        }
-
-        this.updateContentMargins();
-        this._changeDetectorRef.markForCheck();
-      });
+    sidebar._animationStarted.pipe(takeUntil(this._sidebars.changes)).subscribe(() => {
+      this.updateContentMargins();
+      this._changeDetectorRef.markForCheck();
+    });
 
     sidebar.openedChange
       .pipe(takeUntil(this._sidebars.changes))


### PR DESCRIPTION
Reworks the sidevar to animate using CSS, rather than the animations module. This requires less JavaScript, is simpler to maintain and avoids some memory leaks caused by the animations module.