### PR TITLE
fix(angular/menu): remove unused factory functions

### DIFF
--- a/src/angular/menu/menu-trigger.ts
+++ b/src/angular/menu/menu-trigger.ts
@@ -87,18 +87,6 @@ export const SBB_MENU_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrategy>
   },
 );
 
-/** @docs-private */
-export function SBB_MENU_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
-  return () => overlay.scrollStrategies.reposition();
-}
-
-/** @docs-private */
-export const SBB_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER = {
-  provide: SBB_MENU_SCROLL_STRATEGY,
-  deps: [Overlay],
-  useFactory: SBB_MENU_SCROLL_STRATEGY_FACTORY,
-};
-
 /** Default left overlapping of the submenu panel. */
 const SUBMENU_PANEL_LEFT_OVERLAP = 3;
 

--- a/src/angular/menu/menu.module.ts
+++ b/src/angular/menu/menu.module.ts
@@ -10,7 +10,7 @@ import { SbbMenu } from './menu';
 import { SbbMenuContent } from './menu-content';
 import { SbbMenuDynamicTrigger } from './menu-dynamic-trigger';
 import { SbbMenuItem } from './menu-item';
-import { SbbMenuTrigger, SBB_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER } from './menu-trigger';
+import { SbbMenuTrigger } from './menu-trigger';
 
 @NgModule({
   imports: [
@@ -34,6 +34,5 @@ import { SbbMenuTrigger, SBB_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER } from './men
     SbbMenuDynamicTrigger,
     SbbMenuContent,
   ],
-  providers: [SBB_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER],
 })
 export class SbbMenuModule {}


### PR DESCRIPTION
Remove factory functions not necessary anymore since we switched to standalone.

BREAKING CHANGE:

* SBB_MENU_SCROLL_STRATEGY_FACTORY has been removed.
* SBB_MENU_SCROLL_STRATEGY_FACTORY_PROVIDER has been removed.