### PR TITLE
fix(angular/menu): switch internal state to signals

### DIFF
--- a/src/angular/menu/menu.html
+++ b/src/angular/menu/menu.html
@@ -6,7 +6,7 @@
     (click)="closed.emit('click')"
     [class.sbb-menu-panel-animations-disabled]="_animationsDisabled"
     [class.sbb-menu-panel-exit-animation]="_panelAnimationState === 'void'"
-    [class.sbb-menu-panel-animating]="_isAnimating"
+    [class.sbb-menu-panel-animating]="_isAnimating()"
     [style.--sbb-menu-trigger-width.px]="triggerContext ? triggerContext.width : 0"
     [style.--sbb-menu-trigger-height.px]="triggerContext ? triggerContext.height : 0"
     tabindex="-1"

--- a/src/angular/menu/menu.ts
+++ b/src/angular/menu/menu.ts
@@ -22,9 +22,11 @@ import {
   OnInit,
   Output,
   QueryList,
+  signal,
   TemplateRef,
   ViewChild,
   ViewEncapsulation,
+  WritableSignal,
 } from '@angular/core';
 import { merge, Observable, Subject } from 'rxjs';
 import { startWith, switchMap } from 'rxjs/operators';
@@ -140,7 +142,7 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
   readonly _animationDone = new Subject<'void' | 'enter'>();
 
   /** Whether the menu is animating. */
-  _isAnimating: boolean = false;
+  _isAnimating: WritableSignal<boolean> = signal(false);
 
   /** Parent menu of the current menu panel. */
   parentMenu: SbbMenuPanel | undefined;
@@ -446,13 +448,13 @@ export class SbbMenu implements AfterContentInit, SbbMenuPanel<SbbMenuItem>, OnI
         this._exitFallbackTimeout = undefined;
       }
       this._animationDone.next(isExit ? 'void' : 'enter');
-      this._isAnimating = false;
+      this._isAnimating.set(false);
     }
   }
 
   protected _onAnimationStart(state: string) {
     if (state === ENTER_ANIMATION || state === EXIT_ANIMATION) {
-      this._isAnimating = true;
+      this._isAnimating.set(true);
     }
   }
 


### PR DESCRIPTION
Switches the `_isAnimating` state to a signal in order to avoid "changed after checked" errors.