### PR TITLE
fix(angular/toggle): resolve changed after checked errors

### DIFF
--- a/src/angular/toggle/toggle-option.html
+++ b/src/angular/toggle/toggle-option.html
@@ -13,7 +13,7 @@
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="ariaLabelledby"
     [attr.aria-describedby]="ariaDescribedby"
-    [attr.aria-controls]="checked && _details ? toggle._contentId : null"
+    [attr.aria-controls]="checked && _details() ? toggle._contentId : null"
     (change)="_onInputChange($event)"
     (click)="_onInputClick($event)"
   />

--- a/src/angular/toggle/toggle-option.ts
+++ b/src/angular/toggle/toggle-option.ts
@@ -6,11 +6,13 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  contentChild,
   ContentChild,
   ElementRef,
   Inject,
   Input,
-  ViewChild,
+  Signal,
+  viewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import { SbbIcon } from '@sbb-esta/angular/icon';
@@ -94,13 +96,8 @@ export class SbbToggleOption extends _SbbRadioButtonBase {
   @Input() svgIcon: string;
 
   /** The toggle content projection label. */
-  @ContentChild(SbbToggleDetails) _detailsNonStatic: SbbToggleDetails;
-  @ContentChild(SbbToggleDetails, { static: true }) _detailsStatic: SbbToggleDetails;
-  get _details() {
-    return this._detailsNonStatic || this._detailsStatic;
-  }
-
-  @ViewChild(CdkPortal) _content: CdkPortal;
+  _details: Signal<SbbToggleDetails | undefined> = contentChild(SbbToggleDetails);
+  _content: Signal<CdkPortal | undefined> = viewChild(CdkPortal);
 
   constructor(
     @Inject(SBB_RADIO_GROUP) readonly toggle: SbbToggle,

--- a/src/angular/toggle/toggle.html
+++ b/src/angular/toggle/toggle.html
@@ -3,17 +3,19 @@
 </div>
 
 <section class="sbb-toggle-option-content" [id]="_contentId">
-  @if (selected?._details) {
+  @if (selected?._details()) {
     <div
       class="sbb-toggle-option-content-wrapper sbb-scrollbar"
       #toggleOptionContentWrapper
       [@translateHeight]="{
         value: _heightAnimationState,
-        params: { currentHeight: _currentOptionContentWrapperHeight },
+        params: { currentHeight: _currentOptionContentWrapperHeight() },
       }"
       (@translateHeight.done)="_onHeightAnimationDone($event)"
     >
-      <ng-template [cdkPortalOutlet]="selected?._details ? selected?._content : null"></ng-template>
+      <ng-template
+        [cdkPortalOutlet]="selected?._details() ? selected?._content() : null"
+      ></ng-template>
     </div>
   }
 </section>

--- a/src/angular/toggle/toggle.spec.ts
+++ b/src/angular/toggle/toggle.spec.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import { Component, ContentChildren, provideCheckNoChangesConfig, QueryList } from '@angular/core';
+import { Component, ContentChildren, QueryList } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -251,7 +251,6 @@ describe('SbbToggle', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        providers: [provideCheckNoChangesConfig({ exhaustive: false })],
         imports: [NoopAnimationsModule, SbbIconTestingModule],
       });
     }));
@@ -412,7 +411,6 @@ describe('SbbToggle', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        providers: [provideCheckNoChangesConfig({ exhaustive: false })],
         imports: [NoopAnimationsModule, SbbIconTestingModule],
       });
     }));
@@ -459,7 +457,6 @@ describe('SbbToggle', () => {
 
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
-        providers: [provideCheckNoChangesConfig({ exhaustive: false })],
         imports: [NoopAnimationsModule, SbbIconTestingModule],
       });
     }));

--- a/src/angular/toggle/toggle.ts
+++ b/src/angular/toggle/toggle.ts
@@ -13,8 +13,10 @@ import {
   Injector,
   NgZone,
   OnDestroy,
+  signal,
   ViewChild,
   ViewEncapsulation,
+  WritableSignal,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { SbbRadioGroup, SBB_RADIO_GROUP } from '@sbb-esta/angular/radio-button';
@@ -45,7 +47,7 @@ import { SbbToggleOption } from './toggle-option';
     '[class.sbb-toggle-middle-option-selected]': '!_radios.first.checked && !_radios.last.checked',
     '[class.sbb-toggle-last-option-selected]': '_radios.last.checked',
     '[class.sbb-toggle-triple]': '_radios.length === 3',
-    '[class.sbb-toggle-option-has-content]': '!!selected?._details',
+    '[class.sbb-toggle-option-has-content]': '!!selected?._details()',
   },
   animations: [sbbToggleAnimations.translateHeight],
   imports: [CdkPortalOutlet],
@@ -61,7 +63,7 @@ export class SbbToggle
 
   @ViewChild('toggleOptionContentWrapper') _toggleOptionContentWrapper: ElementRef;
   _heightAnimationState: 'void' | 'initial' | 'fixed' | 'auto' = 'initial';
-  _currentOptionContentWrapperHeight: number = 0;
+  _currentOptionContentWrapperHeight: WritableSignal<number> = signal(0);
 
   private _injector = inject(Injector);
 
@@ -90,8 +92,9 @@ export class SbbToggle
     this.change.pipe(startWith(null!), takeUntil(this._destroyed)).subscribe(() => {
       // Animate toggle height by using current height as start height of transition
       if (this._toggleOptionContentWrapper) {
-        this._currentOptionContentWrapperHeight =
-          this._toggleOptionContentWrapper.nativeElement.offsetHeight;
+        this._currentOptionContentWrapperHeight.set(
+          this._toggleOptionContentWrapper.nativeElement.offsetHeight,
+        );
         this._heightAnimationState = 'auto';
       }
       Promise.resolve().then(() => {


### PR DESCRIPTION
Resolves several "changed after checked" errors in the toggle by converting internal state to signals.