### PR TITLE
ci: fix renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "gitAuthor": "sbb-angular-renovate<52953647+sbb-angular-renovate[bot]@users.noreply.github.com>",
   "repositories": ["sbb-design-systems/sbb-angular"],
   "baseBranches": ["main", "20.x"],
-  "includePaths": ["package.json", ".github/**"],
+  "ignorePaths": ["docs/src/assets/stack-blitz/**"],
   "schedule": ["after 10pm every weekday", "before 5am every weekday", "every weekend"],
   "lockFileMaintenance": {
     "schedule": ["before 7am on thursday"],


### PR DESCRIPTION
Renovate is currently not working because it cannot access the `pnpm-workspace.yaml` file. Instead of using `includePaths`, we now use `ignorePaths` to prevent Renovate updating the stackblitz dependencies.