### PR TITLE
fix(angular/tooltip): remove deprecated factory functions

### DIFF
--- a/src/angular/tooltip/tooltip.module.ts
+++ b/src/angular/tooltip/tooltip.module.ts
@@ -6,11 +6,7 @@ import { NgModule } from '@angular/core';
 import { SbbCommonModule } from '@sbb-esta/angular/core';
 import { SbbIconModule } from '@sbb-esta/angular/icon';
 
-import {
-  SbbTooltip,
-  SBB_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER,
-  TooltipComponent,
-} from './tooltip';
+import { SbbTooltip, TooltipComponent } from './tooltip';
 import { SbbTooltipWrapper } from './tooltip-wrapper';
 
 @NgModule({
@@ -25,6 +21,5 @@ import { SbbTooltipWrapper } from './tooltip-wrapper';
     SbbTooltipWrapper,
   ],
   exports: [SbbTooltip, TooltipComponent, SbbTooltipWrapper, CdkScrollableModule],
-  providers: [SBB_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER],
 })
 export class SbbTooltipModule {}

--- a/src/angular/tooltip/tooltip.ts
+++ b/src/angular/tooltip/tooltip.ts
@@ -105,26 +105,6 @@ export const SBB_TOOLTIP_SCROLL_STRATEGY = new InjectionToken<() => ScrollStrate
   },
 );
 
-/**
- * @docs-private
- * @deprecated Will be removed in 22.0.0.
- * @breaking-change 22.0.0
- */
-export function SBB_TOOLTIP_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
-  return () => overlay.scrollStrategies.reposition({ scrollThrottle: SCROLL_THROTTLE_MS });
-}
-
-/**
- * @docs-private
- * @deprecated Will be removed in 22.0.0.
- * @breaking-change 22.0.0
- */
-export const SBB_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER = {
-  provide: SBB_TOOLTIP_SCROLL_STRATEGY,
-  deps: [Overlay],
-  useFactory: SBB_TOOLTIP_SCROLL_STRATEGY_FACTORY,
-};
-
 /** Default `sbbTooltip` options that can be overridden. */
 export interface SbbTooltipDefaultOptions {
   /** Default delay when the tooltip is shown. */


### PR DESCRIPTION
BREAKING CHANGE:
* `SBB_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER` has been removed.
* `SBB_TOOLTIP_SCROLL_STRATEGY_FACTORY` has been removed.