### PR TITLE
fix: add types for journey maps web component

### DIFF
--- a/src/journey-maps-wc/BUILD.bazel
+++ b/src/journey-maps-wc/BUILD.bazel
@@ -87,6 +87,18 @@ esbuild(
     target = "es2022",
 )
 
+genrule(
+    name = "types",
+    srcs = ["//src/journey-maps:npm_package"],
+    outs = [
+        "bundle.d.ts",
+    ],
+    cmd = """
+        cp "$(execpath //src/journey-maps:npm_package)/angular/index.d.ts" "$(execpath bundle.d.ts)"
+    """,
+    output_to_bindir = True,
+)
+
 alias(
     name = "pkg",
     actual = ":npm_package",
@@ -95,7 +107,9 @@ alias(
 npm_package(
     name = "npm_package",
     srcs = [
+        "index.d.ts",
         "package.json",
+        ":bundle.d.ts",
         ":bundle.js",
         ":styles.css",
     ],

--- a/src/journey-maps-wc/index.d.ts
+++ b/src/journey-maps-wc/index.d.ts
@@ -1,0 +1,5 @@
+import type { SbbJourneyMaps } from './bundle';
+
+export type { SbbJourneyMaps, SbbMarker } from './bundle';
+
+export type SbbJourneyMapsElement = HTMLElement & SbbJourneyMaps;

--- a/src/journey-maps-wc/package.json
+++ b/src/journey-maps-wc/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://angular.app.sbb.ch",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "default": "./bundle.js"
     },
     "./styles.css": {


### PR DESCRIPTION
This PR adds a build step to copy the declaration file from `@sbb-esta/journey-maps/angular`, which is then used via a hard-coded `index.d.ts`, which only forwards necessary types.

Closes #2569 