### PR TITLE
fix(angular/datepicker): allow weekday abbreviations with a period

### DIFF
--- a/src/angular/core/datetime/lean-date-adapter.spec.ts
+++ b/src/angular/core/datetime/lean-date-adapter.spec.ts
@@ -14,6 +14,8 @@ describe('LeanDateAdapter', () => {
       { input: '1.1.1', expectedYear: 2001, expectedMonth: 1, expectedDay: 1 },
       { input: '121220', expectedYear: 2020, expectedMonth: 12, expectedDay: 12 },
       { input: '12122020', expectedYear: 2020, expectedMonth: 12, expectedDay: 12 },
+      { input: 'So, 12.01.2025', expectedYear: 2025, expectedMonth: 1, expectedDay: 12 },
+      { input: 'So., 12.01.2025', expectedYear: 2025, expectedMonth: 1, expectedDay: 12 },
       { input: 'Sa, 01012020', expectedYear: 2020, expectedMonth: 1, expectedDay: 1 },
       { input: 'Sa,01012020', expectedYear: 2020, expectedMonth: 1, expectedDay: 1 },
       { input: '01012020', expectedYear: 2020, expectedMonth: 1, expectedDay: 1 },

--- a/src/angular/core/datetime/native-date-adapter.ts
+++ b/src/angular/core/datetime/native-date-adapter.ts
@@ -224,7 +224,7 @@ export class SbbNativeDateAdapter extends SbbDateAdapter<Date> {
   }
 
   protected _splitStringDate(value: string): [number, number, number] | null {
-    const match = /^(\w+,[ ]?)?(\d+)\.(\d+)\.(\d+)$/.exec(value);
+    const match = /^(\w+\.?,[ ]?)?(\d+)\.(\d+)\.(\d+)$/.exec(value);
     if (!match) {
       return null;
     }


### PR DESCRIPTION
According to https://cldr.unicode.org/, German weekday abbreviations use a period, whereas Swiss weekday abbreviations do not. This caused the datepicker to stop working when `de` was selected as `LOCALE_ID` instead of `de-CH`.

This PR makes the date string parsing more robust.