### PR TITLE
fix(angular/radio): updating required value should mark for check

### DIFF
--- a/src/angular/radio-button/radio-button.ts
+++ b/src/angular/radio-button/radio-button.ts
@@ -404,6 +404,9 @@ export class _SbbRadioButtonBase implements OnInit, AfterViewInit, DoCheck, OnDe
     return this._required || (this.radioGroup && this.radioGroup.required);
   }
   set required(value: boolean) {
+    if (value !== this._required) {
+      this._changeDetector.markForCheck();
+    }
     this._required = value;
   }
 


### PR DESCRIPTION
This change ensures that updates to the required value of the radio button also mark the component for check, ensuring OnPush compatibility