### PR TITLE
fix(angular/autocomplete): don't throw NG0911 when destroyed during rendering

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -643,7 +643,9 @@ export class SbbAutocompleteTrigger
     const initialRender = new Observable((subscriber) => {
       afterNextRender(
         () => {
-          subscriber.next();
+          if (!this._componentDestroyed) {
+            subscriber.next();
+          }
         },
         { injector: this._injector },
       );


### PR DESCRIPTION
I wasn’t able to reproduce the issue described in the linked ticket.  
The most likely explanation is that the component gets destroyed when the `afterNextRender` callback executes.  
This change adds a check to skip the callback if the component has already been destroyed.

Fixes #2515