### PR TITLE
refactor(multiple): use renderer for manual event bindings

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -28,6 +28,7 @@ import {
   NgZone,
   OnChanges,
   OnDestroy,
+  Renderer2,
   SimpleChanges,
   ViewContainerRef,
 } from '@angular/core';
@@ -45,7 +46,6 @@ import {
   BehaviorSubject,
   combineLatest,
   defer,
-  fromEvent,
   merge,
   Observable,
   of as observableOf,
@@ -137,6 +137,7 @@ export function getSbbAutocompleteMissingPanelError(): Error {
 export class SbbAutocompleteTrigger
   implements ControlValueAccessor, AfterViewInit, OnChanges, OnDestroy
 {
+  private _injector = inject(Injector);
   private _element = inject<ElementRef<HTMLInputElement>>(ElementRef);
   private _overlay = inject(Overlay);
   private _viewContainerRef = inject(ViewContainerRef);
@@ -148,6 +149,8 @@ export class SbbAutocompleteTrigger
   });
   private _document = inject(DOCUMENT, { optional: true })!;
   private _viewportRuler = inject(ViewportRuler);
+  private _scrollStrategy = inject(SBB_AUTOCOMPLETE_SCROLL_STRATEGY);
+  private _renderer = inject(Renderer2);
   private _defaults = inject<SbbAutocompleteDefaultOptions | null>(
     SBB_AUTOCOMPLETE_DEFAULT_OPTIONS,
     { optional: true },
@@ -156,9 +159,10 @@ export class SbbAutocompleteTrigger
   private _overlayRef: OverlayRef | null;
   private _portal: TemplatePortal;
   private _componentDestroyed = false;
-  private _scrollStrategy = inject(SBB_AUTOCOMPLETE_SCROLL_STRATEGY);
+  private _initialized = new Subject<void>();
   private _keydownSubscription: Subscription | null;
   private _outsideClickSubscription: Subscription | null;
+  private _cleanupWindowBlur: (() => void) | undefined;
 
   /** Old value of the native input. Used to work around issues with the `input` event on IE. */
   private _previousValue: string | number | null;
@@ -306,10 +310,6 @@ export class SbbAutocompleteTrigger
   @Input({ alias: 'sbbAutocompleteDisabled', transform: booleanAttribute })
   autocompleteDisabled: boolean = false;
 
-  private _initialized = new Subject<void>();
-
-  private _injector = inject(Injector);
-
   constructor(...args: unknown[]);
   constructor() {}
 
@@ -319,12 +319,7 @@ export class SbbAutocompleteTrigger
   ngAfterViewInit() {
     this._initialized.next();
     this._initialized.complete();
-
-    const window = this._getWindow();
-
-    if (typeof window !== 'undefined') {
-      this._zone.runOutsideAngular(() => window.addEventListener('blur', this._windowBlurHandler));
-    }
+    this._cleanupWindowBlur = this._renderer.listen('window', 'blur', this._windowBlurHandler);
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -338,12 +333,7 @@ export class SbbAutocompleteTrigger
   }
 
   ngOnDestroy() {
-    const window = this._getWindow();
-
-    if (typeof window !== 'undefined') {
-      window.removeEventListener('blur', this._windowBlurHandler);
-    }
-
+    this._cleanupWindowBlur?.();
     this._viewportSubscription.unsubscribe();
     this._positionSubscription.unsubscribe();
     this._highlightSubscription.unsubscribe();
@@ -459,19 +449,15 @@ export class SbbAutocompleteTrigger
 
   /** Stream of clicks outside of the autocomplete panel. */
   private _getOutsideClickStream(): Observable<any> {
-    return merge(
-      fromEvent(this._document, 'click') as Observable<MouseEvent>,
-      fromEvent(this._document, 'auxclick') as Observable<MouseEvent>,
-      fromEvent(this._document, 'touchend') as Observable<TouchEvent>,
-    ).pipe(
-      filter((event) => {
+    return new Observable((observer) => {
+      const listener = (event: MouseEvent | TouchEvent) => {
         // If we're in the Shadow DOM, the event target will be the shadow root, so we have to
         // fall back to check the first element in the path of the click event.
         const clickTarget = _getEventTarget<HTMLElement>(event)!;
         const formField = this._formField ? this._formField._elementRef.nativeElement : null;
         const customOrigin = this.connectedTo ? this.connectedTo.elementRef.nativeElement : null;
 
-        return (
+        if (
           this._overlayAttached &&
           clickTarget !== this._element.nativeElement &&
           // Normally focus moves inside `mousedown` so this condition will almost always be
@@ -483,9 +469,21 @@ export class SbbAutocompleteTrigger
           (!customOrigin || !customOrigin.contains(clickTarget)) &&
           !!this._overlayRef &&
           !this._overlayRef.overlayElement.contains(clickTarget)
-        );
-      }),
-    );
+        ) {
+          observer.next(event);
+        }
+      };
+
+      const cleanups = [
+        this._renderer.listen('document', 'click', listener),
+        this._renderer.listen('document', 'auxclick', listener),
+        this._renderer.listen('document', 'touchend', listener),
+      ];
+
+      return () => {
+        cleanups.forEach((current) => current());
+      };
+    });
   }
 
   // Implemented as part of ControlValueAccessor.
@@ -1016,11 +1014,6 @@ export class SbbAutocompleteTrigger
   private _canOpen(): boolean {
     const element = this._element.nativeElement;
     return !element.readOnly && !element.disabled && !this.autocompleteDisabled;
-  }
-
-  /** Use defaultView of injected document if available or fallback to global window reference */
-  private _getWindow(): Window {
-    return this._document?.defaultView || window;
   }
 
   /** Scrolls to a particular option in the list. */

--- a/src/angular/button/button.ts
+++ b/src/angular/button/button.ts
@@ -15,6 +15,7 @@ import {
   NgZone,
   OnDestroy,
   QueryList,
+  Renderer2,
   ViewEncapsulation,
 } from '@angular/core';
 import { mixinVariant } from '@sbb-esta/angular/core';
@@ -220,6 +221,8 @@ export class SbbButton
 })
 export class SbbAnchor extends SbbButton implements AfterViewInit, OnDestroy {
   private _ngZone = inject(NgZone);
+  private _renderer = inject(Renderer2);
+  private _cleanupClick: () => void;
 
   /** Tabindex of the button. */
   @Input() tabIndex: number;
@@ -228,13 +231,17 @@ export class SbbAnchor extends SbbButton implements AfterViewInit, OnDestroy {
     super.ngAfterViewInit();
 
     this._ngZone.runOutsideAngular(() => {
-      this._elementRef.nativeElement.addEventListener('click', this._haltDisabledEvents);
+      this._cleanupClick = this._renderer.listen(
+        this._elementRef.nativeElement,
+        'click',
+        this._haltDisabledEvents,
+      );
     });
   }
 
   override ngOnDestroy(): void {
     super.ngOnDestroy();
-    this._elementRef.nativeElement.removeEventListener('click', this._haltDisabledEvents);
+    this._cleanupClick?.();
   }
 
   _haltDisabledEvents = (event: Event): void => {

--- a/src/angular/menu/menu-trigger.ts
+++ b/src/angular/menu/menu-trigger.ts
@@ -15,7 +15,7 @@ import {
   ScrollStrategy,
   VerticalConnectionPos,
 } from '@angular/cdk/overlay';
-import { normalizePassiveListenerOptions } from '@angular/cdk/platform';
+import { _bindEventWithOptions } from '@angular/cdk/platform';
 import { TemplatePortal } from '@angular/cdk/portal';
 import {
   AfterContentInit,
@@ -31,6 +31,7 @@ import {
   OnDestroy,
   OnInit,
   Output,
+  Renderer2,
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
@@ -103,7 +104,7 @@ export const SBB_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER = {
 const SUBMENU_PANEL_LEFT_OVERLAP = 3;
 
 /** Options for binding a passive event listener. */
-const passiveEventListenerOptions = normalizePassiveListenerOptions({ passive: true });
+const passiveEventListenerOptions = { passive: true };
 
 // Boilerplate for applying mixins to SbbMenu.
 const _SbbMenuTriggerMixinBase = mixinVariant(class {});
@@ -144,6 +145,7 @@ export class SbbMenuTrigger
   private _breakpointObserver = inject(BreakpointObserver);
   private _changeDetectorRef = inject(ChangeDetectorRef);
   private _ngZone = inject(NgZone);
+  private _cleanupTouchstart: () => void;
 
   private _portal: TemplatePortal;
   private _overlayRef: OverlayRef | null = null;
@@ -159,16 +161,6 @@ export class SbbMenuTrigger
    * interface lacks some functionality around nested menus and animations.
    */
   _parentSbbMenu: SbbMenu | undefined;
-
-  /**
-   * Handles touch start events on the trigger.
-   * Needs to be an arrow function so we can easily use addEventListener and removeEventListener.
-   */
-  private _handleTouchStart = (event: TouchEvent) => {
-    if (!isFakeTouchstartFromScreenReader(event)) {
-      this._openedBy = 'touch';
-    }
-  };
 
   // Tracking input type is necessary so it's possible to only auto-focus
   // the first item of the list when the menu is opened via the keyboard
@@ -247,6 +239,7 @@ export class SbbMenuTrigger
 
   constructor() {
     const parentMenu = inject<SbbMenuPanel>(SBB_MENU_PANEL, { optional: true })!;
+    const renderer = inject(Renderer2);
 
     super();
     const _element = this._element;
@@ -254,9 +247,15 @@ export class SbbMenuTrigger
 
     this._parentSbbMenu = parentMenu instanceof SbbMenu ? parentMenu : undefined;
 
-    _element.nativeElement.addEventListener(
+    this._cleanupTouchstart = _bindEventWithOptions(
+      renderer,
+      this._element.nativeElement,
       'touchstart',
-      this._handleTouchStart,
+      (event: TouchEvent) => {
+        if (!isFakeTouchstartFromScreenReader(event)) {
+          this._openedBy = 'touch';
+        }
+      },
       passiveEventListenerOptions,
     );
 
@@ -293,12 +292,7 @@ export class SbbMenuTrigger
       PANELS_TO_TRIGGERS.delete(this.menu);
     }
 
-    this._element.nativeElement.removeEventListener(
-      'touchstart',
-      this._handleTouchStart,
-      passiveEventListenerOptions,
-    );
-
+    this._cleanupTouchstart();
     this._menuCloseSubscription.unsubscribe();
     this._closingActionsSubscription.unsubscribe();
     this._hoverSubscription.unsubscribe();

--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -23,8 +23,8 @@ import {
   ScrollStrategy,
 } from '@angular/cdk/overlay';
 import {
-  normalizePassiveListenerOptions,
   Platform,
+  _bindEventWithOptions,
   _getFocusedElementPierceShadowDom,
 } from '@angular/cdk/platform';
 import { ComponentPortal } from '@angular/cdk/portal';
@@ -50,6 +50,7 @@ import {
   OnDestroy,
   Optional,
   Output,
+  Renderer2,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -78,7 +79,7 @@ export const SCROLL_THROTTLE_MS = 20;
 const PANEL_CLASS = 'tooltip-panel';
 
 /** Options used to bind passive event listeners. */
-const passiveListenerOptions = normalizePassiveListenerOptions({ passive: true });
+const passiveListenerOptions = { passive: true };
 
 /**
  * Time between the user putting the pointer on a tooltip
@@ -197,6 +198,8 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
   private _currentPosition: TooltipPosition;
   private readonly _cssClassPrefix: string = 'sbb';
   private _ariaDescriptionPending: boolean;
+  private _injector = inject(Injector);
+  private _renderer = inject(Renderer2);
 
   /** Allows the user to define the position of the tooltip relative to the parent element */
   @Input('sbbTooltipPosition')
@@ -329,12 +332,11 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
   @Input('sbbTooltipPanelClass')
   tooltipPanelClass: string | string[] | Set<string> | { [key: string]: any } = '';
 
-  /** Manually-bound passive event listeners. */
-  private readonly _passiveListeners: (readonly [string, EventListenerOrEventListenerObject])[] =
-    [];
-
   /** Reference to the current document. */
   private _document: Document;
+
+  /** Cleanup functions for manually-bound events. */
+  private readonly _eventCleanups: (() => void)[] = [];
 
   /** Timer started at the last `touchstart` event. */
   private _touchstartTimeout: null | ReturnType<typeof setTimeout> = null;
@@ -344,8 +346,6 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
 
   /** Whether ngOnDestroyed has been called. */
   private _isDestroyed = false;
-
-  private _injector = inject(Injector);
 
   /** Predefined tooltip positions. */
   private readonly _tooltipPositions: Record<TooltipPosition, ConnectedPosition[]> = {
@@ -511,11 +511,8 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
       this._tooltipInstance = null;
     }
 
-    // Clean up the event listeners set in the constructor
-    this._passiveListeners.forEach(([event, listener]) => {
-      nativeElement.removeEventListener(event, listener, passiveListenerOptions);
-    });
-    this._passiveListeners.length = 0;
+    this._eventCleanups.forEach((cleanup) => cleanup());
+    this._eventCleanups.length = 0;
 
     this._destroyed.next();
     this._destroyed.complete();
@@ -775,49 +772,62 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
   /** Binds the pointer events to the tooltip trigger. */
   private _setupPointerEnterEventsIfNeeded() {
     // Optimization: Defer hooking up events if there's no message or the tooltip is disabled.
-    if (
-      this._disabled ||
-      !this.message ||
-      !this._viewInitialized ||
-      this._passiveListeners.length
-    ) {
+    if (this._disabled || !this.message || !this._viewInitialized || this._eventCleanups.length) {
       return;
     }
 
+    const element = this._elementRef.nativeElement;
+
     if (this.trigger === 'click') {
-      this._passiveListeners.push(['click', () => this.show(0)]);
+      this._eventCleanups.push(
+        _bindEventWithOptions(
+          this._renderer,
+          element,
+          'click',
+          () => this.show(0),
+          passiveListenerOptions,
+        ),
+      );
     }
     // The mouse events shouldn't be bound on mobile devices, because they can prevent the
     // first tap from firing its click event or can cause the tooltip to open for clicks.
     else if (this._platformSupportsMouseEvents()) {
-      this._passiveListeners.push([
-        'mouseenter',
-        () => {
-          this._setupPointerExitEventsIfNeeded();
-          this.show();
-        },
-      ]);
+      this._eventCleanups.push(
+        _bindEventWithOptions(
+          this._renderer,
+          element,
+          'mouseenter',
+          () => {
+            this._setupPointerExitEventsIfNeeded();
+            this.show();
+          },
+          passiveListenerOptions,
+        ),
+      );
     } else if (this.touchGestures !== 'off') {
       this._disableNativeGesturesIfNecessary();
 
-      this._passiveListeners.push([
-        'touchstart',
-        () => {
-          // Note that it's important that we don't `preventDefault` here,
-          // because it can prevent click events from firing on the element.
-          this._setupPointerExitEventsIfNeeded();
-          if (this._touchstartTimeout) {
-            clearTimeout(this._touchstartTimeout);
-          }
-          this._touchstartTimeout = setTimeout(() => {
-            this._touchstartTimeout = null;
-            this.show();
-          }, LONGPRESS_DELAY);
-        },
-      ]);
+      this._eventCleanups.push(
+        _bindEventWithOptions(
+          this._renderer,
+          element,
+          'touchstart',
+          () => {
+            // Note that it's important that we don't `preventDefault` here,
+            // because it can prevent click events from firing on the element.
+            this._setupPointerExitEventsIfNeeded();
+            if (this._touchstartTimeout) {
+              clearTimeout(this._touchstartTimeout);
+            }
+            this._touchstartTimeout = setTimeout(() => {
+              this._touchstartTimeout = null;
+              this.show();
+            }, LONGPRESS_DELAY);
+          },
+          passiveListenerOptions,
+        ),
+      );
     }
-
-    this._addListeners(this._passiveListeners);
   }
 
   private _setupPointerExitEventsIfNeeded() {
@@ -826,19 +836,29 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
     }
     this._pointerExitEventsInitialized = true;
 
-    const exitListeners: (readonly [string, EventListenerOrEventListenerObject])[] = [];
+    const element = this._elementRef.nativeElement;
+
     if (this._platformSupportsMouseEvents()) {
-      exitListeners.push(
-        [
+      this._eventCleanups.push(
+        _bindEventWithOptions(
+          this._renderer,
+          element,
           'mouseleave',
           (event) => {
-            const newTarget = (event as MouseEvent).relatedTarget as Node | null;
+            const newTarget = event.relatedTarget as Node | null;
             if (!newTarget || !this._overlayRef?.overlayElement.contains(newTarget)) {
               this.hide();
             }
           },
-        ],
-        ['wheel', (event) => this._wheelListener(event as WheelEvent)],
+          passiveListenerOptions,
+        ),
+        _bindEventWithOptions(
+          this._renderer,
+          element,
+          'wheel',
+          (event) => this._wheelListener(event),
+          passiveListenerOptions,
+        ),
       );
     } else if (this.touchGestures !== 'off') {
       this._disableNativeGesturesIfNecessary();
@@ -849,17 +869,23 @@ export class SbbTooltip implements OnDestroy, AfterViewInit {
         this.hide(this._defaultOptions.touchendHideDelay);
       };
 
-      exitListeners.push(['touchend', touchendListener], ['touchcancel', touchendListener]);
+      this._eventCleanups.push(
+        _bindEventWithOptions(
+          this._renderer,
+          element,
+          'touchend',
+          touchendListener,
+          passiveListenerOptions,
+        ),
+        _bindEventWithOptions(
+          this._renderer,
+          element,
+          'touchcancel',
+          touchendListener,
+          passiveListenerOptions,
+        ),
+      );
     }
-
-    this._addListeners(exitListeners);
-    this._passiveListeners.push(...exitListeners);
-  }
-
-  private _addListeners(listeners: (readonly [string, EventListenerOrEventListenerObject])[]) {
-    listeners.forEach(([event, listener]) => {
-      this._elementRef.nativeElement.addEventListener(event, listener, passiveListenerOptions);
-    });
   }
 
   private _platformSupportsMouseEvents() {


### PR DESCRIPTION
Switches our manual calls into `addEventListener` to use the renderer instead so that tooling (e.g. the tracing service) gets notified about them.