### PR TITLE
ci: run renovate every 30 minutes

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     # The "*" (#42, asterisk) character has special semantics in YAML, so this
     # string has to be quoted.
-    - cron: '0/15 * * * *'
+    - cron: '0/30 * * * *'
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
Currently, we're hitting api rate limits from GitHub. I therefore halve the number of renovate runs.