### PR TITLE
fix(angular/chips): provide default options in root

### DIFF
--- a/src/angular/chips/chip-default-options.ts
+++ b/src/angular/chips/chip-default-options.ts
@@ -1,3 +1,4 @@
+import { ENTER } from '@angular/cdk/keycodes';
 import { InjectionToken } from '@angular/core';
 
 /** Default options, for the chips module, that can be overridden. */
@@ -9,4 +10,10 @@ export interface SbbChipsDefaultOptions {
 /** Injection token to be used to override the default options for the chips module. */
 export const SBB_CHIPS_DEFAULT_OPTIONS = new InjectionToken<SbbChipsDefaultOptions>(
   'sbb-chips-default-options',
+  {
+    providedIn: 'root',
+    factory: () => ({
+      separatorKeyCodes: [ENTER],
+    }),
+  },
 );


### PR DESCRIPTION
This is done for making them usable in standalone components without importing the whole module