### PR TITLE
fix(angular/lightbox): breaking changes for v20

### DIFF
--- a/src/angular/lightbox/lightbox.module.ts
+++ b/src/angular/lightbox/lightbox.module.ts
@@ -6,7 +6,7 @@ import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbDialogModule } from '@sbb-esta/angular/dialog';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
 
-import { SbbLightbox, SBB_LIGHTBOX_SCROLL_STRATEGY_PROVIDER } from './lightbox';
+import { SbbLightbox } from './lightbox';
 import { SbbLightboxContainer } from './lightbox-container';
 import {
   SbbLightboxActions,
@@ -37,6 +37,6 @@ import {
     SbbLightboxContent,
     SbbLightboxActions,
   ],
-  providers: [SbbLightbox, SBB_LIGHTBOX_SCROLL_STRATEGY_PROVIDER],
+  providers: [SbbLightbox],
 })
 export class SbbLightboxModule {}

--- a/src/angular/lightbox/lightbox.ts
+++ b/src/angular/lightbox/lightbox.ts
@@ -28,37 +28,6 @@ export const SBB_LIGHTBOX_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrat
 );
 
 /**
- * @docs-private
- * @deprecated No longer used. To be removed.
- * @breaking-change 19.0.0
- */
-export function SBB_LIGHTBOX_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
-  return () => overlay.scrollStrategies.block();
-}
-
-/**
- * @docs-private
- * @deprecated No longer used. To be removed.
- * @breaking-change 19.0.0
- */
-export function SBB_LIGHTBOX_SCROLL_STRATEGY_PROVIDER_FACTORY(
-  overlay: Overlay,
-): () => ScrollStrategy {
-  return () => overlay.scrollStrategies.block();
-}
-
-/**
- * @docs-private
- * @deprecated No longer used. To be removed.
- * @breaking-change 19.0.0
- */
-export const SBB_LIGHTBOX_SCROLL_STRATEGY_PROVIDER = {
-  provide: SBB_LIGHTBOX_SCROLL_STRATEGY,
-  deps: [Overlay],
-  useFactory: SBB_LIGHTBOX_SCROLL_STRATEGY_PROVIDER_FACTORY,
-};
-
-/**
  * Service to open modal lightboxes.
  */
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
Removes the deprecated symbols for v20 from the lightbox.

BREAKING CHANGE:
* `SBB_LIGHTBOX_SCROLL_STRATEGY_FACTORY` has been removed.
* `SBB_LIGHTBOX_SCROLL_STRATEGY_PROVIDER_FACTORY` has been removed.
* `SBB_LIGHTBOX_SCROLL_STRATEGY_PROVIDER` has been removed.