### PR TITLE
fix(angular/autocomplete): remove unused factory functions

### DIFF
--- a/src/angular/autocomplete/autocomplete-trigger.ts
+++ b/src/angular/autocomplete/autocomplete-trigger.ts
@@ -84,17 +84,6 @@ export const SBB_AUTOCOMPLETE_SCROLL_STRATEGY = new InjectionToken<() => ScrollS
   },
 );
 
-/** @docs-private */
-export function SBB_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
-  return () => overlay.scrollStrategies.reposition();
-}
-
-export const SBB_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER = {
-  provide: SBB_AUTOCOMPLETE_SCROLL_STRATEGY,
-  deps: [Overlay],
-  useFactory: SBB_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY,
-};
-
 /**
  * Creates an error to be thrown when attempting to use an autocomplete trigger without a panel.
  * @docs-private

--- a/src/angular/autocomplete/autocomplete.module.ts
+++ b/src/angular/autocomplete/autocomplete.module.ts
@@ -5,10 +5,7 @@ import { SbbCommonModule, SbbOptionModule } from '@sbb-esta/angular/core';
 
 import { SbbAutocomplete } from './autocomplete';
 import { SbbAutocompleteOrigin } from './autocomplete-origin';
-import {
-  SbbAutocompleteTrigger,
-  SBB_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER,
-} from './autocomplete-trigger';
+import { SbbAutocompleteTrigger } from './autocomplete-trigger';
 
 @NgModule({
   imports: [
@@ -27,6 +24,5 @@ import {
     SbbAutocompleteOrigin,
     SbbAutocompleteTrigger,
   ],
-  providers: [SBB_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER],
 })
 export class SbbAutocompleteModule {}

--- a/src/angular/autocomplete/autocomplete.ts
+++ b/src/angular/autocomplete/autocomplete.ts
@@ -65,14 +65,13 @@ export const SBB_AUTOCOMPLETE_DEFAULT_OPTIONS = new InjectionToken<SbbAutocomple
   'sbb-autocomplete-default-options',
   {
     providedIn: 'root',
-    factory: SBB_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY,
+    factory: () => ({
+      autoActiveFirstOption: false,
+      autoSelectActiveOption: false,
+      requireSelection: false,
+    }),
   },
 );
-
-/** @docs-private */
-export function SBB_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY(): SbbAutocompleteDefaultOptions {
-  return { autoActiveFirstOption: false, autoSelectActiveOption: false, requireSelection: false };
-}
 
 @Component({
   selector: 'sbb-autocomplete',


### PR DESCRIPTION
Remove factory functions not necessary anymore since we switched to standalone.

BREAKING CHANGE:
* `SBB_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY` has been removed.
* `SBB_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY` has been removed.
* `SBB_AUTOCOMPLETE_SCROLL_STRATEGY_FACTORY_PROVIDER` has been removed.`