### PR TITLE
fix(angular/dialog): breaking changes for v20

### DIFF
--- a/src/angular/dialog/dialog.module.ts
+++ b/src/angular/dialog/dialog.module.ts
@@ -5,7 +5,7 @@ import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
 
-import { SbbDialog, SBB_DIALOG_SCROLL_STRATEGY_PROVIDER } from './dialog';
+import { SbbDialog } from './dialog';
 import { SbbDialogContainer } from './dialog-container';
 import {
   SbbDialogActions,
@@ -28,6 +28,6 @@ import {
     SbbDialogContent,
   ],
   exports: [SbbDialogContainer, SbbDialogClose, SbbDialogTitle, SbbDialogContent, SbbDialogActions],
-  providers: [SbbDialog, SBB_DIALOG_SCROLL_STRATEGY_PROVIDER],
+  providers: [SbbDialog],
 })
 export class SbbDialogModule {}

--- a/src/angular/dialog/dialog.ts
+++ b/src/angular/dialog/dialog.ts
@@ -45,37 +45,6 @@ export const SBB_DIALOG_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrateg
 );
 
 /**
- * @docs-private
- * @deprecated No longer used. To be removed.
- * @breaking-change 19.0.0
- */
-export function SBB_DIALOG_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
-  return () => overlay.scrollStrategies.block();
-}
-
-/**
- * @docs-private
- * @deprecated No longer used. To be removed.
- * @breaking-change 19.0.0
- */
-export function SBB_DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY(
-  overlay: Overlay,
-): () => ScrollStrategy {
-  return () => overlay.scrollStrategies.block();
-}
-
-/**
- * @docs-private
- * @deprecated No longer used. To be removed.
- * @breaking-change 19.0.0
- */
-export const SBB_DIALOG_SCROLL_STRATEGY_PROVIDER = {
-  provide: SBB_DIALOG_SCROLL_STRATEGY,
-  deps: [Overlay],
-  useFactory: SBB_DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY,
-};
-
-/**
  * Base class for dialog services. The base dialog service allows
  * for arbitrary dialog refs and dialog container components.
  */


### PR DESCRIPTION
Removes the deprecated symbols for v20 from the checkbox.

BREAKING CHANGE:
* `SBB_DIALOG_SCROLL_STRATEGY_FACTORY` has been removed.
* `SBB_DIALOG_SCROLL_STRATEGY_PROVIDER_FACTORY` has been removed.
* `SBB_DIALOG_SCROLL_STRATEGY_PROVIDER` has been removed.