### PR TITLE
docs: fix display of previous versions in showcase

### DIFF
--- a/docs/src/app/app.component.html
+++ b/docs/src/app/app.component.html
@@ -8,14 +8,12 @@
   }
 
   @if (previousMajorVersions.length) {
-    <sbb-app-chooser-section label="Previous Versions">
-      <a
-        target="_blank"
-        *ngFor="let version of previousMajorVersions"
-        href="https://angular-v{{ version }}.app.sbb.ch/"
-        >Version {{ version }}</a
-      >
-    </sbb-app-chooser-section>
+    @for (version of previousMajorVersions; track version) {
+      <a target="_blank" href="https://angular-v{{ version }}.app.sbb.ch/">
+        Version {{ version }}
+      </a>
+    }
+    <sbb-app-chooser-section label="Previous Versions"> </sbb-app-chooser-section>
   }
   <sbb-app-chooser-section label="Links">
     <a target="_blank" href="https://github.com/sbb-design-systems/sbb-angular">GitHub</a>

--- a/docs/src/app/shared/package-viewer/package-viewer.component.html
+++ b/docs/src/app/shared/package-viewer/package-viewer.component.html
@@ -1,15 +1,16 @@
 <sbb-sidebar-container>
   <sbb-sidebar role="navigation">
-    <sbb-expansion-panel expanded *ngFor="let section of (package | async)?.sections ?? []">
-      <sbb-expansion-panel-header>{{ section.name }}</sbb-expansion-panel-header>
-      <a
-        sbbSidebarLink
-        *ngFor="let entry of section.entries"
-        [routerLink]="entry.link"
-        routerLinkActive="sbb-active"
-        >{{ entry.label }}</a
-      >
-    </sbb-expansion-panel>
+    foo
+    @for (section of package()?.sections ?? []; track section.name) {
+      <sbb-expansion-panel expanded>
+        <sbb-expansion-panel-header>{{ section.name }}</sbb-expansion-panel-header>
+        @for (entry of section.entries; track entry.label) {
+          <a sbbSidebarLink [routerLink]="entry.link" routerLinkActive="sbb-active">
+            {{ entry.label }}
+          </a>
+        }
+      </sbb-expansion-panel>
+    }
   </sbb-sidebar>
   <sbb-sidebar-content role="main">
     <router-outlet />

--- a/docs/src/app/shared/package-viewer/package-viewer.component.html
+++ b/docs/src/app/shared/package-viewer/package-viewer.component.html
@@ -1,6 +1,5 @@
 <sbb-sidebar-container>
   <sbb-sidebar role="navigation">
-    foo
     @for (section of package()?.sections ?? []; track section.name) {
       <sbb-expansion-panel expanded>
         <sbb-expansion-panel-header>{{ section.name }}</sbb-expansion-panel-header>

--- a/docs/src/app/shared/package-viewer/package-viewer.component.ts
+++ b/docs/src/app/shared/package-viewer/package-viewer.component.ts
@@ -1,10 +1,9 @@
-import { AsyncPipe, NgFor } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { SbbExpansionPanel, SbbExpansionPanelHeader } from '@sbb-esta/angular/accordion';
 import { SbbSidebar, SbbSidebarContainer, SbbSidebarContent } from '@sbb-esta/angular/sidebar';
 import { SbbSidebarLink } from '@sbb-esta/angular/sidebar';
-import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { DocsMetaPackage } from '../meta';
@@ -15,7 +14,6 @@ import { DocsMetaPackage } from '../meta';
   imports: [
     SbbSidebarContainer,
     SbbSidebar,
-    NgFor,
     SbbExpansionPanel,
     SbbExpansionPanelHeader,
     SbbSidebarLink,
@@ -23,13 +21,11 @@ import { DocsMetaPackage } from '../meta';
     RouterLink,
     SbbSidebarContent,
     RouterOutlet,
-    AsyncPipe,
   ],
 })
 export class PackageViewerComponent {
-  package: Observable<DocsMetaPackage>;
-
-  constructor(activatedRoute: ActivatedRoute) {
-    this.package = activatedRoute.data.pipe(map((data) => data.packageData));
-  }
+  private activeRoute = inject(ActivatedRoute);
+  readonly package = toSignal(
+    this.activeRoute.data.pipe(map((data) => data.packageData as unknown as DocsMetaPackage)),
+  );
 }


### PR DESCRIPTION
Displaying previous major version stopped working because it was using the old `NgFor` directive without importing it.

This also removes usages of `NgFor` from the package viewer and migrates it to signals.