### PR TITLE
fix(angular/dialog): return `undefined` when closing dialog via header button

### DIFF
--- a/src/angular/dialog/dialog-content-directives.ts
+++ b/src/angular/dialog/dialog-content-directives.ts
@@ -176,7 +176,7 @@ export class _SbbDialogTitleBase implements OnInit, OnDestroy {
     <ng-content></ng-content>
     @if (_closeEnabled) {
       <button
-        sbb-dialog-close
+        [sbb-dialog-close]="undefined"
         class="sbb-dialog-title-close-button sbb-button-reset-frameless"
         [aria-label]="closeAriaLabel"
       >

--- a/src/angular/dialog/dialog.spec.ts
+++ b/src/angular/dialog/dialog.spec.ts
@@ -218,6 +218,25 @@ describe('SbbDialog', () => {
     expect(overlayContainerElement.querySelector('sbb-dialog-container')).toBeNull();
   }));
 
+  it('should close the dialog with undefined result when closed via header button', fakeAsync(() => {
+    const dialogRef = dialog.open(ContentElementDialog, { viewContainerRef: testViewContainerRef });
+    const afterCloseCallback = jasmine.createSpy('afterClose callback');
+
+    dialogRef.afterClosed().subscribe(afterCloseCallback);
+
+    viewContainerFixture.detectChanges();
+    const closeButton = overlayContainerElement.querySelector(
+      '.sbb-dialog-title-close-button',
+    ) as HTMLElement;
+    closeButton.click();
+
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(afterCloseCallback).toHaveBeenCalledWith(undefined);
+    expect(overlayContainerElement.querySelector('sbb-dialog-container')).toBeFalsy();
+  }));
+
   it('should dispose of dialog if view container is destroyed while animating', fakeAsync(() => {
     const dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
 
@@ -1600,7 +1619,9 @@ describe('SbbDialog', () => {
       }));
 
       it('should set the "type" attribute of the close button if not set manually', () => {
-        const button = overlayContainerElement.querySelector('button[sbb-dialog-close]')!;
+        const button = overlayContainerElement.querySelector(
+          'button.sbb-dialog-title-close-button',
+        )!;
 
         expect(button.getAttribute('type')).toBe('button');
       });


### PR DESCRIPTION
This is done to be consistent with the behavior when clicking `ESCAPE`. Before, an empty string was returned as a dialog result because attribute names alone have an empty string as implicit value.

See https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML

Closes #2496