### PR TITLE
fix(multiple): fix VoiceOver confused by Select/Autocomplete's ARIA semantics

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -1,3 +1,4 @@
+import { addAriaReferencedId, removeAriaReferencedId } from '@angular/cdk/a11y';
 import { coerceStringArray } from '@angular/cdk/coercion';
 import { DOWN_ARROW, ENTER, ESCAPE, hasModifierKey, TAB, UP_ARROW } from '@angular/cdk/keycodes';
 import {
@@ -352,6 +353,7 @@ export class SbbAutocompleteTrigger
     this._componentDestroyed = true;
     this._destroyPanel();
     this._closeKeyEventStream.complete();
+    this._clearFromModal();
   }
 
   /** Whether or not the autocomplete panel is open. */
@@ -867,6 +869,7 @@ export class SbbAutocompleteTrigger
 
     this.autocomplete._isOpen = this._overlayAttached = true;
     this._updatePanelState();
+    this._applyModalPanelOwnership();
 
     // We need to do an extra `panelOpen` check in here, because the
     // autocomplete won't be shown if there are no options.
@@ -1059,6 +1062,68 @@ export class SbbAutocompleteTrigger
 
         autocomplete._setScrollTop(newScrollPosition);
       }
+    }
+  }
+
+  /**
+   * Track which modal we have modified the `aria-owns` attribute of. When the combobox trigger is
+   * inside an aria-modal, we apply aria-owns to the parent modal with the `id` of the options
+   * panel. Track the modal we have changed so we can undo the changes on destroy.
+   */
+  private _trackedModal: Element | null = null;
+
+  /**
+   * If the autocomplete trigger is inside of an `aria-modal` element, connect
+   * that modal to the options panel with `aria-owns`.
+   *
+   * For some browser + screen reader combinations, when navigation is inside
+   * of an `aria-modal` element, the screen reader treats everything outside
+   * of that modal as hidden or invisible.
+   *
+   * This causes a problem when the combobox trigger is _inside_ of a modal, because the
+   * options panel is rendered _outside_ of that modal, preventing screen reader navigation
+   * from reaching the panel.
+   *
+   * We can work around this issue by applying `aria-owns` to the modal with the `id` of
+   * the options panel. This effectively communicates to assistive technology that the
+   * options panel is part of the same interaction as the modal.
+   *
+   * At time of this writing, this issue is present in VoiceOver.
+   * See https://github.com/angular/components/issues/20694
+   */
+  private _applyModalPanelOwnership() {
+    // TODO(http://github.com/angular/components/issues/26853): consider de-duplicating this with
+    // the `LiveAnnouncer` and any other usages.
+    //
+    // Note that the selector here is limited to CDK overlays at the moment in order to reduce the
+    // section of the DOM we need to look through. This should cover all the cases we support, but
+    // the selector can be expanded if it turns out to be too narrow.
+    const modal = this._element.nativeElement.closest(
+      'body > .cdk-overlay-container [aria-modal="true"]',
+    );
+
+    if (!modal) {
+      // Most commonly, the autocomplete trigger is not inside a modal.
+      return;
+    }
+
+    const panelId = this.autocomplete.id;
+
+    if (this._trackedModal) {
+      removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+    }
+
+    addAriaReferencedId(modal, 'aria-owns', panelId);
+    this._trackedModal = modal;
+  }
+
+  /** Clears the references to the listbox overlay element from the modal it was added to. */
+  private _clearFromModal() {
+    if (this._trackedModal) {
+      const panelId = this.autocomplete.id;
+
+      removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+      this._trackedModal = null;
     }
   }
 }

--- a/src/angular/select/select.spec.ts
+++ b/src/angular/select/select.spec.ts
@@ -14,13 +14,14 @@ import {
   TAB,
   UP_ARROW,
 } from '@angular/cdk/keycodes';
-import { OverlayContainer } from '@angular/cdk/overlay';
+import { OverlayContainer, OverlayModule } from '@angular/cdk/overlay';
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DebugElement,
+  ElementRef,
   inject,
   OnInit,
   provideCheckNoChangesConfig,
@@ -2158,6 +2159,27 @@ describe('SbbSelect', () => {
                 'value has changed.',
             )
             .toEqual([options[7]]);
+        }));
+      });
+
+      describe('for select inside a modal', () => {
+        let fixture: ComponentFixture<SelectInsideAModal>;
+
+        beforeEach(fakeAsync(() => {
+          fixture = TestBed.createComponent(SelectInsideAModal);
+          fixture.detectChanges();
+        }));
+
+        it('should add the id of the select panel to the aria-owns of the modal', fakeAsync(() => {
+          fixture.componentInstance.select.open();
+          fixture.detectChanges();
+
+          const panelId = `${fixture.componentInstance.select.id}-panel`;
+          const modalElement = fixture.componentInstance.modal.nativeElement;
+
+          expect(modalElement.getAttribute('aria-owns')?.split(' '))
+            .withContext('expecting modal to own the select panel')
+            .toContain(panelId);
         }));
       });
 
@@ -5255,4 +5277,38 @@ class BasicSelectWithFirstAndLastOptionDisabled {
 
   @ViewChild(SbbSelect, { static: true }) select: SbbSelect;
   @ViewChildren(SbbOption) options: QueryList<SbbOption>;
+}
+
+@Component({
+  template: `
+    <button cdkOverlayOrigin #trigger="cdkOverlayOrigin">open dialog</button>
+    <ng-template
+      cdkConnectedOverlay
+      [cdkConnectedOverlayOpen]="true"
+      [cdkConnectedOverlayOrigin]="trigger"
+    >
+      <div role="dialog" [attr.aria-modal]="'true'" #modal>
+        <sbb-form-field>
+          <sbb-label>Select a food</sbb-label>
+          <sbb-select placeholder="Food" ngModel>
+            @for (food of foods; track food) {
+              <sbb-option [value]="food.value">{{ food.viewValue }}</sbb-option>
+            }
+          </sbb-select>
+        </sbb-form-field>
+      </div>
+    </ng-template>
+  `,
+  imports: [SbbSelect, SbbOption, SbbFormFieldModule, FormsModule, OverlayModule],
+})
+class SelectInsideAModal {
+  foods = [
+    { value: 'steak-0', viewValue: 'Steak' },
+    { value: 'pizza-1', viewValue: 'Pizza' },
+    { value: 'tacos-2', viewValue: 'Tacos' },
+  ];
+
+  @ViewChild(SbbSelect) select: SbbSelect;
+  @ViewChildren(SbbOption) options: QueryList<SbbOption>;
+  @ViewChild('modal') modal: ElementRef;
 }

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -1,4 +1,10 @@
-import { ActiveDescendantKeyManager, LiveAnnouncer, _IdGenerator } from '@angular/cdk/a11y';
+import {
+  ActiveDescendantKeyManager,
+  addAriaReferencedId,
+  LiveAnnouncer,
+  removeAriaReferencedId,
+  _IdGenerator,
+} from '@angular/cdk/a11y';
 import { SelectionModel } from '@angular/cdk/collections';
 import {
   A,
@@ -646,6 +652,7 @@ export class SbbSelect
     this._destroy.complete();
     this.stateChanges.complete();
     this._keyManager?.destroy();
+    this._clearFromModal();
   }
 
   /** Toggles the overlay panel open or closed. */
@@ -657,6 +664,8 @@ export class SbbSelect
   /** Opens the overlay panel. */
   open(): void {
     if (this._canOpen()) {
+      this._applyModalPanelOwnership();
+
       this._panelOpen = true;
       this._keyManager.withHorizontalOrientation(null);
       this._highlightCorrectOption();
@@ -682,6 +691,71 @@ export class SbbSelect
         this._calculateOverlayPosition();
       });
     }
+  }
+
+  /**
+   * Track which modal we have modified the `aria-owns` attribute of. When the combobox trigger is
+   * inside an aria-modal, we apply aria-owns to the parent modal with the `id` of the options
+   * panel. Track the modal we have changed so we can undo the changes on destroy.
+   */
+  private _trackedModal: Element | null = null;
+
+  /**
+   * If the autocomplete trigger is inside of an `aria-modal` element, connect
+   * that modal to the options panel with `aria-owns`.
+   *
+   * For some browser + screen reader combinations, when navigation is inside
+   * of an `aria-modal` element, the screen reader treats everything outside
+   * of that modal as hidden or invisible.
+   *
+   * This causes a problem when the combobox trigger is _inside_ of a modal, because the
+   * options panel is rendered _outside_ of that modal, preventing screen reader navigation
+   * from reaching the panel.
+   *
+   * We can work around this issue by applying `aria-owns` to the modal with the `id` of
+   * the options panel. This effectively communicates to assistive technology that the
+   * options panel is part of the same interaction as the modal.
+   *
+   * At time of this writing, this issue is present in VoiceOver.
+   * See https://github.com/angular/components/issues/20694
+   */
+  private _applyModalPanelOwnership() {
+    // TODO(http://github.com/angular/components/issues/26853): consider de-duplicating this with
+    // the `LiveAnnouncer` and any other usages.
+    //
+    // Note that the selector here is limited to CDK overlays at the moment in order to reduce the
+    // section of the DOM we need to look through. This should cover all the cases we support, but
+    // the selector can be expanded if it turns out to be too narrow.
+    const modal = this._elementRef.nativeElement.closest(
+      'body > .cdk-overlay-container [aria-modal="true"]',
+    );
+
+    if (!modal) {
+      // Most commonly, the autocomplete trigger is not inside a modal.
+      return;
+    }
+
+    const panelId = `${this.id}-panel`;
+
+    if (this._trackedModal) {
+      removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+    }
+
+    addAriaReferencedId(modal, 'aria-owns', panelId);
+    this._trackedModal = modal;
+  }
+
+  /** Clears the reference to the listbox overlay element from the modal it was added to. */
+  private _clearFromModal() {
+    if (!this._trackedModal) {
+      // Most commonly, the autocomplete trigger is not used inside a modal.
+      return;
+    }
+
+    const panelId = `${this.id}-panel`;
+
+    removeAriaReferencedId(this._trackedModal, 'aria-owns', panelId);
+    this._trackedModal = null;
   }
 
   /** Closes the overlay panel and focuses the host element. */
@@ -1110,7 +1184,7 @@ export class SbbSelect
 
   /** Emits change event to set the model value. */
   private _propagateChanges(fallbackValue?: any): void {
-    let valueToEmit: any = null;
+    let valueToEmit: any;
 
     if (this.multiple) {
       valueToEmit = (this.selected as SbbOption[]).map((option) => option.value);

--- a/src/angular/select/select.ts
+++ b/src/angular/select/select.ts
@@ -701,7 +701,7 @@ export class SbbSelect
   private _trackedModal: Element | null = null;
 
   /**
-   * If the autocomplete trigger is inside of an `aria-modal` element, connect
+   * If the select trigger is inside of an `aria-modal` element, connect
    * that modal to the options panel with `aria-owns`.
    *
    * For some browser + screen reader combinations, when navigation is inside
@@ -731,7 +731,7 @@ export class SbbSelect
     );
 
     if (!modal) {
-      // Most commonly, the autocomplete trigger is not inside a modal.
+      // Most commonly, the select trigger is not inside a modal.
       return;
     }
 
@@ -748,7 +748,7 @@ export class SbbSelect
   /** Clears the reference to the listbox overlay element from the modal it was added to. */
   private _clearFromModal() {
     if (!this._trackedModal) {
-      // Most commonly, the autocomplete trigger is not used inside a modal.
+      // Most commonly, the select trigger is not used inside a modal.
       return;
     }
 


### PR DESCRIPTION
For Select and Autocomplete components, fix issues where VoiceOver was confused by the ARIA semantics of the combobox. Fix multiple behaviors:

Fix VoiceOver focus ring stuck on the combobox while navigating options. Fix VoiceOver would sometimes reading option as a TextNode and not communicating the selected state and position in set. Fix VoiceOver "flickering" behavior where VoiceOver would display one announcement then quickly change to another announcement. Fix the same issues for both Select and Autocomplete component.

Implement fix by correcting the combobox element and also individual options.

First, move the aria-owns reference to the overlay from the child of the combobox to the parent modal of the comobobx. Having an aria-owns reference inside the combobox element seemed to confuse VoiceOver.

Second, apply aria-hidden="true" to the ripple element and pseudo checkboxes on sbb-option. These DOM nodes are only used for visual purposes, so it is most appropriate to remove them from the accessibility tree. This seemed to make VoiceOver's behavior more consistent.