### PR TITLE
chore: add missing constructor export

### DIFF
--- a/src/angular/core/public-api.ts
+++ b/src/angular/core/public-api.ts
@@ -1,5 +1,6 @@
 export * from './breakpoints/breakpoints';
 export * from './common-behaviors/common.module';
+export * from './common-behaviors/constructor';
 export * from './common-behaviors/error-state';
 export * from './common-behaviors/type-ref';
 export * from './common-behaviors/variant';


### PR DESCRIPTION
It was unintentionally removed when deleting deprecated apis.