### PR TITLE
build: follow symlinks when copying artifacts

### DIFF
--- a/scripts/build.mts
+++ b/scripts/build.mts
@@ -180,7 +180,7 @@ function cleanDistPath(distPath: string) {
  */
 function copyPackageOutput(outputPath: string, targetFolder: string) {
   console.log(`> Copying package output to "${targetFolder}" (from "${outputPath}")`);
-  sh.cp('-R', outputPath, targetFolder);
+  sh.cp('-LR', outputPath, targetFolder);
   sh.chmod('-R', 'u+w', targetFolder);
 }
 


### PR DESCRIPTION
Currently our build script does not follow symlinks when copying artifacts, which breaks in the container build.
This PR adds the configuration to follow symlinks, which should solve this problem.