### PR TITLE
ci: disable frozen lockfile mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,3 @@
-# Frozen lockfile
-common --lockfile_mode=error
-
 # Required by `rules_ts`.
 common --@aspect_rules_ts//ts:skipLibCheck=always
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler


### PR DESCRIPTION
This was copied from angular/components and I am not sure if we need it. Currently, this breaks renovate updates.