### PR TITLE
build: temporary disable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": false,
   "extends": ["config:base"],
   "username": "sbb-angular-renovate[bot]",
   "gitAuthor": "sbb-angular-renovate<52953647+sbb-angular-renovate[bot]@users.noreply.github.com>",


### PR DESCRIPTION
Renovate is not updating dependencies since the update to Angular 20. Currently, it's failing because of the OIDC authentication. I temporary disable it until I found a fix.