### PR TITLE
build: require at least cdk version 19.1.0

### DIFF
--- a/packages.bzl
+++ b/packages.bzl
@@ -6,7 +6,7 @@
 # all in-sync. This map is passed to each ng_package rule to stamp out the appropriate
 # version for the placeholders.
 ANGULAR_PACKAGE_VERSION = "^19.0.0 || ^20.0.0"
-CDK_PACKAGE_VERSION = "^19.0.0"
+CDK_PACKAGE_VERSION = "^19.1.0"
 TSLIB_PACKAGE_VERSION = "^2.3.0"
 RXJS_PACKAGE_VERSION = "^6.5.3 || ^7.4.0"
 

--- a/src/showcase/assets/stack-blitz/package-lock.json
+++ b/src/showcase/assets/stack-blitz/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^19.0.0",
-        "@angular/cdk": "^19.0.0",
+        "@angular/cdk": "^19.1.0",
         "@angular/common": "^19.0.0",
         "@angular/compiler": "^19.0.0",
         "@angular/core": "^19.0.0",
@@ -18,8 +18,8 @@
         "@angular/platform-browser": "^19.0.0",
         "@angular/platform-browser-dynamic": "^19.0.0",
         "@angular/router": "^19.0.0",
-        "@sbb-esta/angular": "^18.6.0",
-        "@sbb-esta/journey-maps": "^18.6.0",
+        "@sbb-esta/angular": "^19.0.0",
+        "@sbb-esta/journey-maps": "^19.0.0",
         "maplibre-gl": "^4.7.1",
         "rxjs": "~7.8.1",
         "tslib": "^2.6.2",
@@ -604,9 +604,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.0.0.tgz",
-      "integrity": "sha512-KcOYhCwN4Bw3L4+W4ymTfPGqRjrkwD8M5jX8GM7YsZ5DsX9OEd/gNrwRvjn+8JItzimXLXdGrcqXrMTxkq7QPA==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.1.tgz",
+      "integrity": "sha512-j7dg18PJIbyeU4DTko3vIK3M2OuUv3H0ZViNddOaLlGN5X93cq4QCGcNhcGm3x3r5rUr/AaexYu+KHMyN8PwmA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4738,27 +4738,27 @@
       ]
     },
     "node_modules/@sbb-esta/angular": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@sbb-esta/angular/-/angular-18.6.1.tgz",
-      "integrity": "sha512-XF+rCT6WJKC/+IAfWmPZSji4b9+mjjd+WOebh2TtoVIjp8vc5Ys0U2oCr386niLQqX/nkNiQyb1JqWJHGrJ8eA==",
+      "version": "19.1.4",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/angular/-/angular-19.1.4.tgz",
+      "integrity": "sha512-cAQRtIfuqs/6P3/EGl5Uc8ZrzQeQAdULV00BrFD1idhwqILqLl8K3utuvCppSB7BK/jf5PqeY1KVT0rIMkkq4Q==",
       "dependencies": {
         "@types/grecaptcha": "^2.0.36"
       },
       "peerDependencies": {
-        "@angular/cdk": "^18.0.0",
-        "@angular/common": "^18.0.0 || ^19.0.0",
-        "@angular/core": "^18.0.0 || ^19.0.0",
-        "@angular/forms": "^18.0.0 || ^19.0.0",
-        "@angular/router": "^18.0.0 || ^19.0.0"
+        "@angular/cdk": "^19.0.0",
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
+        "@angular/forms": "^19.0.0 || ^20.0.0",
+        "@angular/router": "^19.0.0 || ^20.0.0"
       }
     },
     "node_modules/@sbb-esta/journey-maps": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@sbb-esta/journey-maps/-/journey-maps-18.6.1.tgz",
-      "integrity": "sha512-dYH41H4jUQDxSnwUW4jSRdPzj03wc60jGk8X0a0DarwWFuTQOWAPlQlhaH68vpLHjGe+SNHm7Yln/0ZJh9eJcg==",
+      "version": "19.1.4",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/journey-maps/-/journey-maps-19.1.4.tgz",
+      "integrity": "sha512-xQoPURuQGYMiAu6FZa9EtdcTrma1pSDAq8d1R+bG7fUXy2ISVY6I4M7LKiCpGlvJrCw81lAPj0Q2oetFthh6hA==",
       "peerDependencies": {
-        "@angular/common": "^18.0.0 || ^19.0.0",
-        "@angular/core": "^18.0.0 || ^19.0.0",
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
         "@types/geojson": ">=7946",
         "maplibre-gl": "^4.7.1"
       }

--- a/src/showcase/assets/stack-blitz/package.json
+++ b/src/showcase/assets/stack-blitz/package.json
@@ -11,7 +11,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^19.0.0",
-    "@angular/cdk": "^19.0.0",
+    "@angular/cdk": "^19.1.0",
     "@angular/common": "^19.0.0",
     "@angular/compiler": "^19.0.0",
     "@angular/core": "^19.0.0",


### PR DESCRIPTION
Since #2487 SBB Angular uses functionality from `@angular/cdk/platform` that was introduced in `@angular/cdk` 19.1.0. Therefore, we need at least this version.